### PR TITLE
Name the in-memory database

### DIFF
--- a/docs/content/getting-started.md
+++ b/docs/content/getting-started.md
@@ -91,7 +91,7 @@ public class Startup {
   public void ConfigureServices(IServiceCollection services)
   {
       // Again, just an example using EF but you do not have to
-      services.AddDbContext<DemoContext>(opt => opt.UseInMemoryDatabase());
+      services.AddDbContext<DemoContext>(opt => opt.UseInMemoryDatabase("Demo"));
       // This registers a SchemaProvider<DemoContext> and uses reflection to build the schema with default options
       services.AddGraphQLSchema<DemoContext>();
   }


### PR DESCRIPTION
Recent versions of Entity Framework Core require a name with `UseInMemoryDatabase`.