### PR TITLE
fix: Handling dictionaries introspection

### DIFF
--- a/src/EntityGraphQL/Extensions/TypeExtensions.cs
+++ b/src/EntityGraphQL/Extensions/TypeExtensions.cs
@@ -80,6 +80,8 @@ namespace EntityGraphQL.Extensions
                 return type.GetElementType();
             if (type.GenericTypeArguments.Count() == 1)
                 return type.GetGenericArguments()[0];
+            if (type.GenericTypeArguments.Count() == 2)
+                return type.GetGenericArguments()[1];
             return null;
         }
 

--- a/src/tests/EntityGraphQL.Tests/TestDataContext.cs
+++ b/src/tests/EntityGraphQL.Tests/TestDataContext.cs
@@ -19,6 +19,7 @@ namespace EntityGraphQL.Tests
         public List<Location> Locations { get; set; } = new List<Location>();
         public virtual List<Person> People { get; set; } = new List<Person>();
         public IEnumerable<User> Users { get; set; } = new List<User>();
+        public Dictionary<string, object> Attributes { get; set; } = new Dictionary<string, object>();
     }
 
     public class ProjectOld


### PR DESCRIPTION
Hi
This is not a big deal, but I need to manipulate dictionary through GraphQL, and I get this error in introspection:
`{"data":{},"errors":[{"message":"Field error: __schema - Value cannot be null. (Parameter 'type')"}]}`

GraphQL is working, but this is painfull to not have introspection to develop the front.

Regards