### PR TITLE
Only get types for public instance properties of mutations.

### DIFF
--- a/src/EntityGraphQL/Schema/MutationField.cs
+++ b/src/EntityGraphQL/Schema/MutationField.cs
@@ -30,7 +30,7 @@ namespace EntityGraphQL.Schema
                 .SingleOrDefault(p => p.GetCustomAttribute(typeof(MutationArgumentsAttribute)) != null || p.ParameterType.GetTypeInfo().GetCustomAttribute(typeof(MutationArgumentsAttribute)) != null)?.ParameterType;
             if (ArgumentsType != null)
             {
-                foreach (var item in ArgumentsType.GetProperties())
+                foreach (var item in ArgumentsType.GetProperties(BindingFlags.Instance | BindingFlags.Public))
                 {
                     if (GraphQLIgnoreAttribute.ShouldIgnoreMemberFromInput(item))
                         continue;


### PR DESCRIPTION
There are a few other calls to `GetProperties` in the codebase without arguments. It's not clear whether they also should filter their output.