### PR TITLE
Wildcard queries don't honor removed fields

### DIFF
--- a/src/EntityGraphQL.AspNet/PolicyOrRoleBasedAuthorization.cs
+++ b/src/EntityGraphQL.AspNet/PolicyOrRoleBasedAuthorization.cs
@@ -30,7 +30,7 @@ namespace EntityGraphQL.AspNet
             // if the list is empty it means identity.IsAuthenticated needs to be true, if full it requires certain authorization
             if (requiredAuth != null && requiredAuth.Any() && user != null)
             {
-                // check polcies if principal with used
+                // check polices if principal with used
                 if (authService != null)
                 {
                     var allPoliciesValid = true;

--- a/src/EntityGraphQL/Schema/BaseSchemaTypeWithFields.cs
+++ b/src/EntityGraphQL/Schema/BaseSchemaTypeWithFields.cs
@@ -101,10 +101,7 @@ namespace EntityGraphQL.Schema
         /// <param name="name"></param>
         public void RemoveField(string name)
         {
-            if (FieldsByName.ContainsKey(name))
-            {
-                FieldsByName.Remove(name);
-            }
+            FieldsByName.Remove(name);
         }
     }
 }


### PR DESCRIPTION
When a query does not include any fields, all fields are returned even if some fields have been removed via `RemoveField`.

For example, even with this configuration:
``` c#
schema.Type<Person>().RemoveField(p => p.Id);
```
the query `{ people }` returns the `Id` field.

This behavior limits the ability for EntityGraphQL to be used with entity types used internally by the server. It would be convenient to add app's existing entity types to a GraphQL DB context, except with sensitive and incompatible fields removed. However, since a GraphQL client can access all fields, regardless of `RemoveField`, this approach isn't currently viable.

To reproduce this issue, run the test `WildcardQueriesHonorRemovedFields` in this PR.