### PR TITLE
add basic support for nullable ref types

### DIFF
--- a/src/EntityGraphQL/Extensions/TypeExtensions.cs
+++ b/src/EntityGraphQL/Extensions/TypeExtensions.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
+using System.Reflection;
+using System.Collections.ObjectModel;
 
 namespace EntityGraphQL.Extensions
 {
@@ -101,6 +103,53 @@ namespace EntityGraphQL.Extensions
         public static bool IsNullableType(this Type t)
         {
             return t.IsGenericType && t.GetGenericTypeDefinition() == typeof(Nullable<>);
+        }
+
+
+        public static bool IsNullable(this PropertyInfo property) =>
+           IsNullableHelper(property.PropertyType, property.DeclaringType, property.CustomAttributes);
+
+        public static bool IsNullable(this FieldInfo field) =>
+            IsNullableHelper(field.FieldType, field.DeclaringType, field.CustomAttributes);
+
+        private static bool IsNullableHelper(Type memberType, MemberInfo? declaringType, IEnumerable<CustomAttributeData> customAttributes)
+        {
+            if (memberType.IsValueType)
+                return Nullable.GetUnderlyingType(memberType) != null;
+
+            var nullable = customAttributes
+                .FirstOrDefault(x => x.AttributeType.FullName == "System.Runtime.CompilerServices.NullableAttribute");
+            if (nullable != null && nullable.ConstructorArguments.Count == 1)
+            {
+                var attributeArgument = nullable.ConstructorArguments[0];
+                if (attributeArgument.ArgumentType == typeof(byte[]))
+                {
+                    var args = (ReadOnlyCollection<CustomAttributeTypedArgument>)attributeArgument.Value!;
+                    if (args.Count > 0 && args[0].ArgumentType == typeof(byte))
+                    {
+                        return (byte)args[0].Value! == 2;
+                    }
+                }
+                else if (attributeArgument.ArgumentType == typeof(byte))
+                {
+                    return (byte)attributeArgument.Value! == 2;
+                }
+            }
+
+            for (var type = declaringType; type != null; type = type.DeclaringType)
+            {
+                var context = type.CustomAttributes
+                    .FirstOrDefault(x => x.AttributeType.FullName == "System.Runtime.CompilerServices.NullableContextAttribute");
+                if (context != null &&
+                    context.ConstructorArguments.Count == 1 &&
+                    context.ConstructorArguments[0].ArgumentType == typeof(byte))
+                {
+                    return (byte)context.ConstructorArguments[0].Value! == 2;
+                }
+            }
+
+            // Couldn't find a suitable attribute
+            return true;
         }
     }
 }

--- a/src/EntityGraphQL/Schema/ArgType.cs
+++ b/src/EntityGraphQL/Schema/ArgType.cs
@@ -65,7 +65,7 @@ namespace EntityGraphQL.Schema
                 defaultValue = null;
             }
 
-            var arg = new ArgType(fieldNamer(field.Name), field.Name, new GqlTypeInfo(() => schema.GetSchemaType(typeToUse.IsConstructedGenericType && typeToUse.GetGenericTypeDefinition() == typeof(EntityQueryType<>) ? typeof(string) : typeToUse.GetNonNullableOrEnumerableType(), null), typeToUse), memberInfo, type)
+            var arg = new ArgType(fieldNamer(field.Name), field.Name, new GqlTypeInfo(() => schema.GetSchemaType(typeToUse.IsConstructedGenericType && typeToUse.GetGenericTypeDefinition() == typeof(EntityQueryType<>) ? typeof(string) : typeToUse.GetNonNullableOrEnumerableType(), null), typeToUse, memberInfo), memberInfo, type)
             {
                 DefaultValue = defaultValue,
                 IsRequired = markedRequired

--- a/src/EntityGraphQL/Schema/GqlTypeInfo.cs
+++ b/src/EntityGraphQL/Schema/GqlTypeInfo.cs
@@ -16,13 +16,13 @@ namespace EntityGraphQL.Schema
         /// <param name="schemaTypeGetter">Func to get the ISchemaType. Lookup is func as the type might be added later. It is cached after first look up</param>
         /// <param name="typeDotnet">The dotnet type as it is. E.g. the List<T> etc. </param>
         /// <param name="nullableValueTypes">value types are nullable. Used for arguments where they may have default values</param>
-        public GqlTypeInfo(Func<ISchemaType> schemaTypeGetter, Type typeDotnet, bool nullableValueTypes = false)
+        public GqlTypeInfo(Func<ISchemaType> schemaTypeGetter, Type typeDotnet, bool nullableValueTypes = false, bool nullableReferenceType = true)
         {
             SchemaTypeGetter = schemaTypeGetter;
 
             TypeDotnet = typeDotnet;
-            TypeNotNullable = !nullableValueTypes && TypeDotnet.IsValueType && !TypeDotnet.IsNullableType();
             IsList = TypeDotnet.IsEnumerableOrArray();
+            TypeNotNullable = !nullableValueTypes && TypeDotnet.IsValueType && !TypeDotnet.IsNullableType() || !nullableReferenceType;
             ElementTypeNullable = false;
         }
 

--- a/src/EntityGraphQL/Schema/GqlTypeInfo.cs
+++ b/src/EntityGraphQL/Schema/GqlTypeInfo.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Reflection;
 using EntityGraphQL.Extensions;
 
 namespace EntityGraphQL.Schema
@@ -16,13 +17,29 @@ namespace EntityGraphQL.Schema
         /// <param name="schemaTypeGetter">Func to get the ISchemaType. Lookup is func as the type might be added later. It is cached after first look up</param>
         /// <param name="typeDotnet">The dotnet type as it is. E.g. the List<T> etc. </param>
         /// <param name="nullableValueTypes">value types are nullable. Used for arguments where they may have default values</param>
-        public GqlTypeInfo(Func<ISchemaType> schemaTypeGetter, Type typeDotnet, bool nullableValueTypes = false, bool nullableReferenceType = true)
+        public GqlTypeInfo(Func<ISchemaType> schemaTypeGetter, Type typeDotnet, bool nullableValueTypes = false)
         {
             SchemaTypeGetter = schemaTypeGetter;
 
             TypeDotnet = typeDotnet;
             IsList = TypeDotnet.IsEnumerableOrArray();
-            TypeNotNullable = !nullableValueTypes && TypeDotnet.IsValueType && !TypeDotnet.IsNullableType() || !nullableReferenceType;
+            TypeNotNullable = !nullableValueTypes && TypeDotnet.IsValueType && !TypeDotnet.IsNullableType();
+            ElementTypeNullable = false;
+        }
+
+        /// <summary>
+        /// New GqlTypeInfo object that represents information about the return/argument type
+        /// </summary>
+        /// <param name="schemaTypeGetter">Func to get the ISchemaType. Lookup is func as the type might be added later. It is cached after first look up</param>
+        /// <param name="typeDotnet">The dotnet type as it is. E.g. the List<T> etc. </param>
+        /// <param name="fieldInfo">value types are nullable. Used for arguments where they may have default values</param>
+        public GqlTypeInfo(Func<ISchemaType> schemaTypeGetter, Type typeDotnet, MemberInfo memberInfo)
+        {
+            SchemaTypeGetter = schemaTypeGetter;
+
+            TypeDotnet = typeDotnet;
+            IsList = TypeDotnet.IsEnumerableOrArray();
+            TypeNotNullable = !memberInfo.IsNullable();
             ElementTypeNullable = false;
         }
 

--- a/src/EntityGraphQL/Schema/MutationType.cs
+++ b/src/EntityGraphQL/Schema/MutationType.cs
@@ -83,7 +83,7 @@ public class MutationType
             requiredClaims = requiredClaims.Concat(classLevelRequiredAuth);
         var actualReturnType = GetTypeFromMutationReturn(isAsync ? method.ReturnType.GetGenericArguments()[0] : method.ReturnType);
         var typeName = SchemaType.Schema.GetSchemaType(actualReturnType.GetNonNullableOrEnumerableType(), null).Name;
-        var returnType = new GqlTypeInfo(() => SchemaType.Schema.Type(typeName), actualReturnType);
+        var returnType = new GqlTypeInfo(() => SchemaType.Schema.Type(typeName), actualReturnType, method);
         var mutationField = new MutationField(SchemaType.Schema, name, returnType, mutationClassInstance, method, description ?? string.Empty, requiredClaims, isAsync, SchemaType.Schema.SchemaFieldNamer, autoAddInputTypes);
 
         var validators = method.GetCustomAttributes<ArgumentValidatorAttribute>();

--- a/src/EntityGraphQL/Schema/SchemaBuilder.cs
+++ b/src/EntityGraphQL/Schema/SchemaBuilder.cs
@@ -199,17 +199,11 @@ namespace EntityGraphQL.Schema
             if (baseReturnType.IsEnumerableOrArray())
                 baseReturnType = baseReturnType.GetEnumerableOrArrayType()!;
 
-            CacheType(baseReturnType, schema, createEnumTypes, createNewComplexTypes, fieldNamer, isInputType);
-
-            bool nullableRefType = true;
-            if (prop is PropertyInfo x)
-            {
-                nullableRefType = x.IsNullable();
-            }
+            CacheType(baseReturnType, schema, createEnumTypes, createNewComplexTypes, fieldNamer, isInputType);          
 
             // see if there is a direct type mapping from the expression return to to something.
             // otherwise build the type info
-            var returnTypeInfo = schema.GetCustomTypeMapping(le.ReturnType) ?? new GqlTypeInfo(() => schema.GetSchemaType(baseReturnType, null), le.Body.Type, nullableReferenceType: nullableRefType);
+            var returnTypeInfo = schema.GetCustomTypeMapping(le.ReturnType) ?? new GqlTypeInfo(() => schema.GetSchemaType(baseReturnType, null), le.Body.Type, prop);
             var field = new Field(schema, fieldNamer(prop.Name), le, description, returnTypeInfo, requiredClaims);
             
             var extensions = prop.GetCustomAttributes(typeof(FieldExtensionAttribute), false)?.Cast<FieldExtensionAttribute>().ToList();

--- a/src/EntityGraphQL/Schema/SchemaType.cs
+++ b/src/EntityGraphQL/Schema/SchemaType.cs
@@ -48,7 +48,7 @@ namespace EntityGraphQL.Schema
 
                     var enumName = Enum.Parse(TypeDotnet, field.Name).ToString();
                     var description = (field.GetCustomAttribute(typeof(DescriptionAttribute)) as DescriptionAttribute)?.Description;
-                    var schemaField = new Field(Schema, enumName, null, description, new GqlTypeInfo(() => Schema.GetSchemaType(TypeDotnet, null), TypeDotnet), Schema.AuthorizationService.GetRequiredAuthFromMember(field));
+                    var schemaField = new Field(Schema, enumName, null, description, new GqlTypeInfo(() => Schema.GetSchemaType(TypeDotnet, null), TypeDotnet, field), Schema.AuthorizationService.GetRequiredAuthFromMember(field));
                     var obsoleteAttribute = field.GetCustomAttribute<ObsoleteAttribute>();
                     if (obsoleteAttribute != null)
                     {

--- a/src/tests/EntityGraphQL.Tests/SchemaTests/GraphQLSchemaGenerateTests.cs
+++ b/src/tests/EntityGraphQL.Tests/SchemaTests/GraphQLSchemaGenerateTests.cs
@@ -237,6 +237,18 @@ namespace EntityGraphQL.Tests
             // this exists as it is not null
             Assert.Contains("Obsolete @deprecated(reason: \"This is an obsolete genre\")", schema);
         }
+
+        [Fact]
+        public void TestNullableRefTypeMutationField()
+        {
+            var schemaProvider = SchemaBuilder.FromObject<IgnoreTestSchema>(false);
+            schemaProvider.AddMutationsFrom(new NullableRefTypeMutations());
+            var schema = schemaProvider.ToGraphQLSchemaString();
+            // this exists as it is not null
+            Assert.Contains("addAlbum(name: String!, genre: Genre!): Album\r\n", schema);
+            Assert.Contains("addAlbum2(name: String!, genre: Genre!): Album!", schema);
+            Assert.Contains("addAlbum3(name: String!, genre: Genre!): Album\r\n", schema);
+        }
     }
 
     public class IgnoreTestMutations
@@ -277,7 +289,51 @@ namespace EntityGraphQL.Tests
             db.Albums.Add(newAlbum);
             return ctx => ctx.Albums.First(a => a.Id == newAlbum.Id);
         }
+
     }
+
+    public class NullableRefTypeMutations
+    {
+        [GraphQLMutation]
+        public Expression<Func<IgnoreTestSchema, Album>> AddAlbum(IgnoreTestSchema db, Album args)
+        {
+            var newAlbum = new Album
+            {
+                Id = new Random().Next(100),
+                Name = args.Name,
+            };
+            db.Albums.Add(newAlbum);
+            return ctx => ctx.Albums.First(a => a.Id == newAlbum.Id);
+        }
+
+#nullable enable
+        [GraphQLMutation]
+        public Expression<Func<IgnoreTestSchema, Album>> AddAlbum2(IgnoreTestSchema db, Album args)
+        {
+            var newAlbum = new Album
+            {
+                Id = new Random().Next(100),
+                Name = args.Name,
+            };
+            db.Albums.Add(newAlbum);
+            return ctx => ctx.Albums.First(a => a.Id == newAlbum.Id);
+        }
+
+
+        [GraphQLMutation]
+        public Expression<Func<IgnoreTestSchema, Album?>> AddAlbum3(IgnoreTestSchema db, Album args)
+        {
+            var newAlbum = new Album
+            {
+                Id = new Random().Next(100),
+                Name = args.Name,
+            };
+            db.Albums.Add(newAlbum);
+            return ctx => ctx.Albums.First(a => a.Id == newAlbum.Id);
+        }
+#nullable restore
+    }
+
 
     public class MovieArgs
     {

--- a/src/tests/EntityGraphQL.Tests/Util/NullableReferenceTypeTests.cs
+++ b/src/tests/EntityGraphQL.Tests/Util/NullableReferenceTypeTests.cs
@@ -12,6 +12,8 @@ namespace EntityGraphQL.Tests.Util
 
         public class WithoutNullableRefEnabled
         {
+            public int NonNullableInt { get; set; }
+            public int? NullableInt { get; set; }
             public string Nullable { get; set; }
             public IEnumerable<Test> Tests { get; set; }
         }
@@ -19,13 +21,23 @@ namespace EntityGraphQL.Tests.Util
         [Fact]
         public void TestNullableWithoutNullableRefEnabled()
         {
-            var propertyInfo = typeof(WithoutNullableRefEnabled).GetProperty("Nullable");            
+            var propertyInfo = typeof(WithoutNullableRefEnabled).GetProperty("NonNullableInt");            
+            Assert.False(propertyInfo.IsNullable());
+
+            propertyInfo = typeof(WithoutNullableRefEnabled).GetProperty("NullableInt");
             Assert.True(propertyInfo.IsNullable());
 
+            propertyInfo = typeof(WithoutNullableRefEnabled).GetProperty("Nullable");
+            Assert.True(propertyInfo.IsNullable());
+
+            propertyInfo = typeof(WithoutNullableRefEnabled).GetProperty("Tests");
+            Assert.True(propertyInfo.IsNullable());
 
             var schema = SchemaBuilder.FromObject<WithoutNullableRefEnabled>();
             var schemaString = schema.ToGraphQLSchemaString();
 
+            Assert.Contains(@"nonNullableInt: Int!", schemaString);
+            Assert.Contains(@"nullableInt: Int", schemaString);
             Assert.Contains(@"nullable: String", schemaString);
             Assert.Contains(@"tests: [Test!]", schemaString);
         }
@@ -33,6 +45,8 @@ namespace EntityGraphQL.Tests.Util
 #nullable enable
         public class WithNullableRefEnabled
         {
+            public int NonNullableInt { get; set; }
+            public int? NullableInt { get; set; }
             public string NonNullable { get; set; } = "";
             public string? Nullable { get; set; }
             public IEnumerable<Test> Tests { get; set; } = new List<Test>();
@@ -43,7 +57,13 @@ namespace EntityGraphQL.Tests.Util
         [Fact]
         public void TestNullableWithNullableRefEnabled()
         {
-            var propertyInfo = typeof(WithNullableRefEnabled).GetProperty("Nullable");
+            var propertyInfo = typeof(WithoutNullableRefEnabled).GetProperty("NonNullableInt");
+            Assert.False(propertyInfo.IsNullable());
+
+            propertyInfo = typeof(WithoutNullableRefEnabled).GetProperty("NullableInt");
+            Assert.True(propertyInfo.IsNullable());
+
+            propertyInfo = typeof(WithNullableRefEnabled).GetProperty("Nullable");
             Assert.True(propertyInfo.IsNullable());
 
             propertyInfo = typeof(WithNullableRefEnabled).GetProperty("NonNullable");
@@ -52,6 +72,8 @@ namespace EntityGraphQL.Tests.Util
             var schema = SchemaBuilder.FromObject<WithNullableRefEnabled>();
             var schemaString = schema.ToGraphQLSchemaString();
 
+            Assert.Contains(@"nonNullableInt: Int!", schemaString);
+            Assert.Contains(@"nullableInt: Int", schemaString);
             Assert.Contains(@"nullable: String", schemaString);
             Assert.Contains(@"nonNullable: String!", schemaString);
             Assert.Contains(@"tests: [Test!]!", schemaString);

--- a/src/tests/EntityGraphQL.Tests/Util/NullableReferenceTypeTests.cs
+++ b/src/tests/EntityGraphQL.Tests/Util/NullableReferenceTypeTests.cs
@@ -1,0 +1,62 @@
+using EntityGraphQL.Compiler.Util;
+using Xunit;
+using EntityGraphQL.Extensions;
+using EntityGraphQL.Schema;
+using System.Collections.Generic;
+
+namespace EntityGraphQL.Tests.Util
+{
+    public class NullableReferenceTypeTests
+    {
+        public class Test { }
+
+        public class WithoutNullableRefEnabled
+        {
+            public string Nullable { get; set; }
+            public IEnumerable<Test> Tests { get; set; }
+        }
+
+        [Fact]
+        public void TestNullableWithoutNullableRefEnabled()
+        {
+            var propertyInfo = typeof(WithoutNullableRefEnabled).GetProperty("Nullable");            
+            Assert.True(propertyInfo.IsNullable());
+
+
+            var schema = SchemaBuilder.FromObject<WithoutNullableRefEnabled>();
+            var schemaString = schema.ToGraphQLSchemaString();
+
+            Assert.Contains(@"nullable: String", schemaString);
+            Assert.Contains(@"tests: [Test!]", schemaString);
+        }
+
+#nullable enable
+        public class WithNullableRefEnabled
+        {
+            public string NonNullable { get; set; } = "";
+            public string? Nullable { get; set; }
+            public IEnumerable<Test> Tests { get; set; } = new List<Test>();
+            public IEnumerable<Test>? Tests2 { get; set; }
+        }
+#nullable restore
+
+        [Fact]
+        public void TestNullableWithNullableRefEnabled()
+        {
+            var propertyInfo = typeof(WithNullableRefEnabled).GetProperty("Nullable");
+            Assert.True(propertyInfo.IsNullable());
+
+            propertyInfo = typeof(WithNullableRefEnabled).GetProperty("NonNullable");
+            Assert.False(propertyInfo.IsNullable());
+
+            var schema = SchemaBuilder.FromObject<WithNullableRefEnabled>();
+            var schemaString = schema.ToGraphQLSchemaString();
+
+            Assert.Contains(@"nullable: String", schemaString);
+            Assert.Contains(@"nonNullable: String!", schemaString);
+            Assert.Contains(@"tests: [Test!]!", schemaString);
+            Assert.Contains(@"tests2: [Test!]", schemaString);
+        }
+
+    }
+}

--- a/src/tests/EntityGraphQL.Tests/Util/NullableReferenceTypeTests.cs
+++ b/src/tests/EntityGraphQL.Tests/Util/NullableReferenceTypeTests.cs
@@ -16,6 +16,7 @@ namespace EntityGraphQL.Tests.Util
             public int? NullableInt { get; set; }
             public string Nullable { get; set; }
             public IEnumerable<Test> Tests { get; set; }
+            public IEnumerable<Test> NullableMethod() { return null!; }
         }
 
         [Fact]
@@ -32,6 +33,9 @@ namespace EntityGraphQL.Tests.Util
 
             propertyInfo = typeof(WithoutNullableRefEnabled).GetProperty("Tests");
             Assert.True(propertyInfo.IsNullable());
+
+            var methodInfo = typeof(WithoutNullableRefEnabled).GetMethod("NullableMethod");
+            Assert.True(methodInfo.IsNullable());
 
             var schema = SchemaBuilder.FromObject<WithoutNullableRefEnabled>();
             var schemaString = schema.ToGraphQLSchemaString();
@@ -51,6 +55,8 @@ namespace EntityGraphQL.Tests.Util
             public string? Nullable { get; set; }
             public IEnumerable<Test> Tests { get; set; } = new List<Test>();
             public IEnumerable<Test>? Tests2 { get; set; }
+            public IEnumerable<Test> NonNullableMethod() { return null!; }
+            public IEnumerable<Test?> NullableMethod() { return null!; }
         }
 #nullable restore
 
@@ -68,6 +74,12 @@ namespace EntityGraphQL.Tests.Util
 
             propertyInfo = typeof(WithNullableRefEnabled).GetProperty("NonNullable");
             Assert.False(propertyInfo.IsNullable());
+
+            var methodInfo = typeof(WithNullableRefEnabled).GetMethod("NullableMethod");
+            Assert.True(methodInfo.IsNullable());
+
+            methodInfo = typeof(WithNullableRefEnabled).GetMethod("NonNullableMethod");
+            Assert.False(methodInfo.IsNullable());
 
             var schema = SchemaBuilder.FromObject<WithNullableRefEnabled>();
             var schemaString = schema.ToGraphQLSchemaString();


### PR DESCRIPTION
given the following context

```
public class Context
{
   public string NonNullable { get; set; } = "";
   public string? Nullable { get; set; }   
   public IEnumerable<Test> Tests { get; set; } = new List<Test>();
   public IEnumerable<Test>? Tests2 { get; set; }
}
```

generate the following query type

```
type Query {
	nonNullable: String!
	nullable: String
	tests: [Test!]!
	tests2: [Test!]
}
```

