### PR TITLE
feature: Allow GraphQL mutation arguments as seperate arguments

### DIFF
--- a/src/EntityGraphQL/Compiler/Util/ArgumentUtil.cs
+++ b/src/EntityGraphQL/Compiler/Util/ArgumentUtil.cs
@@ -103,7 +103,7 @@ public static class ArgumentUtil
         return argumentValues;
     }
 
-    private static object? BuildArgumentFromMember(ISchemaProvider schema, IReadOnlyDictionary<string, object>? args, string memberName, Type memberType, object? defaultValue, IList<string> validationErrors)
+    public static object? BuildArgumentFromMember(ISchemaProvider schema, IReadOnlyDictionary<string, object>? args, string memberName, Type memberType, object? defaultValue, IList<string> validationErrors)
     {
         string argName = memberName;
         // check we have required arguments

--- a/src/EntityGraphQL/Schema/ArgType.cs
+++ b/src/EntityGraphQL/Schema/ArgType.cs
@@ -45,6 +45,13 @@ namespace EntityGraphQL.Schema
             return arg;
         }
 
+        public static ArgType FromParameter(ISchemaProvider schema, ParameterInfo prop, object? defaultValue, Func<string, string> fieldNamer)
+        {
+            var arg = MakeArgType(schema, prop.Member, prop.ParameterType, prop.Member, defaultValue, fieldNamer);
+
+            return arg;
+        }
+
         public static ArgType FromField(ISchemaProvider schema, FieldInfo field, object? defaultValue, Func<string, string> fieldNamer)
         {
             var arg = MakeArgType(schema, field, field.FieldType, field, defaultValue, fieldNamer);

--- a/src/EntityGraphQL/Schema/Attributes/GraphQLIgnoreAttribute.cs
+++ b/src/EntityGraphQL/Schema/Attributes/GraphQLIgnoreAttribute.cs
@@ -48,6 +48,23 @@ namespace EntityGraphQL.Schema
             }
             return false;
         }
+
+        /// <summary>
+        /// Parameter is marked as being ignored for inclusion in the Mutation Input types
+        /// </summary>
+        /// <param name="prop"></param>
+        /// <returns></returns>
+        public static bool ShouldIgnoreMemberFromInput(ParameterInfo prop)
+        {
+            if (prop.GetCustomAttribute(typeof(GraphQLIgnoreAttribute)) is GraphQLIgnoreAttribute attribute)
+            {
+                if (attribute.IgnoreFrom == GraphQLIgnoreType.All || attribute.IgnoreFrom == GraphQLIgnoreType.Input)
+                {
+                    return true;
+                }
+            }
+            return false;
+        }
     }
 
     public enum GraphQLIgnoreType

--- a/src/tests/EntityGraphQL.Tests/MutationTests/MutationMethodParameterTests.cs
+++ b/src/tests/EntityGraphQL.Tests/MutationTests/MutationMethodParameterTests.cs
@@ -1,0 +1,145 @@
+﻿using Xunit;
+using System.Linq;
+using EntityGraphQL.Schema;
+using Microsoft.Extensions.DependencyInjection;
+using System.Reflection;
+using System.Collections.Generic;
+using System;
+
+namespace EntityGraphQL.Tests
+{
+    public class MutationMethodParameterTests
+    {
+        [Fact]
+        public void TestSeparateArguments_PrimitivesOnly()
+        {
+            var schemaProvider = SchemaBuilder.FromObject<TestDataContext>(false);
+            schemaProvider.AddScalarType<DateTime>("DateTime", "");
+            schemaProvider.AddScalarType<decimal>("decimal", "");
+            schemaProvider.AddMutationsFrom(new PeopleMutations(), false);
+            // Add a argument field with a require parameter
+            var gql = new QueryRequest
+            {
+                Query = @"mutation addPersonPrimitive($id: Int, $name: String!, $birthday: DateTime, $weight: decimal, $gender: Gender) {
+                  addPersonPrimitive(id: $id, name: $name, birthday: $birthday, weight: $weight, gender: $gender) { id name }
+                }",
+                Variables = new QueryVariables {
+                    { "id", 3 },
+                    { "name", "Frank" },
+                    { "birthday", DateTime.Today },
+                    { "weight", 45.5 },
+                    { "gender", Gender.Male }
+                }
+            };
+            var res = schemaProvider.ExecuteRequest(gql, new TestDataContext(), null, null);
+            Assert.Null(res.Errors);
+        }
+
+        [Fact]
+        public void TestSeparateArguments_PrimitivesOnly_WithInlineDefaults()
+        {
+            var schemaProvider = SchemaBuilder.FromObject<TestDataContext>(false);
+            schemaProvider.AddScalarType<DateTime>("DateTime", "");
+            schemaProvider.AddScalarType<decimal>("decimal", "");
+            schemaProvider.AddMutationsFrom(new PeopleMutations(), false);
+            // Add a argument field with a require parameter
+            var gql = new QueryRequest
+            {
+                Query = @"mutation addPersonPrimitive($birthday: DateTime, $weight: decimal, $gender: Gender) {
+                  addPersonPrimitive(id: 3, name: """", birthday: $birthday, weight: $weight, gender: $gender) { id name }
+                }",
+                Variables = new QueryVariables {
+                    { "birthday", DateTime.Today },
+                    { "weight", 45.5 },
+                    { "gender", Gender.Male }
+                }
+            };
+            var res = schemaProvider.ExecuteRequest(gql, new TestDataContext(), null, null);
+            Assert.Null(res.Errors);
+        }
+
+        [Fact]
+        public void TestSeparateArguments()
+        {
+            var schemaProvider = SchemaBuilder.FromObject<TestDataContext>(false);
+            schemaProvider.AddInputType<InputObject>("InputObject", "");
+            schemaProvider.AddMutationsFrom(new PeopleMutations(), false);
+            // Add a argument field with a require parameter
+            var gql = new QueryRequest
+            {
+                Query = @"mutation AddPersonSeparateArguments($name: String!, $names: [String!], $nameInput: InputObject, $gender: Gender) {
+                  addPersonSeparateArguments(name: $name, names: $names, nameInput: $nameInput, gender: $gender) { id name }
+                }",
+                Variables = new QueryVariables {
+                    { "name", "Frank" },
+                    { "names", new [] { "Frank" } },
+                    { "nameInput", null },
+                    { "gender", Gender.Female }
+                }
+            };
+            var res = schemaProvider.ExecuteRequest(gql, new TestDataContext(), null, null);
+            Assert.Null(res.Errors);
+        }
+
+        [Fact]
+        public void TestSingleArgument()
+        {
+            var schemaProvider = SchemaBuilder.FromObject<TestDataContext>(false);
+            schemaProvider.AddInputType<InputObject>("InputObject", "");
+            schemaProvider.AddMutationsFrom(new PeopleMutations(), false);
+            // Add a argument field with a require parameter
+            var gql = new QueryRequest
+            {
+                Query = @"mutation AddPersonSingleArgument($nameInput: InputObject) {
+                  addPersonSingleArgument(nameInput: $nameInput) { id name }
+                }",
+                Variables = new QueryVariables {
+                    { "nameInput", new InputObject() { Name = "Frank" } },
+                }
+            };
+            var res = schemaProvider.ExecuteRequest(gql, new TestDataContext(), null, null);
+            Assert.Null(res.Errors);
+        }
+
+        [Fact]
+        public void TestSingleArgument_AutoAddInputTypes()
+        {
+            var schemaProvider = SchemaBuilder.FromObject<TestDataContext>(false);            
+            schemaProvider.AddMutationsFrom(new PeopleMutations(), true);
+            // Add a argument field with a require parameter
+            var gql = new QueryRequest
+            {
+                Query = @"mutation AddPersonSingleArgument($nameInput: InputObject) {
+                  addPersonSingleArgument(nameInput: $nameInput) { id name }
+                }",
+                Variables = new QueryVariables {
+                    { "nameInput", new InputObject() { Name = "Frank" } },
+                }
+            };
+            var res = schemaProvider.ExecuteRequest(gql, new TestDataContext(), null, null);
+            Assert.Null(res.Errors);
+        }
+
+        [Fact]
+        public void TestSeparateArguments_AutoAddInputTypes()
+        {
+            var schemaProvider = SchemaBuilder.FromObject<TestDataContext>(false);
+            schemaProvider.AddMutationsFrom(new PeopleMutations(), true);
+            // Add a argument field with a require parameter
+            var gql = new QueryRequest
+            {
+                Query = @"mutation AddPersonSeparateArguments($name: String!, $names: [String!], $nameInput: InputObject, $gender: Gender) {
+                  addPersonSeparateArguments(name: $name, names: $names, nameInput: $nameInput, gender: $gender) { id name }
+                }",
+                Variables = new QueryVariables {
+                    { "name", "Frank" },
+                    { "names", new [] { "Frank" } },
+                    { "nameInput", null },
+                    { "gender", Gender.Female }
+                }
+            };
+            var res = schemaProvider.ExecuteRequest(gql, new TestDataContext(), null, null);
+            Assert.Null(res.Errors);
+        }
+    }
+}

--- a/src/tests/EntityGraphQL.Tests/MutationTests/MutationMethodParameterTests.cs
+++ b/src/tests/EntityGraphQL.Tests/MutationTests/MutationMethodParameterTests.cs
@@ -16,7 +16,7 @@ namespace EntityGraphQL.Tests
             var schemaProvider = SchemaBuilder.FromObject<TestDataContext>(false);
             schemaProvider.AddScalarType<DateTime>("DateTime", "");
             schemaProvider.AddScalarType<decimal>("decimal", "");
-            schemaProvider.AddMutationsFrom(new PeopleMutations(), false);
+            schemaProvider.AddMutationsFrom<PeopleMutations>(false);
             // Add a argument field with a require parameter
             var gql = new QueryRequest
             {
@@ -41,7 +41,7 @@ namespace EntityGraphQL.Tests
             var schemaProvider = SchemaBuilder.FromObject<TestDataContext>(false);
             schemaProvider.AddScalarType<DateTime>("DateTime", "");
             schemaProvider.AddScalarType<decimal>("decimal", "");
-            schemaProvider.AddMutationsFrom(new PeopleMutations(), false);
+            schemaProvider.AddMutationsFrom<PeopleMutations>(false);
             // Add a argument field with a require parameter
             var gql = new QueryRequest
             {
@@ -63,7 +63,7 @@ namespace EntityGraphQL.Tests
         {
             var schemaProvider = SchemaBuilder.FromObject<TestDataContext>(false);
             schemaProvider.AddInputType<InputObject>("InputObject", "");
-            schemaProvider.AddMutationsFrom(new PeopleMutations(), false);
+            schemaProvider.AddMutationsFrom<PeopleMutations>(false);
             // Add a argument field with a require parameter
             var gql = new QueryRequest
             {
@@ -86,7 +86,7 @@ namespace EntityGraphQL.Tests
         {
             var schemaProvider = SchemaBuilder.FromObject<TestDataContext>(false);
             schemaProvider.AddInputType<InputObject>("InputObject", "");
-            schemaProvider.AddMutationsFrom(new PeopleMutations(), false);
+            schemaProvider.AddMutationsFrom<PeopleMutations>(false);
             // Add a argument field with a require parameter
             var gql = new QueryRequest
             {
@@ -104,8 +104,8 @@ namespace EntityGraphQL.Tests
         [Fact]
         public void TestSingleArgument_AutoAddInputTypes()
         {
-            var schemaProvider = SchemaBuilder.FromObject<TestDataContext>(false);            
-            schemaProvider.AddMutationsFrom(new PeopleMutations(), true);
+            var schemaProvider = SchemaBuilder.FromObject<TestDataContext>(false);
+            schemaProvider.AddMutationsFrom<PeopleMutations>(true);
             // Add a argument field with a require parameter
             var gql = new QueryRequest
             {
@@ -124,7 +124,7 @@ namespace EntityGraphQL.Tests
         public void TestSeparateArguments_AutoAddInputTypes()
         {
             var schemaProvider = SchemaBuilder.FromObject<TestDataContext>(false);
-            schemaProvider.AddMutationsFrom(new PeopleMutations(), true);
+            schemaProvider.AddMutationsFrom<PeopleMutations>(true);
             // Add a argument field with a require parameter
             var gql = new QueryRequest
             {

--- a/src/tests/EntityGraphQL.Tests/MutationTests/MutationTests.cs
+++ b/src/tests/EntityGraphQL.Tests/MutationTests/MutationTests.cs
@@ -33,48 +33,6 @@ namespace EntityGraphQL.Tests
         }
 
         [Fact]
-        public void TestSeparateArguments()
-        {
-            var schemaProvider = SchemaBuilder.FromObject<TestDataContext>(false);
-            schemaProvider.AddMutationsFrom(new PeopleMutations(), true);
-            // Add a argument field with a require parameter
-            var gql = new QueryRequest
-            {
-                Query = @"mutation AddPersonSeparateArguments($name: String!, $names: [String!], $nameInput: InputObject, $gender: Gender) {
-                  addPersonSeparateArguments(name: $name, names: $names, nameInput: $nameInput, gender: $gender) { id name }
-                }",
-                Variables = new QueryVariables { 
-                    { "name", "Frank" },
-                    { "names", new [] { "Frank" } },
-                    { "nameInput", null },
-                    { "gender", Gender.Female }
-                }
-            };
-            var res = schemaProvider.ExecuteRequest(gql, new TestDataContext(), null, null);
-            Assert.Null(res.Errors);
-        }
-
-        [Fact]
-        public void TestSingleArgument()
-        {
-            var schemaProvider = SchemaBuilder.FromObject<TestDataContext>(false);
-            schemaProvider.AddMutationsFrom(new PeopleMutations(), true);
-            // Add a argument field with a require parameter
-            var gql = new QueryRequest
-            {
-                Query = @"mutation AddPersonSingleArgument($nameInput: InputObject) {
-                  addPersonSingleArgument(nameInput: $nameInput) { id name }
-                }",
-                Variables = new QueryVariables {
-                    { "nameInput", new InputObject() { Name = "Frank" } },
-                }
-            };
-            var res = schemaProvider.ExecuteRequest(gql, new TestDataContext(), null, null);
-            Assert.Null(res.Errors);
-        }
-
-
-        [Fact]
         public void SupportsMutationOptional()
         {
             var schemaProvider = SchemaBuilder.FromObject<TestDataContext>(false);

--- a/src/tests/EntityGraphQL.Tests/MutationTests/MutationTests.cs
+++ b/src/tests/EntityGraphQL.Tests/MutationTests/MutationTests.cs
@@ -835,7 +835,7 @@ namespace EntityGraphQL.Tests
             var schemaProvider = SchemaBuilder.FromObject<TestDataContext>(false);
             schemaProvider.Mutation().AddFrom<IMutations>();
         
-            Assert.Equal(22, schemaProvider.Mutation().SchemaType.GetFields().Count());
+            Assert.Equal(23, schemaProvider.Mutation().SchemaType.GetFields().Count());
         }
 
         public class NonAttributeMarkedMethod

--- a/src/tests/EntityGraphQL.Tests/MutationTests/PeopleMutations.cs
+++ b/src/tests/EntityGraphQL.Tests/MutationTests/PeopleMutations.cs
@@ -20,6 +20,20 @@ namespace EntityGraphQL.Tests
 
         [GraphQLMutation]
 
+        public Person AddPersonSeparateArguments(string name, List<string> names, InputObject nameInput, Gender? gender)
+        {
+            return new Person { Name = string.IsNullOrEmpty(name) ? "Default" : name, Id = 555, Projects = new List<Project>() };
+        }
+
+        [GraphQLMutation]
+
+        public Person AddPersonSingleArgument(InputObject nameInput)
+        {
+            return new Person { Name = string.IsNullOrEmpty(nameInput.Name) ? "Default" : nameInput.Name, Id = 555, Projects = new List<Project>() };
+        }
+
+        [GraphQLMutation]
+
         public Expression<Func<TestDataContext, Person>> AddPersonNames(TestDataContext db, PeopleMutationsArgs args)
         {
             var id = 11;

--- a/src/tests/EntityGraphQL.Tests/MutationTests/PeopleMutations.cs
+++ b/src/tests/EntityGraphQL.Tests/MutationTests/PeopleMutations.cs
@@ -27,6 +27,13 @@ namespace EntityGraphQL.Tests
 
         [GraphQLMutation]
 
+        public Person AddPersonPrimitive(int id, string name, DateTime birthday, decimal weight, Gender? gender)
+        {
+            return new Person { Name = string.IsNullOrEmpty(name) ? "Default" : name, Id = 555, Projects = new List<Project>() };
+        }
+
+        [GraphQLMutation]
+
         public Person AddPersonSingleArgument(InputObject nameInput)
         {
             return new Person { Name = string.IsNullOrEmpty(nameInput.Name) ? "Default" : nameInput.Name, Id = 555, Projects = new List<Project>() };


### PR DESCRIPTION
#146

Although I feel like it could have broken something.
```
 [GraphQLMutation]
public Person AddPersonSeparateArguments(string name, List<string> names, InputObject nameInput, Gender? gender)
{
  return new Person { Name = string.IsNullOrEmpty(name) ? "Default" : name, Id = 555, Projects = new List<Project>() };
}
```

becomes
```
addPersonSeparateArguments(name: String, names: [String!], nameInput: InputObject, gender: Gender): Person
```

and

```
[GraphQLMutation]
public Person AddPersonSingleArgument(InputObject nameInput)
{
  return new Person { Name = string.IsNullOrEmpty(nameInput.Name) ? "Default" : nameInput.Name, Id = 555, Projects = new List<Project>() };
}
```

becomes

```
addPersonSingleArgument(nameInput: InputObject): Person
```

both with auto add input types on.
