### PR TITLE
mutation controllers always created per request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Breaking changes:
 - Removed obsolete `ISchemaType.BaseType`. Use `ISchemaType.BaseTypes`
 - Cleaned up `SchemaType` constructors - using `GqlTypeEnum` instead of many boolean flags
 - Removed obsolete `SchemaProvider.AddInheritedType<TBaseType>`
+- Removed the instance parameter from `AddMutationsFrom` and friends. Mutation "controllers" are now always created per request like an asp.net controller. Use DI for any constructor parameters
 
 Changes:
 

--- a/docs/content/schema-creation/01-mutations.md
+++ b/docs/content/schema-creation/01-mutations.md
@@ -46,9 +46,9 @@ You can add the mutation controller to a schema in the following ways:
 schema.AddMutationsFrom<PeopleMutations>();
 ```
 
-EntityGraphQL adds the `PeopleMutations` mutation controller and all its mutation methods (those with `[GraphQLMutation]` applied).
+EntityGraphQL adds the `PeopleMutations` mutation controller and all its mutation methods (those with `[GraphQLMutation]` applied) to the schema.
 
-For each mutation request, EntityGraphQL creates a new instance of `PeopleMuations` and provides services to it through [dependency injection](#dependenciesinjection&services).
+For each mutation request, EntityGraphQL creates a new instance of `PeopleMuations` and provides services to its constructor through [dependency injection](#dependenciesinjection&services).
 
 **Register all mutation controllers implementing or derving from a type**
 
@@ -57,18 +57,6 @@ schema.AddMutationsFrom<IPersonnelMutations>();
 ```
 
 If the type parameter to `AddMutationsFrom` is an interface or base class, EntityGraphQL also adds as mutation controllers all types (in the same assembly) that implement the interface or derive from the base class. In example above, all classes that implement `IPersonnelMutations` would be added to the schema.
-
-**Providing an Instance of the mutation class**
-
-```
-schema.AddMutationsFrom(new PeopleMutations());
-```
-
-EntityGraphQL will find all methods marked as `[GraphQLMutation]` on the PeopleMuations type and add them as mutations.
-
-When calling the mutation it will use the instance of the PeopleMuations you provided.
-
-This method is considered obsolete and will be removed in a future version. We suggest you use one of the above methods and utilse the ServiceProvider to register your mutation classes with your desired lifetime.
 
 **Now we can add people!**
 

--- a/docs/content/schema-creation/01-mutations.md
+++ b/docs/content/schema-creation/01-mutations.md
@@ -48,7 +48,7 @@ schema.AddMutationsFrom<PeopleMutations>();
 
 EntityGraphQL adds the `PeopleMutations` mutation controller and all its mutation methods (those with `[GraphQLMutation]` applied) to the schema.
 
-For each mutation request, EntityGraphQL creates a new instance of `PeopleMuations`, any parameters for the constructor are resolved via the service provider and [dependency injection](#dependenciesinjection&services). DI is also used to inject services into the mutation methods, allowing you to have an empty constructor.
+For each mutation request, EntityGraphQL creates a new instance of `PeopleMuations`. The constructor and mutation methods accept services passed through [dependency injection](#dependenciesinjection&services).
 
 **Register all mutation controllers implementing or derving from a type**
 

--- a/docs/content/schema-creation/01-mutations.md
+++ b/docs/content/schema-creation/01-mutations.md
@@ -48,7 +48,7 @@ schema.AddMutationsFrom<PeopleMutations>();
 
 EntityGraphQL adds the `PeopleMutations` mutation controller and all its mutation methods (those with `[GraphQLMutation]` applied) to the schema.
 
-For each mutation request, EntityGraphQL creates a new instance of `PeopleMuations` and provides services to its constructor through [dependency injection](#dependenciesinjection&services).
+For each mutation request, EntityGraphQL creates a new instance of `PeopleMuations`, any parameters for the constructor are resolved via the service provider and [dependency injection](#dependenciesinjection&services). DI is also used to inject services into the mutation methods, allowing you to have an empty constructor.
 
 **Register all mutation controllers implementing or derving from a type**
 

--- a/docs/content/schema-creation/01-mutations.md
+++ b/docs/content/schema-creation/01-mutations.md
@@ -46,7 +46,7 @@ You can add the mutation controller to a schema in the following ways:
 schema.AddMutationsFrom<PeopleMutations>();
 ```
 
-EntityGraphQL adds the `PeopleMutations` mutation controller and all its mutation methods (those with [GraphQLMutation] applied).
+EntityGraphQL adds the `PeopleMutations` mutation controller and all its mutation methods (those with `[GraphQLMutation]` applied).
 
 For each mutation request, EntityGraphQL creates a new instance of `PeopleMuations` and provides services to it through [dependency injection](#dependenciesinjection&services).
 
@@ -64,7 +64,7 @@ If the type parameter to `AddMutationsFrom` is an interface or base class, Entit
 schema.AddMutationsFrom(new PeopleMutations());
 ```
 
-EntityGraphQL will find all methods marked as [GraphQLMutation] on the PeopleMuations type and add them as mutations.
+EntityGraphQL will find all methods marked as `[GraphQLMutation]` on the PeopleMuations type and add them as mutations.
 
 When calling the mutation it will use the instance of the PeopleMuations you provided.
 
@@ -98,7 +98,7 @@ _Obsolete_
 If true, any class types seen in the mutation argument properties will be added to the schema
 
 **addNonAttributedMethods**
-If true, EntityGraphQL will add any method in the mutation class as a mutation without needing the [GraphQLMutation] attribute. Methods must be **Public** and **not inherited** but can be either **static** or **instance**.
+If true, EntityGraphQL will add any method in the mutation class as a mutation without needing the `[GraphQLMutation]` attribute. Methods must be **Public** and **not inherited** but can be either **static** or **instance**.
 
 # Adding a Mutations as a Delegate
 

--- a/src/EntityGraphQL/EntityGraphQL.csproj
+++ b/src/EntityGraphQL/EntityGraphQL.csproj
@@ -26,6 +26,7 @@
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
     <PackageReference Include="System.Runtime.Caching" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
     <PackageReference Include="HotChocolate.Language" Version="12.7.0" />
   </ItemGroup>
   <ItemGroup>

--- a/src/EntityGraphQL/Schema/ISchemaProvider.cs
+++ b/src/EntityGraphQL/Schema/ISchemaProvider.cs
@@ -27,7 +27,7 @@ namespace EntityGraphQL.Schema
         ISchemaType AddInterface(Type type, string name, string description);
         SchemaType<TBaseType> AddInputType<TBaseType>(string name, string? description);
         ISchemaType AddInputType(Type type, string name, string? description);
-        void AddMutationsFrom<TType>(TType? mutationClassInstance = null, bool autoAddInputTypes = false, bool addNonAttributedMethods = false) where TType : class;
+        void AddMutationsFrom<TType>(bool autoAddInputTypes = false, bool addNonAttributedMethods = false) where TType : class;
         ISchemaType AddScalarType(Type clrType, string gqlTypeName, string? description);
         SchemaType<TType> AddScalarType<TType>(string gqlTypeName, string? description);
         SchemaType<TBaseType> AddType<TBaseType>(string name, string? description);

--- a/src/EntityGraphQL/Schema/MutationField.cs
+++ b/src/EntityGraphQL/Schema/MutationField.cs
@@ -7,21 +7,20 @@ using System.Threading.Tasks;
 using EntityGraphQL.Compiler;
 using EntityGraphQL.Compiler.Util;
 using EntityGraphQL.Extensions;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace EntityGraphQL.Schema
 {
     public class MutationField : BaseField
     {
         public override GraphQLQueryFieldType FieldType { get; } = GraphQLQueryFieldType.Mutation;
-        private readonly object? mutationClassInstance;
         private readonly MethodInfo method;
         private readonly bool isAsync;
 
-        public MutationField(ISchemaProvider schema, string methodName, GqlTypeInfo returnType, object? mutationClassInstance, MethodInfo method, string description, RequiredAuthorization requiredAuth, bool isAsync, Func<string, string> fieldNamer, bool autoAddInputTypes)
+        public MutationField(ISchemaProvider schema, string methodName, GqlTypeInfo returnType, MethodInfo method, string description, RequiredAuthorization requiredAuth, bool isAsync, Func<string, string> fieldNamer, bool autoAddInputTypes)
             : base(schema, methodName, description, returnType)
         {
             Services = new List<Type>();
-            this.mutationClassInstance = mutationClassInstance;
             this.method = method;
             RequiredAuthorization = requiredAuth;
             this.isAsync = isAsync;
@@ -116,20 +115,16 @@ namespace EntityGraphQL.Schema
                 }
             }
 
-            object? instance = mutationClassInstance;
+            object? instance = null;
+            // we create an instance _per request_ injecting any parameters to the constructor
+            // We kind of treat a mutation class like an asp.net controller
+            // and we do not want to register them in the service provider to avoid the same issues controllers would have
+            // with different lifetime objects
             if (instance == null)
             {
-                //try instantiate the mutation class using the service provider
-                if (serviceProvider != null)
-                {
-                    instance = serviceProvider.GetService(method.DeclaringType);
-                }
-
-                //fallback to activator create instance
-                if (instance == null)
-                {
-                    instance = Activator.CreateInstance(method.DeclaringType);
-                }
+                instance = serviceProvider != null ?
+                    ActivatorUtilities.CreateInstance(serviceProvider, method.DeclaringType) :
+                    Activator.CreateInstance(method.DeclaringType);
             }
 
             object? result;

--- a/src/EntityGraphQL/Schema/MutationType.cs
+++ b/src/EntityGraphQL/Schema/MutationType.cs
@@ -23,10 +23,9 @@ public class MutationType
     /// <summary>
     /// Add any public methods (static or not) marked with GraphQLMutationAttribute in the given object to the schema. Method names are added as using fieldNamer
     /// </summary>
-    /// <param name="mutationClassInstance">Instance of a class with mutation methods marked with [GraphQLMutation]</param>
     /// <param name="autoAddInputTypes">If true, any class types seen in the mutation argument properties will be added to the schema</param>
     /// <typeparam name="TType"></typeparam>
-    public MutationType AddFrom<TType>(TType? mutationClassInstance = null, bool autoAddInputTypes = false, bool addNonAttributedMethods = false) where TType : class
+    public MutationType AddFrom<TType>(bool autoAddInputTypes = false, bool addNonAttributedMethods = false) where TType : class
     {
         var types = typeof(TType).Assembly
                             .GetTypes()
@@ -42,7 +41,7 @@ public class MutationType
                 if (attribute != null || addNonAttributedMethods)
                 {
                     string name = SchemaType.Schema.SchemaFieldNamer(method.Name);
-                    AddMutationMethod(name, mutationClassInstance, classLevelRequiredAuth, method, attribute?.Description ?? "", autoAddInputTypes);
+                    AddMutationMethod(name, classLevelRequiredAuth, method, attribute?.Description ?? "", autoAddInputTypes);
                 }
             }
         }
@@ -80,10 +79,10 @@ public class MutationType
     /// <param name="autoAddInputTypes">If true, any class types seen in the mutation argument properties will be added to the schema</param>
     public MutationField Add(string mutationName, string description, Delegate mutationDelegate, bool autoAddInputTypes = false)
     {
-        return AddMutationMethod(mutationName, mutationDelegate.Target, null, mutationDelegate.Method, description, autoAddInputTypes);
+        return AddMutationMethod(mutationName, null, mutationDelegate.Method, description, autoAddInputTypes);
     }
 
-    private MutationField AddMutationMethod<TType>(string name, TType mutationClassInstance, RequiredAuthorization? classLevelRequiredAuth, MethodInfo method, string? description, bool autoAddInputTypes)
+    private MutationField AddMutationMethod(string name, RequiredAuthorization? classLevelRequiredAuth, MethodInfo method, string? description, bool autoAddInputTypes)
     {
         var isAsync = method.GetCustomAttribute(typeof(AsyncStateMachineAttribute)) != null;
         var methodAuth = SchemaType.Schema.AuthorizationService.GetRequiredAuthFromMember(method);
@@ -93,7 +92,7 @@ public class MutationType
         var actualReturnType = GetTypeFromMutationReturn(isAsync ? method.ReturnType.GetGenericArguments()[0] : method.ReturnType);
         var typeName = SchemaType.Schema.GetSchemaType(actualReturnType.GetNonNullableOrEnumerableType(), null).Name;
         var returnType = new GqlTypeInfo(() => SchemaType.Schema.Type(typeName), actualReturnType, method);
-        var mutationField = new MutationField(SchemaType.Schema, name, returnType, mutationClassInstance, method, description ?? string.Empty, requiredClaims, isAsync, SchemaType.Schema.SchemaFieldNamer, autoAddInputTypes);
+        var mutationField = new MutationField(SchemaType.Schema, name, returnType, method, description ?? string.Empty, requiredClaims, isAsync, SchemaType.Schema.SchemaFieldNamer, autoAddInputTypes);
 
         var validators = method.GetCustomAttributes<ArgumentValidatorAttribute>();
         if (validators != null)

--- a/src/EntityGraphQL/Schema/SchemaProvider.cs
+++ b/src/EntityGraphQL/Schema/SchemaProvider.cs
@@ -427,12 +427,11 @@ namespace EntityGraphQL.Schema
         /// Add any methods marked with GraphQLMutationAttribute in the given object to the schema. Method names are added as using fieldNamer
         /// </summary>
         /// <typeparam name="TType"></typeparam>
-        /// <param name="mutationClassInstance">Instance of a class with mutation methods marked with [GraphQLMutation]</param>
         /// <param name="autoAddInputTypes">If true, any class types seen in the mutation argument properties will be added to the schema</param>
         /// <param name="addNonAttributedMethods">If true, add any method in the mutation class even if it isn't marked with the mutation attribute</param>
-        public void AddMutationsFrom<TType>(TType? mutationClassInstance = null, bool autoAddInputTypes = false, bool addNonAttributedMethods = false) where TType : class
+        public void AddMutationsFrom<TType>(bool autoAddInputTypes = false, bool addNonAttributedMethods = false) where TType : class
         {
-            mutationType.AddFrom((TType?)null, autoAddInputTypes, addNonAttributedMethods);
+            mutationType.AddFrom<TType>(autoAddInputTypes, addNonAttributedMethods);
         }
 
         /// <summary>

--- a/src/tests/EntityGraphQL.Tests/ErrorTests.cs
+++ b/src/tests/EntityGraphQL.Tests/ErrorTests.cs
@@ -12,7 +12,7 @@ namespace EntityGraphQL.Tests
         public void MutationReportsError()
         {
             var schemaProvider = SchemaBuilder.FromObject<TestDataContext>(false);
-            schemaProvider.AddMutationsFrom(new PeopleMutations());
+            schemaProvider.AddMutationsFrom<PeopleMutations>();
             // Add a argument field with a require parameter
             var gql = new QueryRequest
             {
@@ -55,7 +55,7 @@ namespace EntityGraphQL.Tests
         public void TestErrorFieldNotIncludedInResponseWhenNoErrors()
         {
             var schemaProvider = SchemaBuilder.FromObject<TestDataContext>(false);
-            schemaProvider.AddMutationsFrom(new PeopleMutations());
+            schemaProvider.AddMutationsFrom<PeopleMutations>();
             var gql = new QueryRequest
             {
                 Query = @"{

--- a/src/tests/EntityGraphQL.Tests/MutationTests/MutationTests.cs
+++ b/src/tests/EntityGraphQL.Tests/MutationTests/MutationTests.cs
@@ -17,7 +17,7 @@ namespace EntityGraphQL.Tests
         public void MissingRequiredVar()
         {
             var schemaProvider = SchemaBuilder.FromObject<TestDataContext>(false);
-            schemaProvider.AddMutationsFrom(new PeopleMutations());
+            schemaProvider.AddMutationsFrom<PeopleMutations>();
             // Add a argument field with a require parameter
             var gql = new QueryRequest
             {
@@ -36,7 +36,7 @@ namespace EntityGraphQL.Tests
         public void SupportsMutationOptional()
         {
             var schemaProvider = SchemaBuilder.FromObject<TestDataContext>(false);
-            schemaProvider.AddMutationsFrom(new PeopleMutations());
+            schemaProvider.AddMutationsFrom<PeopleMutations>();
             // Add a argument field with a require parameter
             var gql = new QueryRequest
             {
@@ -64,7 +64,7 @@ namespace EntityGraphQL.Tests
         public void SupportsMutationArrayArg()
         {
             var schemaProvider = SchemaBuilder.FromObject<TestDataContext>(false);
-            schemaProvider.AddMutationsFrom(new PeopleMutations());
+            schemaProvider.AddMutationsFrom<PeopleMutations>();
             // Add a argument field with a require parameter
             var gql = new QueryRequest
             {
@@ -98,7 +98,7 @@ namespace EntityGraphQL.Tests
             // ctx => ctx.People.First(p => p.Id == myNewPerson.Id)
             // that myNewPerson.Id does not get replace by something dumb like p.Id == p.Id
             var schemaProvider = SchemaBuilder.FromObject<TestDataContext>(false);
-            schemaProvider.AddMutationsFrom(new PeopleMutations());
+            schemaProvider.AddMutationsFrom<PeopleMutations>();
             // Add a argument field with a require parameter
             var query = @"mutation AddPerson($names: [String]) {
   addPersonNamesExpression(names: $names) {
@@ -150,7 +150,7 @@ namespace EntityGraphQL.Tests
         {
             var schemaProvider = SchemaBuilder.FromObject<TestDataContext>(false);
             schemaProvider.AddInputType<InputObject>("InputObject", "Using an object in the arguments");
-            schemaProvider.AddMutationsFrom(new PeopleMutations());
+            schemaProvider.AddMutationsFrom<PeopleMutations>();
             // Add a argument field with a require parameter
             var gql = new QueryRequest
             {
@@ -174,7 +174,7 @@ namespace EntityGraphQL.Tests
         {
             var schemaProvider = SchemaBuilder.FromObject<TestDataContext>(false);
             schemaProvider.AddInputType<InputObject>("InputObject", "Using an object in the arguments");
-            schemaProvider.AddMutationsFrom(new PeopleMutations());
+            schemaProvider.AddMutationsFrom<PeopleMutations>();
             // Add a argument field with a require parameter
             var gql = new QueryRequest
             {
@@ -198,7 +198,7 @@ namespace EntityGraphQL.Tests
         {
             var schemaProvider = SchemaBuilder.FromObject<TestDataContext>(false);
             schemaProvider.AddInputType<InputObject>("InputObject", "Using an object in the arguments");
-            schemaProvider.AddMutationsFrom(new PeopleMutations());
+            schemaProvider.AddMutationsFrom<PeopleMutations>();
             // Add a argument field with a require parameter
             var gql = new QueryRequest
             {
@@ -230,7 +230,7 @@ namespace EntityGraphQL.Tests
         {
             var schemaProvider = SchemaBuilder.FromObject<TestDataContext>(false);
             schemaProvider.AddInputType<InputObject>("InputObject", "Using an object in the arguments");
-            schemaProvider.AddMutationsFrom(new PeopleMutations());
+            schemaProvider.AddMutationsFrom<PeopleMutations>();
             // Add a argument field with a require parameter
             var gql = new QueryRequest
             {
@@ -262,7 +262,7 @@ namespace EntityGraphQL.Tests
         {
             var schemaProvider = SchemaBuilder.FromObject<TestDataContext>(false);
             schemaProvider.AddInputType<InputObject>("InputObject", "Using an object in the arguments");
-            schemaProvider.AddMutationsFrom(new PeopleMutations());
+            schemaProvider.AddMutationsFrom<PeopleMutations>();
             // Add a argument field with a require parameter
             var gql = new QueryRequest
             {
@@ -296,7 +296,7 @@ namespace EntityGraphQL.Tests
         public void SupportsSelectionFromConstant()
         {
             var schemaProvider = SchemaBuilder.FromObject<TestDataContext>(false);
-            schemaProvider.AddMutationsFrom(new PeopleMutations());
+            schemaProvider.AddMutationsFrom<PeopleMutations>();
             // Add a argument field with a require parameter
             var gql = new QueryRequest
             {
@@ -331,7 +331,7 @@ namespace EntityGraphQL.Tests
                 type.AddField("age", "Person's age")
                     .ResolveWithService<AgeService>((p, service) => service.GetAge(p.Birthday));
             });
-            schemaProvider.AddMutationsFrom(new PeopleMutations());
+            schemaProvider.AddMutationsFrom<PeopleMutations>();
             // Add a argument field with a require parameter
             var gql = new QueryRequest
             {
@@ -373,7 +373,7 @@ namespace EntityGraphQL.Tests
                 type.AddField("age", "Person's age")
                     .ResolveWithService<AgeService>((p, service) => service.GetAge(p.Birthday));
             });
-            schemaProvider.AddMutationsFrom(new PeopleMutations());
+            schemaProvider.AddMutationsFrom<PeopleMutations>();
             // Add a argument field with a require parameter
             var gql = new QueryRequest
             {
@@ -409,7 +409,7 @@ namespace EntityGraphQL.Tests
         public void MutationReturnsCollectionConst()
         {
             var schemaProvider = SchemaBuilder.FromObject<TestDataContext>(false);
-            schemaProvider.AddMutationsFrom(new PeopleMutations());
+            schemaProvider.AddMutationsFrom<PeopleMutations>();
             // Add a argument field with a require parameter
             var gql = new QueryRequest
             {
@@ -441,7 +441,7 @@ namespace EntityGraphQL.Tests
         public void TestAsyncMutationNonObjectReturn()
         {
             var schemaProvider = SchemaBuilder.FromObject<TestDataContext>(false);
-            schemaProvider.AddMutationsFrom(new PeopleMutations());
+            schemaProvider.AddMutationsFrom<PeopleMutations>();
             // Add a argument field with a require parameter
             var gql = new QueryRequest
             {
@@ -462,7 +462,7 @@ namespace EntityGraphQL.Tests
         public void TestUnnamedMutationOp()
         {
             var schemaProvider = SchemaBuilder.FromObject<TestDataContext>(false);
-            schemaProvider.AddMutationsFrom(new PeopleMutations());
+            schemaProvider.AddMutationsFrom<PeopleMutations>();
             // Add a argument field with a require parameter
             var gql = new QueryRequest
             {
@@ -483,7 +483,7 @@ namespace EntityGraphQL.Tests
         public void TestRequiredGuid()
         {
             var schemaProvider = SchemaBuilder.FromObject<TestDataContext>(false);
-            schemaProvider.AddMutationsFrom(new PeopleMutations());
+            schemaProvider.AddMutationsFrom<PeopleMutations>();
             // Add a argument field with a require parameter
             var gql = new QueryRequest
             {
@@ -504,7 +504,7 @@ namespace EntityGraphQL.Tests
         public void TestNonNullIsRequired()
         {
             var schemaProvider = SchemaBuilder.FromObject<TestDataContext>(false);
-            schemaProvider.AddMutationsFrom(new PeopleMutations());
+            schemaProvider.AddMutationsFrom<PeopleMutations>();
             // Add a argument field with a require parameter
             var gql = new QueryRequest
             {
@@ -522,7 +522,7 @@ namespace EntityGraphQL.Tests
         public void TestListArgInputType()
         {
             var schemaProvider = SchemaBuilder.FromObject<TestDataContext>(false);
-            schemaProvider.AddMutationsFrom(new PeopleMutations());
+            schemaProvider.AddMutationsFrom<PeopleMutations>();
             schemaProvider.AddInputType<InputObject>("InputObject", "Input data").AddAllFields();
             // Add a argument field with a require parameter
             var gql = new QueryRequest
@@ -543,7 +543,7 @@ namespace EntityGraphQL.Tests
         public void TestListArgInputTypeUsingVariables()
         {
             var schemaProvider = SchemaBuilder.FromObject<TestDataContext>(false);
-            schemaProvider.AddMutationsFrom(new PeopleMutations());
+            schemaProvider.AddMutationsFrom<PeopleMutations>();
             schemaProvider.AddInputType<InputObject>("InputObject", "Input data").AddAllFields();
             // Add a argument field with a require parameter
             var gql = new QueryRequest
@@ -567,7 +567,7 @@ namespace EntityGraphQL.Tests
         TestListIntArgInputType()
         {
             var schemaProvider = SchemaBuilder.FromObject<TestDataContext>(false);
-            schemaProvider.AddMutationsFrom(new PeopleMutations());
+            schemaProvider.AddMutationsFrom<PeopleMutations>();
             schemaProvider.AddInputType<InputObjectId>("InputObjectId", "InputObjectId").AddAllFields();
             // Add a argument field with a require parameter
             var gql = new QueryRequest
@@ -587,7 +587,7 @@ namespace EntityGraphQL.Tests
         public void TestFloatArgInputType()
         {
             var schemaProvider = SchemaBuilder.FromObject<TestDataContext>(false);
-            schemaProvider.AddMutationsFrom(new PeopleMutations());
+            schemaProvider.AddMutationsFrom<PeopleMutations>();
             schemaProvider.AddInputType<FloatInput>("FloatInput", "FloatInput").AddAllFields();
             var gql = new QueryRequest
             {
@@ -606,7 +606,7 @@ namespace EntityGraphQL.Tests
         public void TestDoubleArgInputType()
         {
             var schemaProvider = SchemaBuilder.FromObject<TestDataContext>(false);
-            schemaProvider.AddMutationsFrom(new PeopleMutations());
+            schemaProvider.AddMutationsFrom<PeopleMutations>();
             schemaProvider.AddInputType<DoubleInput>("DoubleInput", "DoubleInput").AddAllFields();
             var gql = new QueryRequest
             {
@@ -625,7 +625,7 @@ namespace EntityGraphQL.Tests
         public void TestDecimalArgInputType()
         {
             var schemaProvider = SchemaBuilder.FromObject<TestDataContext>(false);
-            schemaProvider.AddMutationsFrom(new PeopleMutations());
+            schemaProvider.AddMutationsFrom<PeopleMutations>();
             schemaProvider.AddInputType<DecimalInput>("DecimalInput", "DecimalInput").AddAllFields();
             var gql = new QueryRequest
             {
@@ -644,7 +644,7 @@ namespace EntityGraphQL.Tests
         public void TestComplexReturn()
         {
             var schemaProvider = SchemaBuilder.FromObject<TestDataContext>(false);
-            schemaProvider.AddMutationsFrom(new PeopleMutations());
+            schemaProvider.AddMutationsFrom<PeopleMutations>();
             schemaProvider.AddInputType<DecimalInput>("DecimalInput", "DecimalInput").AddAllFields();
             var gql = new QueryRequest
             {
@@ -702,7 +702,7 @@ namespace EntityGraphQL.Tests
         public void TestNoArgMutationWithService()
         {
             var schemaProvider = SchemaBuilder.FromObject<TestDataContext>(false);
-            schemaProvider.AddMutationsFrom(new PeopleMutations());
+            schemaProvider.AddMutationsFrom<PeopleMutations>();
             // Add a argument field with a require parameter
             var gql = new QueryRequest
             {
@@ -725,7 +725,7 @@ namespace EntityGraphQL.Tests
         public void TestNullableGuid()
         {
             var schemaProvider = SchemaBuilder.FromObject<TestDataContext>(false);
-            schemaProvider.AddMutationsFrom(new PeopleMutations());
+            schemaProvider.AddMutationsFrom<PeopleMutations>();
             var gql = new QueryRequest
             {
                 Query = @"mutation Mute($id: ID, $int: Int, $float: Float, $double: Float, $bool: Boolean, $enum: Gender) {
@@ -754,7 +754,7 @@ namespace EntityGraphQL.Tests
         public void TestNullableGuidEmptyString()
         {
             var schemaProvider = SchemaBuilder.FromObject<TestDataContext>(false);
-            schemaProvider.AddMutationsFrom(new PeopleMutations());
+            schemaProvider.AddMutationsFrom<PeopleMutations>();
             var gql = new QueryRequest
             {
                 Query = @"mutation Mute($id: ID) {
@@ -777,7 +777,7 @@ namespace EntityGraphQL.Tests
         public void TestListGuidTypeUsingVariables()
         {
             var schemaProvider = SchemaBuilder.FromObject<TestDataContext>(false);
-            schemaProvider.AddMutationsFrom(new PeopleMutations());
+            schemaProvider.AddMutationsFrom<PeopleMutations>();
             // Add a argument field with a require parameter
             var gql = new QueryRequest
             {
@@ -800,7 +800,7 @@ namespace EntityGraphQL.Tests
         public void TestListGuidTypeUsingVariablesRequired()
         {
             var schemaProvider = SchemaBuilder.FromObject<TestDataContext>(false);
-            schemaProvider.AddMutationsFrom(new PeopleMutations());
+            schemaProvider.AddMutationsFrom<PeopleMutations>();
             // Add a argument field with a require parameter
             var gql = new QueryRequest
             {
@@ -829,7 +829,7 @@ namespace EntityGraphQL.Tests
         {
             var schemaProvider = SchemaBuilder.FromObject<TestDataContext>(false);
             schemaProvider.Mutation().AddFrom<IMutations>();
-        
+
 
             Assert.Equal(20, schemaProvider.Mutation().SchemaType.GetFields().Count());
         }
@@ -879,26 +879,6 @@ namespace EntityGraphQL.Tests
         }
 
         [Fact]
-        public void TestRightValueReturnedFromAlreadyInstantiatedMutationClass()
-        {
-            var schemaProvider = SchemaBuilder.FromObject<TestDataContext>(false);
-            schemaProvider.Mutation().AddFrom(new MutationClassInstantiationTest(1), addNonAttributedMethods: true);
-
-
-            var gql = new QueryRequest
-            {
-                Query = @"mutation getValue() {
-                    getValue()
-                }"
-            };
-
-            var testSchema = new TestDataContext();
-            var results = schemaProvider.ExecuteRequest(gql, testSchema, null, null);
-            Assert.Null(results.Errors);            
-            Assert.Equal(1, results.Data["getValue"]);
-        }
-
-        [Fact]
         public void TestRightValueReturnedFromActivatorCreateMutationClass()
         {
             var schemaProvider = SchemaBuilder.FromObject<TestDataContext>(false);
@@ -939,6 +919,6 @@ namespace EntityGraphQL.Tests
             Assert.Equal(2, results.Data["getValue"]);
         }
 
-       
+
     }
 }

--- a/src/tests/EntityGraphQL.Tests/MutationTests/MutationTests.cs
+++ b/src/tests/EntityGraphQL.Tests/MutationTests/MutationTests.cs
@@ -896,29 +896,5 @@ namespace EntityGraphQL.Tests
             Assert.Null(results.Errors);
             Assert.Equal(0, results.Data["getValue"]);
         }
-
-        [Fact]
-        public void TestRightValueReturnedFromServiceProviderMutationClass()
-        {
-            var schemaProvider = SchemaBuilder.FromObject<TestDataContext>(false);
-            schemaProvider.Mutation().AddFrom<MutationClassInstantiationTest>(addNonAttributedMethods: true);
-
-            var gql = new QueryRequest
-            {
-                Query = @"mutation getValue() {
-                    getValue()
-                }"
-            };
-
-            var serviceCollection = new ServiceCollection();
-            serviceCollection.AddSingleton(new MutationClassInstantiationTest(2));
-
-            var testSchema = new TestDataContext();
-            var results = schemaProvider.ExecuteRequest(gql, testSchema, serviceCollection.BuildServiceProvider(), null);
-            Assert.Null(results.Errors);
-            Assert.Equal(2, results.Data["getValue"]);
-        }
-
-
     }
 }

--- a/src/tests/EntityGraphQL.Tests/QueryTests/VariableTests.cs
+++ b/src/tests/EntityGraphQL.Tests/QueryTests/VariableTests.cs
@@ -95,7 +95,7 @@ namespace EntityGraphQL.Tests
         public void QueryVariableDefinitionRequiredBySchemaItIsNotRequired()
         {
             var schemaProvider = SchemaBuilder.FromObject<TestDataContext>(false);
-            schemaProvider.AddMutationsFrom(new PeopleMutations());
+            schemaProvider.AddMutationsFrom<PeopleMutations>();
             var gql = new QueryRequest
             {
                 Query = @"mutation Mute($id: ID!) { # required here but not in the actual schema

--- a/src/tests/EntityGraphQL.Tests/SchemaTests/GraphQLSchemaGenerateTests.cs
+++ b/src/tests/EntityGraphQL.Tests/SchemaTests/GraphQLSchemaGenerateTests.cs
@@ -43,7 +43,8 @@ namespace EntityGraphQL.Tests
         public void TestIgnoreInputFails()
         {
             var schemaProvider = SchemaBuilder.FromObject<IgnoreTestSchema>(false);
-            schemaProvider.AddMutationsFrom(new IgnoreTestMutations());
+            schemaProvider.
+            AddMutationsFrom<IgnoreTestMutations>();
             // Add a argument field with a require parameter
             var gql = new QueryRequest
             {
@@ -66,7 +67,7 @@ namespace EntityGraphQL.Tests
         public void TestIgnoreInputPasses()
         {
             var schemaProvider = SchemaBuilder.FromObject<IgnoreTestSchema>(false);
-            schemaProvider.AddMutationsFrom(new IgnoreTestMutations());
+            schemaProvider.AddMutationsFrom<IgnoreTestMutations>();
             // Add a argument field with a require parameter
             var gql = new QueryRequest
             {
@@ -91,7 +92,7 @@ namespace EntityGraphQL.Tests
         public void TestIgnoreAllInInput()
         {
             var schemaProvider = SchemaBuilder.FromObject<IgnoreTestSchema>(false);
-            schemaProvider.AddMutationsFrom(new IgnoreTestMutations());
+            schemaProvider.AddMutationsFrom<IgnoreTestMutations>();
             // Add a argument field with a require parameter
             var gql = new QueryRequest
             {
@@ -133,7 +134,7 @@ namespace EntityGraphQL.Tests
         public void TestIgnoreWithSchema()
         {
             var schemaProvider = SchemaBuilder.FromObject<IgnoreTestSchema>(false);
-            schemaProvider.AddMutationsFrom(new IgnoreTestMutations());
+            schemaProvider.AddMutationsFrom<IgnoreTestMutations>();
             schemaProvider.Type<Album>().RemoveField("old");
             var schema = schemaProvider.ToGraphQLSchemaString();
             Assert.DoesNotContain("hiddenField", schema);
@@ -152,7 +153,7 @@ namespace EntityGraphQL.Tests
         public void TestMutationWithListReturnType()
         {
             var schemaProvider = SchemaBuilder.FromObject<IgnoreTestSchema>();
-            schemaProvider.AddMutationsFrom(new IgnoreTestMutations());
+            schemaProvider.AddMutationsFrom<IgnoreTestMutations>();
             var schema = schemaProvider.ToGraphQLSchemaString();
             Assert.Contains("addAlbum2(name: String!, genre: Genre!): [Album!]", schema);
         }
@@ -162,7 +163,7 @@ namespace EntityGraphQL.Tests
         {
             var schemaProvider = SchemaBuilder.FromObject<IgnoreTestSchema>(false);
             schemaProvider.Type<Album>().RemoveField("old");
-            schemaProvider.AddMutationsFrom(new IgnoreTestMutations());
+            schemaProvider.AddMutationsFrom<IgnoreTestMutations>();
             var schema = schemaProvider.ToGraphQLSchemaString();
             // this exists as it is not null
             Assert.Contains(@"type Album {
@@ -189,7 +190,7 @@ namespace EntityGraphQL.Tests
         public void TestNotNullArgs()
         {
             var schemaProvider = SchemaBuilder.FromObject<IgnoreTestSchema>(false);
-            schemaProvider.AddMutationsFrom(new IgnoreTestMutations());
+            schemaProvider.AddMutationsFrom<IgnoreTestMutations>();
             var schema = schemaProvider.ToGraphQLSchemaString();
             // this exists as it is not null
             Assert.Contains("addAlbum(name: String!, genre: Genre!): Album", schema);
@@ -199,7 +200,7 @@ namespace EntityGraphQL.Tests
         public void TestNotNullEnumerableElementByDefault()
         {
             var schemaProvider = SchemaBuilder.FromObject<IgnoreTestSchema>(false);
-            schemaProvider.AddMutationsFrom(new IgnoreTestMutations());
+            schemaProvider.AddMutationsFrom<IgnoreTestMutations>();
             var schema = schemaProvider.ToGraphQLSchemaString();
             // this exists as it is not null
             Assert.Contains("albums: [Album!]", schema);
@@ -208,7 +209,7 @@ namespace EntityGraphQL.Tests
         public void TestNullEnumerableElement()
         {
             var schemaProvider = SchemaBuilder.FromObject<IgnoreTestSchema>(false);
-            schemaProvider.AddMutationsFrom(new IgnoreTestMutations());
+            schemaProvider.AddMutationsFrom<IgnoreTestMutations>();
             var schema = schemaProvider.ToGraphQLSchemaString();
             // this exists as it is not null
             Assert.Contains("nullAlbums: [Album]", schema);
@@ -226,7 +227,7 @@ namespace EntityGraphQL.Tests
         public void TestDeprecatedMutationField()
         {
             var schemaProvider = SchemaBuilder.FromObject<IgnoreTestSchema>(false);
-            schemaProvider.AddMutationsFrom(new IgnoreTestMutations());
+            schemaProvider.AddMutationsFrom<IgnoreTestMutations>();
             var schema = schemaProvider.ToGraphQLSchemaString();
             // this exists as it is not null
             Assert.Contains("addAlbumOld(name: String!, genre: Genre!): Album @deprecated(reason: \"This is obsolete\")", schema);
@@ -244,7 +245,7 @@ namespace EntityGraphQL.Tests
         public void TestNullableRefTypeMutationField()
         {
             var schemaProvider = SchemaBuilder.FromObject<IgnoreTestSchema>(false);
-            schemaProvider.AddMutationsFrom(new NullableRefTypeMutations());
+            schemaProvider.AddMutationsFrom<NullableRefTypeMutations>();
             var schema = schemaProvider.ToGraphQLSchemaString();
             // this exists as it is not null
             Assert.Contains("addAlbum(name: String!, genre: Genre!): Album", schema);

--- a/src/tests/EntityGraphQL.Tests/SerializationTests.cs
+++ b/src/tests/EntityGraphQL.Tests/SerializationTests.cs
@@ -21,7 +21,7 @@ namespace EntityGraphQL.AspNet.Tests
         {
             var schemaProvider = SchemaBuilder.FromObject<TestDataContext>(false);
             schemaProvider.AddInputType<InputObject>("InputObject", "Using an object in the arguments");
-            schemaProvider.AddMutationsFrom(new PeopleMutations());
+            schemaProvider.AddMutationsFrom<PeopleMutations>();
             schemaProvider.AddCustomTypeConverter(new JObjectTypeConverter());
             schemaProvider.AddCustomTypeConverter(new JTokenTypeConverter());
             // Simulate a JSON request with JSON.NET
@@ -55,7 +55,7 @@ namespace EntityGraphQL.AspNet.Tests
         {
             // test that even though we don't know about JArray they are IEnumerable and can easily be handled
             var schemaProvider = SchemaBuilder.FromObject<TestDataContext>(false);
-            schemaProvider.AddMutationsFrom(new PeopleMutations());
+            schemaProvider.AddMutationsFrom<PeopleMutations>();
             schemaProvider.AddCustomTypeConverter(new JObjectTypeConverter());
             schemaProvider.AddCustomTypeConverter(new JTokenTypeConverter());
 
@@ -80,7 +80,7 @@ namespace EntityGraphQL.AspNet.Tests
         {
             // test that even though we don't know about JArray they are IEnumerable and can easily be handled
             var schemaProvider = SchemaBuilder.FromObject<TestDataContext>(false);
-            schemaProvider.AddMutationsFrom(new PeopleMutations());
+            schemaProvider.AddMutationsFrom<PeopleMutations>();
             schemaProvider.AddCustomTypeConverter(new JObjectTypeConverter());
             schemaProvider.AddCustomTypeConverter(new JTokenTypeConverter());
 
@@ -104,7 +104,7 @@ namespace EntityGraphQL.AspNet.Tests
         public void JsonNewtonsoftJValue()
         {
             var schemaProvider = SchemaBuilder.FromObject<TestDataContext>();
-            schemaProvider.AddMutationsFrom(new PeopleMutations());
+            schemaProvider.AddMutationsFrom<PeopleMutations>();
             schemaProvider.AddCustomTypeConverter(new JObjectTypeConverter());
             schemaProvider.AddCustomTypeConverter(new JTokenTypeConverter());
             schemaProvider.AddCustomTypeConverter(new JValueTypeConverter());
@@ -130,7 +130,7 @@ namespace EntityGraphQL.AspNet.Tests
         {
             var schemaProvider = SchemaBuilder.FromObject<TestDataContext>(false);
             schemaProvider.AddInputType<InputObject>("InputObject", "Using an object in the arguments");
-            schemaProvider.AddMutationsFrom(new PeopleMutations());
+            schemaProvider.AddMutationsFrom<PeopleMutations>();
             // Simulate a JSON request with System.Text.Json
             // variables will end up having JsonElements
             var q = @"{

--- a/src/tests/EntityGraphQL.Tests/ValidationTests.cs
+++ b/src/tests/EntityGraphQL.Tests/ValidationTests.cs
@@ -14,7 +14,7 @@ public class ValidationTests
     public void TestValidationAttributesOnMutationArgs()
     {
         var schema = SchemaBuilder.FromObject<ValidationTestsContext>();
-        schema.AddMutationsFrom(new ValidationTestsMutations());
+        schema.AddMutationsFrom<ValidationTestsMutations>();
         var gql = new QueryRequest
         {
             Query = @"mutation Mutate {


### PR DESCRIPTION
Instead of looking a mutation controller up in the service provider which can lead to mis-matched lifetimes of services. Always create a mutation controller per request (using DI for constructor) like asp.net controllers.