### PR TITLE
Remove boilerplate type descriptions

### DIFF
--- a/src/EntityGraphQL/Schema/SchemaBuilder.cs
+++ b/src/EntityGraphQL/Schema/SchemaBuilder.cs
@@ -15,7 +15,7 @@ using System.Collections.ObjectModel;
 namespace EntityGraphQL.Schema
 {
     /// <summary>
-    /// A simple schema provider to automattically create a query schema based on an object.
+    /// A simple schema provider to automatically create a query schema based on an object.
     /// Commonly used with a DbContext.
     /// </summary>
     public static class SchemaBuilder
@@ -68,7 +68,7 @@ namespace EntityGraphQL.Schema
         /// <summary>
         /// Given the type TContextType recursively create a query schema based on the public properties of the object. Schema is added into the provider schema
         /// </summary>
-        /// <param name="schema">Schema tp add types to.</param>
+        /// <param name="schema">Schema to add types to.</param>
         /// <param name="autoCreateIdArguments">If true (default), automatically create a field for any root array thats context object contains an Id property. I.e. If Actor has an Id property and the root TContextType contains IEnumerable<Actor> Actors. A root field Actor(id) will be created.</param>
         /// <param name="fieldNamer">Optionally provider a function to generate the GraphQL field name. By default this will make fields names that follow GQL style in lowerCaseCamelStyle</param>
         /// <typeparam name="TContextType"></typeparam>

--- a/src/EntityGraphQL/Schema/SchemaProvider.cs
+++ b/src/EntityGraphQL/Schema/SchemaProvider.cs
@@ -78,11 +78,11 @@ namespace EntityGraphQL.Schema
                 {typeof(bool), new GqlTypeInfo(() => Type("Boolean"), typeof(bool))},
             };
 
-            var queryContext = new SchemaType<TContextType>(this, "Query", "The query type represents all of the entry points into the object graph", null, GqlTypeEnum.Object);
+            var queryContext = new SchemaType<TContextType>(this, "Query", null, null, GqlTypeEnum.Object);
             this.queryType = queryContext;
             schemaTypes.Add(queryContext.Name, queryContext);
 
-            var mutationType = new MutationType(this, "Mutation", "The mutation type schema represents all of the mutation functions in the schema", null);
+            var mutationType = new MutationType(this, "Mutation", null, null);
             this.mutationType = mutationType;
             schemaTypes.Add(mutationType.SchemaType.Name, mutationType.SchemaType);
 
@@ -114,8 +114,8 @@ namespace EntityGraphQL.Schema
         }
 
         /// <summary>
-        /// Add a custom type converter to convert query variables into the expected dotnet types. I.e. the incoming varables from 
-        /// the rquest which may be strings or JSON into the dotnet tyopes on the argument classes.
+        /// Add a custom type converter to convert query variables into the expected dotnet types. I.e. the incoming variables from 
+        /// the request which may be strings or JSON into the dotnet types on the argument classes.
         /// For example a string to DateTime converter.
         /// 
         /// EntityGraphQL already handles Guid, DateTime, InputTypes from the schema, arrays/lists, System.Text.Json elements, float/double/decimal/int/short/uint/long/etc


### PR DESCRIPTION
The descriptions for the `Query` and `Mutations` types can be considered unnecessary, since they are already well-defined types. Users may read the comments expecting to find specific details about a particular GraphQL API, only to end up realizing they are just boilerplate. OTOH, such comments can be useful for new users. It's a tradeoff. Another factor is that tools may not expect description here (see dotansimha/graphql-code-generator#8025).

If a description is ultimately included, better grammar would be like this:
> The query type representing all the entry points into the object graph.