### PR TITLE
Multiple inheritance and code cleanup

### DIFF
--- a/docs/content/schema-creation/03-types.md
+++ b/docs/content/schema-creation/03-types.md
@@ -109,11 +109,18 @@ public class Droid : Character {
 schema.AddInterface<Character>(name: "Character", description: "represents any character in the Star Wars trilogy");
     .AddAllFields();
 
-schema.AddInheritedType<Human>(name: "Human", "", baseType: "Character")
-    .AddAllFields();
+schema.AddType<Human>("")
+    .AddAllFields()
+    .AddAllBaseTypes();
 
-schema.AddInheritedType<Droid>(name: "Droid", "", baseType: "Character");
-    .AddAllFields();
+schema.AddType<Droid>("");
+    .AddBaseType<Character>();
+
+// or
+
+schema.AddType<Droid>("");
+    .AddBaseType("Character");
+
 ```
 
 produces the graphql schema:

--- a/src/EntityGraphQL/Schema/BaseSchemaTypeWithFields.cs
+++ b/src/EntityGraphQL/Schema/BaseSchemaTypeWithFields.cs
@@ -12,12 +12,21 @@ namespace EntityGraphQL.Schema
         public abstract Type TypeDotnet { get; }
         public string Name { get; }
         public string? Description { get; set; }
-        public abstract bool IsInput { get; }
-        public abstract bool IsInterface { get; }
-        public abstract bool IsEnum { get; }
-        public abstract bool IsScalar { get; }
-        public abstract string? BaseType { get; }
-        public bool RequiresSelection => !IsScalar && !IsEnum;
+        public GqlTypeEnum GqlType { get; protected set; }
+
+        protected List<ISchemaType> _baseTypes = new List<ISchemaType>();
+        public IList<ISchemaType> BaseTypes => _baseTypes.AsReadOnly();
+
+        [Obsolete]
+        public bool IsInput { get { return GqlType == GqlTypeEnum.Input; } }
+        [Obsolete]
+        public bool IsInterface { get { return GqlType == GqlTypeEnum.Interface; } }
+        [Obsolete]
+        public bool IsEnum { get { return GqlType == GqlTypeEnum.Enum; } }
+        [Obsolete]
+        public bool IsScalar { get { return GqlType == GqlTypeEnum.Scalar; } }
+        
+        public bool RequiresSelection => GqlType != GqlTypeEnum.Scalar && GqlType != GqlTypeEnum.Enum;
         public RequiredAuthorization? RequiredAuthorization { get; set; }
 
         protected BaseSchemaTypeWithFields(ISchemaProvider schema, string name, string? description, RequiredAuthorization? requiredAuthorization)
@@ -104,5 +113,9 @@ namespace EntityGraphQL.Schema
         {
             FieldsByName.Remove(name);
         }
+
+        public abstract ISchemaType AddAllBaseTypes();
+        public abstract ISchemaType AddBaseType<TClrType>();
+        public abstract ISchemaType AddBaseType(string name);
     }
 }

--- a/src/EntityGraphQL/Schema/GqlTypeEnum.cs
+++ b/src/EntityGraphQL/Schema/GqlTypeEnum.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace EntityGraphQL.Schema
+{
+    public enum GqlTypeEnum
+    {
+        Scalar,
+        Enum,
+        Object,
+        Interface,
+        Input,
+        Mutation,
+    }
+}

--- a/src/EntityGraphQL/Schema/ISchemaType.cs
+++ b/src/EntityGraphQL/Schema/ISchemaType.cs
@@ -6,6 +6,7 @@ namespace EntityGraphQL.Schema
     public interface ISchemaType
     {
         Type TypeDotnet { get; }
+        GqlTypeEnum GqlType { get; }
         string Name { get; }
         string? Description { get; set; }
         bool IsInput { get; }
@@ -13,7 +14,7 @@ namespace EntityGraphQL.Schema
         bool IsEnum { get; }
         bool IsScalar { get; }
         bool RequiresSelection { get; }
-        string? BaseType { get; }
+        public IList<ISchemaType> BaseTypes { get; }
         RequiredAuthorization? RequiredAuthorization { get; set; }
         IField GetField(string identifier, QueryRequestContext? requestContext);
         IEnumerable<IField> GetFields();
@@ -22,5 +23,8 @@ namespace EntityGraphQL.Schema
         void AddFields(IEnumerable<IField> fields);
         IField AddField(IField field);
         void RemoveField(string name);
+        ISchemaType AddAllBaseTypes();
+        ISchemaType AddBaseType<TClrType>();
+        ISchemaType AddBaseType(string name);
     }
 }

--- a/src/EntityGraphQL/Schema/Models/Introspection.cs
+++ b/src/EntityGraphQL/Schema/Models/Introspection.cs
@@ -53,7 +53,7 @@ namespace EntityGraphQL.Schema.Models
 
         public InputValue[] InputFields { get; set; } = new InputValue[0];
 
-        public TypeElement[] Interfaces { get; private set; } = new TypeElement[0];
+        public TypeElement[] Interfaces { get; set; } = new TypeElement[0];
 
         public EnumValue[] EnumValues { get; set; } = new EnumValue[0];
 

--- a/src/EntityGraphQL/Schema/MutationType.cs
+++ b/src/EntityGraphQL/Schema/MutationType.cs
@@ -130,23 +130,28 @@ public class MutationSchemaType : BaseSchemaTypeWithFields<MutationField>
 {
     public override Type TypeDotnet => typeof(MutationType);
 
-    public override bool IsInput => false;
-
-    public override bool IsEnum => false;
-
-    public override bool IsScalar => false;
-
-    public override bool IsInterface => false;
-
-    public override string? BaseType => null;
-
     public MutationSchemaType(ISchemaProvider schema, string name, string? description, RequiredAuthorization? requiredAuthorization)
         : base(schema, name, description, requiredAuthorization)
     {
+        GqlType = GqlTypeEnum.Mutation;
     }
 
     public override ISchemaType AddAllFields(bool autoCreateNewComplexTypes = false, bool autoCreateEnumTypes = true)
     {
         return this;
+    }
+
+    public override ISchemaType AddAllBaseTypes()
+    {
+        throw new Exception("Cannot add base types to a mutation");
+    }
+    public override ISchemaType AddBaseType<TClrType>()
+    {
+        throw new Exception("Cannot add base types to a mutation");
+
+    }
+    public override ISchemaType AddBaseType(string name)
+    {
+        throw new Exception("Cannot add base types to a mutation");
     }
 }

--- a/src/EntityGraphQL/Schema/SchemaGenerator.cs
+++ b/src/EntityGraphQL/Schema/SchemaGenerator.cs
@@ -98,9 +98,12 @@ type {rootQueryType.Name} {{
                     _ => "type"
                 };
 
-                var implements = string.IsNullOrWhiteSpace(typeItem.BaseType)
-                    ? ""
-                    : $"implements {typeItem.BaseType} ";
+
+                var implements = "";
+
+                if (typeItem.BaseTypes != null && typeItem.BaseTypes.Count() > 0) {
+                    implements += $"implements {string.Join(" & ", typeItem.BaseTypes.Select(i => i.Name))} ";
+                }
 
                 types.AppendLine($"{type} {typeItem.Name} {implements}{{");
                 foreach (var field in typeItem.GetFields())

--- a/src/EntityGraphQL/Schema/SchemaIntrospection.cs
+++ b/src/EntityGraphQL/Schema/SchemaIntrospection.cs
@@ -75,12 +75,9 @@
                     Description = st.Description,                   
                 };
 
-                if(!string.IsNullOrEmpty(st.BaseType))
+                if(st.BaseTypes != null && st.BaseTypes.Count() > 0)
                 {
-                    typeElement.Interfaces = new[]
-                    {
-                        new TypeElement("INTERFACE", st.BaseType)
-                    };
+                    typeElement.Interfaces = st.BaseTypes.Select(baseType => new TypeElement("INTERFACE", baseType.Name)).ToArray();                    
                 }
 
                 types.Add(typeElement);

--- a/src/EntityGraphQL/Schema/SchemaIntrospection.cs
+++ b/src/EntityGraphQL/Schema/SchemaIntrospection.cs
@@ -72,8 +72,16 @@
 
                 var typeElement = new TypeElement(kind, st.Name)
                 {
-                    Description = st.Description
+                    Description = st.Description,                   
                 };
+
+                if(!string.IsNullOrEmpty(st.BaseType))
+                {
+                    typeElement.Interfaces = new[]
+                    {
+                        new TypeElement("INTERFACE", st.BaseType)
+                    };
+                }
 
                 types.Add(typeElement);
             }

--- a/src/EntityGraphQL/Schema/SchemaIntrospection.cs
+++ b/src/EntityGraphQL/Schema/SchemaIntrospection.cs
@@ -63,8 +63,14 @@
             var types = new List<TypeElement>();
 
             foreach (var st in schema.GetNonContextTypes().Where(s => !s.IsInput && !s.IsEnum && !s.IsScalar))
-            {
-                var typeElement = new TypeElement("OBJECT", st.Name)
+            {                
+                var kind = st switch
+                {
+                    { IsInterface: true } => "INTERFACE",
+                    _ => "OBJECT"
+                };
+
+                var typeElement = new TypeElement(kind, st.Name)
                 {
                     Description = st.Description
                 };

--- a/src/EntityGraphQL/Schema/SchemaType.cs
+++ b/src/EntityGraphQL/Schema/SchemaType.cs
@@ -9,35 +9,48 @@ namespace EntityGraphQL.Schema
     public class SchemaType<TBaseType> : BaseSchemaTypeWithFields<Field>
     {
         public override Type TypeDotnet { get; }
-        public override bool IsInput { get; }
-        public override bool IsEnum { get; }
-        public override bool IsScalar { get; }
-        public override bool IsInterface { get; }
-        public override string? BaseType { get; }
 
+        [Obsolete]
         public SchemaType(ISchemaProvider schema, string name, string? description, RequiredAuthorization? requiredAuthorization, bool isInput = false, bool isEnum = false, bool isScalar = false, bool isInterface = false, string? baseType = null)
-            : this(schema, typeof(TBaseType), name, description, requiredAuthorization, isInput, isEnum, isScalar, isInterface, baseType)
+            : this(schema, typeof(TBaseType), name, description, requiredAuthorization,
+                isInput ? GqlTypeEnum.Input :
+                isEnum ? GqlTypeEnum.Enum :
+                isScalar ? GqlTypeEnum.Scalar :
+                isInterface ? GqlTypeEnum.Interface :
+                GqlTypeEnum.Object,
+                baseType
+            )
         {
         }
 
-        public SchemaType(ISchemaProvider schema, Type dotnetType, string name, string? description, RequiredAuthorization? requiredAuthorization, bool isInput = false, bool isEnum = false, bool isScalar = false, bool isInterface = false, string? baseType = null)
-            : base(schema, name, description, requiredAuthorization)
+        public SchemaType(ISchemaProvider schema, string name, string? description, RequiredAuthorization? requiredAuthorization, GqlTypeEnum gqlType = GqlTypeEnum.Object, string? baseType = null)
+            : this(schema, typeof(TBaseType), name, description, requiredAuthorization, gqlType, baseType)
+        {
+
+        }
+
+
+        public SchemaType(ISchemaProvider schema, Type dotnetType, string name, string? description, RequiredAuthorization? requiredAuthorization, GqlTypeEnum gqlType = GqlTypeEnum.Object, string? baseType = null)
+            : base(schema, name, description, requiredAuthorization)                
         {
             TypeDotnet = dotnetType;
-            IsInput = isInput;
-            IsEnum = isEnum;
-            IsScalar = isScalar;
-            IsInterface = isInterface;
+            GqlType = gqlType;
+
             RequiredAuthorization = requiredAuthorization;
-            BaseType = baseType;
-            if (!isScalar)
+
+            if (gqlType != GqlTypeEnum.Scalar)
             {
-                if (isInterface)
+                if (gqlType == GqlTypeEnum.Interface)
                     // Because the type might actually be the type extending from the interface we need to look it up
                     AddField("__typename", t => schema.Type(t!.GetType().Name).Name, "Type name").IsNullable(false);
                 else
                     // Simple and allows FieldExtensions that create new types that are not interfaces not have to worry about updating the typename expression
                     AddField("__typename", _ => Name, "Type name").IsNullable(false);
+            }
+
+            if (baseType != null)
+            {
+                _baseTypes.Add(schema.GetSchemaType(baseType, null));
             }
         }
 
@@ -50,7 +63,7 @@ namespace EntityGraphQL.Schema
         /// <returns>The schema type the fields were added to</returns>
         public override ISchemaType AddAllFields(bool autoCreateNewComplexTypes = false, bool autoCreateEnumTypes = true)
         {
-            if (IsEnum)
+            if (GqlType == GqlTypeEnum.Enum)
             {
                 foreach (var field in TypeDotnet.GetFields())
                 {
@@ -304,6 +317,41 @@ namespace EntityGraphQL.Schema
             if (RequiredAuthorization == null)
                 RequiredAuthorization = new RequiredAuthorization();
             RequiredAuthorization.RequiresAnyPolicy(policies);
+            return this;
+        }
+
+
+        public override ISchemaType AddAllBaseTypes()
+        {
+            var baseType = Schema.GetSchemaType(TypeDotnet.BaseType, null);
+            if(baseType != null)
+            {
+                _baseTypes.Add(baseType);
+            }
+
+            foreach (var i in this.TypeDotnet.GetInterfaces())
+            {
+                var interfaceType = Schema.GetSchemaType(i, null);
+                if (interfaceType != null)
+                {
+                    _baseTypes.Add(interfaceType);
+                }
+            }
+
+          return this;
+        }
+
+        public override ISchemaType AddBaseType<TypeDotnet>()
+        {
+            var baseType = Schema.GetSchemaType(typeof(TypeDotnet), null);
+            _baseTypes.Add(baseType);
+            return this;
+        }
+
+        public override ISchemaType AddBaseType(string name)
+        {
+            var baseType = Schema.GetSchemaType(name, null);
+            _baseTypes.Add(baseType);
             return this;
         }
     }

--- a/src/tests/EntityGraphQL.Tests/SchemaTests/GraphQLSchemaGenerateTests.cs
+++ b/src/tests/EntityGraphQL.Tests/SchemaTests/GraphQLSchemaGenerateTests.cs
@@ -254,8 +254,12 @@ namespace EntityGraphQL.Tests
         public void TestAbstractClass()
         {
             var schemaProvider = SchemaBuilder.FromObject<AbstractClassTestSchema>(false);
-            schemaProvider.AddInheritedType<AbstractClassTestSchema.Dog>("Dog", "Dogs are animals", "Animal").AddAllFields();
-            schemaProvider.AddInheritedType<AbstractClassTestSchema.Cat>("Cat", "Cats are animals", "Animal").AddAllFields();
+
+            schemaProvider.AddType<AbstractClassTestSchema.Dog>("Dogs are animals").AddAllBaseTypes().AddAllFields();
+            schemaProvider.AddType<AbstractClassTestSchema.Cat>("Cats are animals").AddBaseType<Animal>().AddAllFields();
+            schemaProvider.AddType<AbstractClassTestSchema.Fish>("Fish are animals");
+
+            schemaProvider.UpdateType<AbstractClassTestSchema.Fish>(x => x.AddBaseType("Animal").AddAllFields());
 
             var schema = schemaProvider.ToGraphQLSchemaString();
             // this exists as it is not null
@@ -263,6 +267,27 @@ namespace EntityGraphQL.Tests
 
             Assert.Contains(@"type Cat implements Animal", schema);
             Assert.Contains(@"type Dog implements Animal", schema);
+            Assert.Contains(@"type Fish implements Animal", schema);
+        }
+
+        [Fact]
+        public void TestMultipleInheritance()
+        {
+            var schemaProvider = SchemaBuilder.FromObject<AbstractClassTestSchema>(false);
+
+            schemaProvider.AddType<AbstractClassTestSchema.ISwim>("").AddAllFields();
+            schemaProvider.AddType<AbstractClassTestSchema.Dog>("Dogs are animals").AddAllBaseTypes().AddAllFields();
+            schemaProvider.AddType<AbstractClassTestSchema.Cat>("Cats are animals").AddBaseType<Animal>().AddAllFields();
+            schemaProvider.AddType<AbstractClassTestSchema.Fish>("Fish are animals").AddAllBaseTypes().AddAllFields();
+
+            var schema = schemaProvider.ToGraphQLSchemaString();
+            // this exists as it is not null
+            Assert.Contains(@"interface Animal", schema);
+            Assert.Contains(@"interface ISwim", schema);
+
+            Assert.Contains(@"type Cat implements Animal", schema);
+            Assert.Contains(@"type Dog implements Animal", schema);
+            Assert.Contains(@"type Fish implements Animal & ISwim", schema);
         }
 
         [Fact]
@@ -378,6 +403,11 @@ namespace EntityGraphQL.Tests
             public string Name { get; set; }
         }
 
+        public interface ISwim
+        {
+            public int Fins { get; set; }
+        }
+
         public class Cat : Animal
         {
             public int Lives { get; set; }
@@ -386,6 +416,11 @@ namespace EntityGraphQL.Tests
         public class Dog : Animal
         {
             public int Bones { get; set; }
+        }
+
+        public class Fish : Animal, ISwim
+        {
+            public int Fins { get; set; }
         }
     }
 

--- a/src/tests/EntityGraphQL.Tests/SchemaTests/SchemaBuilderTests.cs
+++ b/src/tests/EntityGraphQL.Tests/SchemaTests/SchemaBuilderTests.cs
@@ -136,7 +136,7 @@ namespace EntityGraphQL.Tests
         public void InheritedClassesBecomeObjectsIntrospection()
         {
             var schemaProvider = SchemaBuilder.FromObject<TestSchema3>();
-            schemaProvider.AddType<InheritedClass>("InheritedClass");
+            schemaProvider.AddInheritedType<InheritedClass>("InheritedClass", "", "AbstractClass");
             Assert.False(schemaProvider.Type<InheritedClass>().IsInterface);
             Assert.Single(schemaProvider.Type<InheritedClass>().GetFields());
 
@@ -147,6 +147,10 @@ namespace EntityGraphQL.Tests
                       __type(name: ""InheritedClass"") {
                         name
                         kind
+                        interfaces {
+                            name
+                            kind
+                        }
                       }
                     }"
             };
@@ -161,6 +165,9 @@ namespace EntityGraphQL.Tests
 
             Assert.Equal("InheritedClass", ((dynamic)res.Data["__type"]).name);
             Assert.Equal("OBJECT", ((dynamic)res.Data["__type"]).kind);
+
+            Assert.Equal("INTERFACE", ((dynamic)res.Data["__type"]).interfaces[0].kind);
+            Assert.Equal("AbstractClass", ((dynamic)res.Data["__type"]).interfaces[0].name);
         }
 
         [Fact]

--- a/src/tests/EntityGraphQL.Tests/SchemaTests/SchemaBuilderTests.cs
+++ b/src/tests/EntityGraphQL.Tests/SchemaTests/SchemaBuilderTests.cs
@@ -95,11 +95,11 @@ namespace EntityGraphQL.Tests
         public void AbstractClassesBecomeInterfaces()
         {            
             var schemaProvider = SchemaBuilder.FromObject<TestSchema3>();
-            Assert.True(schemaProvider.Type<AbstractClass>().IsInterface);
+            Assert.Equal(GqlTypeEnum.Interface, schemaProvider.Type<AbstractClass>().GqlType);
             Assert.Equal(2, schemaProvider.Type<AbstractClass>().GetFields().Count());
 
             schemaProvider.AddType<InheritedClass>("InheritedClass");
-            Assert.False(schemaProvider.Type<InheritedClass>().IsInterface);
+            Assert.Equal(GqlTypeEnum.Object, schemaProvider.Type<InheritedClass>().GqlType);
             Assert.Single(schemaProvider.Type<InheritedClass>().GetFields());
         }
 
@@ -136,8 +136,8 @@ namespace EntityGraphQL.Tests
         public void InheritedClassesBecomeObjectsIntrospection()
         {
             var schemaProvider = SchemaBuilder.FromObject<TestSchema3>();
-            schemaProvider.AddInheritedType<InheritedClass>("InheritedClass", "", "AbstractClass");
-            Assert.False(schemaProvider.Type<InheritedClass>().IsInterface);
+            schemaProvider.AddType<InheritedClass>("").AddAllBaseTypes();
+            Assert.Equal(GqlTypeEnum.Object, schemaProvider.Type<InheritedClass>().GqlType);
             Assert.Single(schemaProvider.Type<InheritedClass>().GetFields());
 
             var gql = new QueryRequest

--- a/src/tests/EntityGraphQL.Tests/SchemaTests/SchemaBuilderTests.cs
+++ b/src/tests/EntityGraphQL.Tests/SchemaTests/SchemaBuilderTests.cs
@@ -103,6 +103,95 @@ namespace EntityGraphQL.Tests
             Assert.Single(schemaProvider.Type<InheritedClass>().GetFields());
         }
 
+        [Fact]
+        public void AbstractClassesBecomeInterfacesIntrospection()
+        {
+            var schemaProvider = SchemaBuilder.FromObject<TestSchema3>();
+
+            var gql = new QueryRequest
+            {
+                Query = @"
+        query IntrospectionQuery {
+          __type(name: ""AbstractClass"") {
+            name
+            kind
+          }
+        }"
+            };
+
+            var context = new TestDataContext
+            {
+                Projects = new List<Project>()
+            };
+
+            var res = schemaProvider.ExecuteRequest(gql, new TestSchema3(), null, null);
+            Assert.Null(res.Errors);
+            
+            Assert.Equal("AbstractClass", ((dynamic)res.Data["__type"]).name);
+            Assert.Equal("INTERFACE", ((dynamic)res.Data["__type"]).kind);
+        }
+
+
+        [Fact]
+        public void InheritedClassesBecomeObjectsIntrospection()
+        {
+            var schemaProvider = SchemaBuilder.FromObject<TestSchema3>();
+            schemaProvider.AddType<InheritedClass>("InheritedClass");
+            Assert.False(schemaProvider.Type<InheritedClass>().IsInterface);
+            Assert.Single(schemaProvider.Type<InheritedClass>().GetFields());
+
+            var gql = new QueryRequest
+            {
+                Query = @"
+                    query IntrospectionQuery {
+                      __type(name: ""InheritedClass"") {
+                        name
+                        kind
+                      }
+                    }"
+            };
+
+            var context = new TestDataContext
+            {
+                Projects = new List<Project>()
+            };
+
+            var res = schemaProvider.ExecuteRequest(gql, new TestSchema3(), null, null);
+            Assert.Null(res.Errors);
+
+            Assert.Equal("InheritedClass", ((dynamic)res.Data["__type"]).name);
+            Assert.Equal("OBJECT", ((dynamic)res.Data["__type"]).kind);
+        }
+
+        [Fact]
+        public void NonAbstractClassesBecomeObjectsIntrospection()
+        {
+            var schemaProvider = SchemaBuilder.FromObject<TestSchema2>();
+
+            var gql = new QueryRequest
+            {
+                Query = @"
+        query IntrospectionQuery {
+          __type(name: ""Property"") {
+            name
+            kind
+          }
+        }"
+            };
+                
+
+            var context = new TestDataContext
+            {
+                Projects = new List<Project>()
+            };
+
+            var res = schemaProvider.ExecuteRequest(gql, new TestSchema2(), null, null);
+            Assert.Null(res.Errors);
+
+            Assert.Equal("Property", ((dynamic)res.Data["__type"]).name);
+            Assert.Equal("OBJECT", ((dynamic)res.Data["__type"]).kind);
+        }
+
         // This would be your Entity/Object graph you use with EntityFramework
         private class TestSchema
         {

--- a/src/tests/EntityGraphQL.Tests/SchemaTests/SchemaProviderTests.cs
+++ b/src/tests/EntityGraphQL.Tests/SchemaTests/SchemaProviderTests.cs
@@ -75,11 +75,11 @@ namespace EntityGraphQL.Tests
 
             Assert.Equal("Dog", schema.Type("Dog").Name);
             Assert.False(schema.Type("Dog").IsInterface);
-            Assert.Equal("Animal", schema.Type("Dog").BaseType);
+            Assert.Equal("Animal", schema.Type("Dog").BaseTypes[0].Name);
 
             Assert.Equal("Cat", schema.Type("Cat").Name);
             Assert.False(schema.Type("Cat").IsInterface);
-            Assert.Equal("Animal", schema.Type("Cat").BaseType);
+            Assert.Equal("Animal", schema.Type("Cat").BaseTypes[0].Name);
         }
     }
 }

--- a/src/tests/EntityGraphQL.Tests/SchemaTests/TestAbstractDataGraphSchema.cs
+++ b/src/tests/EntityGraphQL.Tests/SchemaTests/TestAbstractDataGraphSchema.cs
@@ -20,8 +20,8 @@ namespace EntityGraphQL.Tests
                 var animal = AddInterface<Animal>(name: "Animal", description: "An animal");
                 animal.AddAllFields();
 
-                AddInheritedType<Dog>(name: "Dog", "", baseType: "Animal");
-                AddInheritedType<Cat>(name: "Cat", "", baseType: "Animal");
+                AddType<Dog>("").AddAllBaseTypes();
+                AddType<Cat>("").AddAllBaseTypes();
 
                 UpdateQuery(query =>
                 {


### PR DESCRIPTION
Includes changes from https://github.com/EntityGraphQL/EntityGraphQL/pull/139/

* Cleanup SchemaType to use an enum instead of lots of boolean type variables (controversial? i tried to not break any public api)
* Allow types to inherit from multiple base classes/interfaces
* Cleanup Interfaces api a bit - added a "AddAllBaseTypes, AddBaseType<T> and AddBaseType(string)" which provides a lot more flexiblity (there were issues when a type was auto detected before you could add its base type)