### PR TITLE
SchemaBuilder options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ Breaking changes:
 - Renamed `ISchemaType.AddBaseType` to `ISchemaType.Implements` to align with GraphQL language
   - `ISchemaType.Implements` will throw an exception if you try to implement a non-interface
 - Renamed `ISchemaType.AddAllBaseTypes` to `ISchemaType.ImplementAllBaseTypes` to align with GraphQL language
+- `Create` & `FromObject` on `SchemaBuilder` now take option classes to configure the create of the schema through reflection
+  - `ISchemaType.AddAllFields` also takes the option class to configure it's behaviour
+  - `ISchemaType.AddAllFields` default behaviour now auto adds any complex types found really reflection the properties & fields and will add those to the schema
 
 Changes:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Breaking changes:
 - `Create` & `FromObject` on `SchemaBuilder` now take option classes to configure the create of the schema through reflection
   - `ISchemaType.AddAllFields` also takes the option class to configure it's behaviour
   - `ISchemaType.AddAllFields` default behaviour now auto adds any complex types found really reflection the properties & fields and will add those to the schema
+- Added new option when building a schema with `SchemaBuilder.FromObject` - `AutoCreateInterfaceTypes`. Defaults to `false`. If `true` any abstract classes or interfaces on types reflected with be added as Interfaces in the schema. This is useful if you expose lists of entities on a base/interface type.
 
 Changes:
 

--- a/docs/content/schema-creation.md
+++ b/docs/content/schema-creation.md
@@ -124,13 +124,18 @@ Type Person {
 
 ```
 schema.AddType<Person>("Person", "All about the project")
-    .AddAllFields(
-        autoCreateNewComplexTypes: false,
-        autoCreateEnumTypes: true
-    );
+    .AddAllFields();
 ```
 
-- `autoCreateNewComplexTypes` - If there is a field that returns another custom .NET type this will create a whole new GraphQL type for it
+- `options` - you can configure how `AddAllFields` works with the properties of `SchemaBuilderOptions`
+
+```
+schema.AddType<Person>("Person", "All about the project")
+    .AddAllFields(new SchemaBuilderOptions
+    {
+        AutoCreateNewComplexTypes = false, // do not add custom dotnet types found as property/field types to the schema. Only add scalar type fields
+    });
+```
 
 ## Modifying the generated schema
 

--- a/src/EntityGraphQL.AspNet/Extensions/AddGraphQLOptions.cs
+++ b/src/EntityGraphQL.AspNet/Extensions/AddGraphQLOptions.cs
@@ -3,19 +3,10 @@ using EntityGraphQL.Schema;
 
 namespace EntityGraphQL.AspNet
 {
-    public class AddGraphQLOptions<TSchemaContext>
+    public class AddGraphQLOptions<TSchemaContext> : SchemaBuilderOptions
     {
         /// <summary>
-        /// If true the schema builder will automatically create a singular field for any collection fields whose type has an Id field. 
-        /// E.g. a people field will add a person(id) field.
-        /// </summary>
-        public bool AutoCreateIdArguments { get; set; } = true;
-        /// <summary>
-        /// If true the schema builder will automatically create any Enum types found in the context object graph.
-        /// </summary>
-        public bool AutoCreateEnumTypes { get; set; } = true;
-        /// <summary>
-        /// If true the schema will be built via reflection on the context type.
+        /// If true the schema will be built via reflection on the context type. You can customise this with the properties inherited from SchemaBuilderOptions
         /// If false the schema will be created with the TSchemaContext as it's context but will be empty of fields/types. 
         /// You can fully populate it in the ConfigureSchema callback
         /// </summary>
@@ -23,7 +14,7 @@ namespace EntityGraphQL.AspNet
         /// <summary>
         /// Overwrite the default field naming convention. (Default is lowerCaseFields)
         /// </summary>
-        public Func<string, string> FieldNamer { get; set; } = SchemaBuilder.DefaultNamer;
+        public Func<string, string> FieldNamer { get; set; } = SchemaBuilderSchemaOptions.DefaultFieldNamer;
         /// <summary>
         /// Called after the schema object is created but before the context is reflected into it. Use for set up of type mappings or 
         /// anything that may be needed for the schema to be built correctly.

--- a/src/EntityGraphQL.AspNet/Extensions/EntityGraphQLAspNetServiceCollectionExtensions.cs
+++ b/src/EntityGraphQL.AspNet/Extensions/EntityGraphQLAspNetServiceCollectionExtensions.cs
@@ -44,7 +44,7 @@ namespace EntityGraphQL.AspNet
             var schema = new SchemaProvider<TSchemaContext>(new PolicyOrRoleBasedAuthorization(authService), options.FieldNamer);
             options.PreBuildSchemaFromContext?.Invoke(schema);
             if (options.AutoBuildSchemaFromContext)
-                schema.PopulateFromContext(options.AutoCreateIdArguments, options.AutoCreateEnumTypes);
+                schema.PopulateFromContext(options);
             options.ConfigureSchema?.Invoke(schema);
             serviceCollection.AddSingleton(schema);
 

--- a/src/EntityGraphQL/Schema/BaseSchemaTypeWithFields.cs
+++ b/src/EntityGraphQL/Schema/BaseSchemaTypeWithFields.cs
@@ -82,7 +82,7 @@ namespace EntityGraphQL.Schema
 
             return false;
         }
-        public abstract ISchemaType AddAllFields(bool autoCreateNewComplexTypes = false, bool autoCreateEnumTypes = true);
+        public abstract ISchemaType AddAllFields(SchemaBuilderOptions? options = null);
 
         public void AddFields(IEnumerable<IField> fields)
         {

--- a/src/EntityGraphQL/Schema/ISchemaProvider.cs
+++ b/src/EntityGraphQL/Schema/ISchemaProvider.cs
@@ -45,7 +45,7 @@ namespace EntityGraphQL.Schema
         ISchemaType GetSchemaType(Type dotnetType, QueryRequestContext? requestContext);
         bool HasType(string typeName);
         bool HasType(Type type);
-        void PopulateFromContext(bool autoCreateIdArguments, bool autoCreateEnumTypes);
+        void PopulateFromContext(SchemaBuilderOptions? options = null);
         ISchemaProvider RemoveType<TType>();
         ISchemaProvider RemoveType(string schemaType);
         void RemoveTypeAndAllFields<TSchemaType>();

--- a/src/EntityGraphQL/Schema/ISchemaType.cs
+++ b/src/EntityGraphQL/Schema/ISchemaType.cs
@@ -43,7 +43,7 @@ namespace EntityGraphQL.Schema
         IField GetField(string identifier, QueryRequestContext? requestContext);
         IEnumerable<IField> GetFields();
         bool HasField(string identifier, QueryRequestContext? requestContext);
-        ISchemaType AddAllFields(bool autoCreateNewComplexTypes = false, bool autoCreateEnumTypes = true);
+        ISchemaType AddAllFields(SchemaBuilderOptions? options = null);
         void AddFields(IEnumerable<IField> fields);
         IField AddField(IField field);
         void RemoveField(string name);

--- a/src/EntityGraphQL/Schema/MutationField.cs
+++ b/src/EntityGraphQL/Schema/MutationField.cs
@@ -51,7 +51,7 @@ namespace EntityGraphQL.Schema
         {
             var inputType = propType.GetEnumerableOrArrayType() ?? propType;
             if (autoAddInputTypes && !schema.HasType(inputType))
-                schema.AddInputType(inputType, inputType.Name, null).AddAllFields(true);
+                schema.AddInputType(inputType, inputType.Name, null).AddAllFields();
         }
 
         public void Deprecate(string reason)

--- a/src/EntityGraphQL/Schema/MutationType.cs
+++ b/src/EntityGraphQL/Schema/MutationType.cs
@@ -144,7 +144,7 @@ public class MutationSchemaType : BaseSchemaTypeWithFields<MutationField>
         GqlType = GqlTypeEnum.Mutation;
     }
 
-    public override ISchemaType AddAllFields(bool autoCreateNewComplexTypes = false, bool autoCreateEnumTypes = true)
+    public override ISchemaType AddAllFields(SchemaBuilderOptions? options = null)
     {
         return this;
     }

--- a/src/EntityGraphQL/Schema/SchemaBuilder.cs
+++ b/src/EntityGraphQL/Schema/SchemaBuilder.cs
@@ -13,21 +13,37 @@ using EntityGraphQL.Schema.FieldExtensions;
 
 namespace EntityGraphQL.Schema
 {
+    /// <summary>
+    /// Options used by the SchemaBuilder factory with creating the SchemaProvider
+    /// </summary>
     public class SchemaBuilderSchemaOptions
     {
         public static readonly Func<string, string> DefaultFieldNamer = name =>
         {
             return name[..1].ToLowerInvariant() + name[1..];
         };
-
+        /// <summary>
+        /// Function to name fields when reading the properties from reflection. Default is camelCase
+        /// </summary>
         public Func<string, string> FieldNamer { get; set; } = DefaultFieldNamer;
+        /// <summary>
+        /// If true (default) schema introspection will be enabled for the schema
+        /// </summary>
         public bool IntrospectionEnabled { get; set; } = true;
-
+        /// <summary>
+        /// 
+        /// </summary>
         public IGqlAuthorizationService AuthorizationService { get; set; } = new RoleBasedAuthorization();
     }
 
+    /// <summary>
+    /// Options used by SchemaBuilder when reflection the object graph to auto create schema types & fields
+    /// </summary>
     public class SchemaBuilderOptions
     {
+        /// <summary>
+        /// List properties or field names to ignore. Default includes a list of EF properties
+        /// </summary>
         public HashSet<string> IgnoreProps { get; set; } = new()
         {
             "Database",
@@ -35,14 +51,31 @@ namespace EntityGraphQL.Schema
             "ChangeTracker",
             "ContextId"
         };
-
+        /// <summary>
+        /// List of dotnet type names to ignore when adding types to the schema
+        /// </summary>
         public HashSet<string> IgnoreTypes { get; set; } = new()
         {
             "String",
             "Byte[]"
         };
-        public bool AutoCreateIdArguments { get; set; } = true;
+        /// <summary>
+        /// If true when SchemaBuilder encounters a field that returns a list of entities and the entity has a property 
+        /// or field name Id t will also create a schema field with a singular name and an argument of id for that entity.
+        /// e.g. if it sees IEnumerable<Person> People; It will create the schema fields
+        /// {
+        ///   people: [Person]
+        ///   person(id: ID!): Person
+        /// }
+        /// </summary>
+        public bool AutoCreateFieldWithIdArguments { get; set; } = true;
+        /// <summary>
+        /// If true (default) and an enum type is encountered during reflection of the object graph it will be added to the schema as an Enum
+        /// </summary>
         public bool AutoCreateEnumTypes { get; set; } = true;
+        /// <summary>
+        /// If true (default) and an object type is encountered during reflection of the object graph it will be added to the schema as a Type including it's fields
+        /// </summary>
         public bool AutoCreateNewComplexTypes { get; set; } = true;
     }
 
@@ -216,7 +249,7 @@ namespace EntityGraphQL.Schema
             var returnTypeInfo = schema.GetCustomTypeMapping(le.ReturnType) ?? new GqlTypeInfo(() => schema.GetSchemaType(baseReturnType, null), le.Body.Type, prop);
             var field = new Field(schema, schema.SchemaFieldNamer(prop.Name), le, description, returnTypeInfo, requiredClaims);
 
-            if (options.AutoCreateIdArguments)
+            if (options.AutoCreateFieldWithIdArguments)
             {
                 // add non-pural field with argument of ID
                 var idArgField = AddFieldWithIdArgumentIfExists(schema, prop.ReflectedType, field);

--- a/src/EntityGraphQL/Schema/SchemaBuilder.cs
+++ b/src/EntityGraphQL/Schema/SchemaBuilder.cs
@@ -14,72 +14,6 @@ using EntityGraphQL.Schema.FieldExtensions;
 namespace EntityGraphQL.Schema
 {
     /// <summary>
-    /// Options used by the SchemaBuilder factory with creating the SchemaProvider
-    /// </summary>
-    public class SchemaBuilderSchemaOptions
-    {
-        public static readonly Func<string, string> DefaultFieldNamer = name =>
-        {
-            return name[..1].ToLowerInvariant() + name[1..];
-        };
-        /// <summary>
-        /// Function to name fields when reading the properties from reflection. Default is camelCase
-        /// </summary>
-        public Func<string, string> FieldNamer { get; set; } = DefaultFieldNamer;
-        /// <summary>
-        /// If true (default) schema introspection will be enabled for the schema
-        /// </summary>
-        public bool IntrospectionEnabled { get; set; } = true;
-        /// <summary>
-        /// 
-        /// </summary>
-        public IGqlAuthorizationService AuthorizationService { get; set; } = new RoleBasedAuthorization();
-    }
-
-    /// <summary>
-    /// Options used by SchemaBuilder when reflection the object graph to auto create schema types & fields
-    /// </summary>
-    public class SchemaBuilderOptions
-    {
-        /// <summary>
-        /// List properties or field names to ignore. Default includes a list of EF properties
-        /// </summary>
-        public HashSet<string> IgnoreProps { get; set; } = new()
-        {
-            "Database",
-            "Model",
-            "ChangeTracker",
-            "ContextId"
-        };
-        /// <summary>
-        /// List of dotnet type names to ignore when adding types to the schema
-        /// </summary>
-        public HashSet<string> IgnoreTypes { get; set; } = new()
-        {
-            "String",
-            "Byte[]"
-        };
-        /// <summary>
-        /// If true when SchemaBuilder encounters a field that returns a list of entities and the entity has a property 
-        /// or field name Id t will also create a schema field with a singular name and an argument of id for that entity.
-        /// e.g. if it sees IEnumerable<Person> People; It will create the schema fields
-        /// {
-        ///   people: [Person]
-        ///   person(id: ID!): Person
-        /// }
-        /// </summary>
-        public bool AutoCreateFieldWithIdArguments { get; set; } = true;
-        /// <summary>
-        /// If true (default) and an enum type is encountered during reflection of the object graph it will be added to the schema as an Enum
-        /// </summary>
-        public bool AutoCreateEnumTypes { get; set; } = true;
-        /// <summary>
-        /// If true (default) and an object type is encountered during reflection of the object graph it will be added to the schema as a Type including it's fields
-        /// </summary>
-        public bool AutoCreateNewComplexTypes { get; set; } = true;
-    }
-
-    /// <summary>
     /// A simple schema provider to automatically create a query schema based on an object.
     /// Commonly used with a DbContext.
     /// </summary>
@@ -103,12 +37,29 @@ namespace EntityGraphQL.Schema
         /// <summary>
         /// Given the type TContextType recursively create a query schema based on the public properties of the object.
         /// </summary>
+        /// <param name="buildOptions">SchemaBuilderOptions to use to create the SchemaProvider and configure the rules for auto creating the schema types and fields</param>
+        /// <param name="logger">A logger to use in the schema</param>
+        /// <typeparam name="TContextType"></typeparam>
+        /// <returns></returns>
+        public static SchemaProvider<TContextType> FromObject<TContextType>(SchemaBuilderOptions? buildOptions = null, ILogger<SchemaProvider<TContextType>>? logger = null)
+        {
+            if (buildOptions == null)
+                buildOptions = new SchemaBuilderOptions();
+            var schemaOptions = new SchemaBuilderSchemaOptions();
+
+            var schema = new SchemaProvider<TContextType>(schemaOptions.AuthorizationService, schemaOptions.FieldNamer, logger, schemaOptions.IntrospectionEnabled);
+            return FromObject(schema, buildOptions);
+        }
+
+        /// <summary>
+        /// Given the type TContextType recursively create a query schema based on the public properties of the object.
+        /// </summary>
         /// <param name="schemaOptions">Options to create the SchemaProvider.</param>
         /// <param name="buildOptions">SchemaBuilderOptions to use to create the SchemaProvider and configure the rules for auto creating the schema types and fields</param>
         /// <param name="logger">A logger to use in the schema</param>
         /// <typeparam name="TContextType"></typeparam>
         /// <returns></returns>
-        public static SchemaProvider<TContextType> FromObject<TContextType>(SchemaBuilderSchemaOptions? schemaOptions = null, SchemaBuilderOptions? buildOptions = null, ILogger<SchemaProvider<TContextType>>? logger = null)
+        public static SchemaProvider<TContextType> FromObject<TContextType>(SchemaBuilderSchemaOptions? schemaOptions, SchemaBuilderOptions? buildOptions = null, ILogger<SchemaProvider<TContextType>>? logger = null)
         {
             if (buildOptions == null)
                 buildOptions = new SchemaBuilderOptions();
@@ -283,7 +234,7 @@ namespace EntityGraphQL.Schema
                     description = d.Description;
                 }
 
-                if (options.AutoCreateNewComplexTypes && (typeInfo.IsClass || typeInfo.IsInterface))
+                if ((options.AutoCreateNewComplexTypes && typeInfo.IsClass) || ((typeInfo.IsInterface || typeInfo.IsAbstract) && options.AutoCreateInterfaceTypes))
                 {
                     // add type before we recurse more that may also add the type
                     // dynamcially call generic method
@@ -301,6 +252,11 @@ namespace EntityGraphQL.Schema
 
                     var fields = GetFieldsFromObject(propType, schema, options, isInputType);
                     typeAdded.AddFields(fields);
+
+                    if (options.AutoCreateInterfaceTypes)
+                    {
+                        typeAdded.ImplementAllBaseTypes(true, true);
+                    }
                 }
                 else if (options.AutoCreateEnumTypes && typeInfo.IsEnum && !schema.HasType(propType.Name))
                 {
@@ -310,6 +266,14 @@ namespace EntityGraphQL.Schema
                 {
                     Type type = Nullable.GetUnderlyingType(propType)!;
                     schema.AddEnum(type.Name, type, description);
+                }
+                else
+                {
+                    var type = schema.GetSchemaType(propType, null);
+                    if (options.AutoCreateInterfaceTypes)
+                    {
+                        type.ImplementAllBaseTypes(true, true);
+                    }
                 }
             }
         }

--- a/src/EntityGraphQL/Schema/SchemaBuilderOptions.cs
+++ b/src/EntityGraphQL/Schema/SchemaBuilderOptions.cs
@@ -1,0 +1,75 @@
+using System;
+using System.Collections.Generic;
+
+namespace EntityGraphQL.Schema
+{
+    /// <summary>
+    /// Options used by SchemaBuilder when reflection the object graph to auto create schema types & fields
+    /// </summary>
+    public class SchemaBuilderOptions
+    {
+        /// <summary>
+        /// List properties or field names to ignore. Default includes a list of EF properties
+        /// </summary>
+        public HashSet<string> IgnoreProps { get; set; } = new()
+        {
+            "Database",
+            "Model",
+            "ChangeTracker",
+            "ContextId"
+        };
+        /// <summary>
+        /// List of dotnet type names to ignore when adding types to the schema
+        /// </summary>
+        public HashSet<string> IgnoreTypes { get; set; } = new()
+        {
+            "String",
+            "Byte[]"
+        };
+        /// <summary>
+        /// If true when SchemaBuilder encounters a field that returns a list of entities and the entity has a property 
+        /// or field name Id t will also create a schema field with a singular name and an argument of id for that entity.
+        /// e.g. if it sees IEnumerable<Person> People; It will create the schema fields
+        /// {
+        ///   people: [Person]
+        ///   person(id: ID!): Person
+        /// }
+        /// </summary>
+        public bool AutoCreateFieldWithIdArguments { get; set; } = true;
+        /// <summary>
+        /// If true (default) and an enum type is encountered during reflection of the object graph it will be added to the schema as an Enum
+        /// </summary>
+        public bool AutoCreateEnumTypes { get; set; } = true;
+        /// <summary>
+        /// If true (default) and an object type is encountered during reflection of the object graph it will be added to the schema as a Type including it's fields. If that type is an interface it will be added as an interface
+        /// </summary>
+        public bool AutoCreateNewComplexTypes { get; set; } = true;
+        /// <summary>
+        /// If true (default = false), any object type that is encountered during reflection of the object graph that has abstract or interface types (regardless of if they are referenced by other fields), those will be added to the schema as an Interface including it's fields
+        /// </summary>
+        public bool AutoCreateInterfaceTypes { get; set; } = false;
+    }
+
+    /// <summary>
+    /// Options used by the SchemaBuilder factory with creating the SchemaProvider
+    /// </summary>
+    public class SchemaBuilderSchemaOptions
+    {
+        public static readonly Func<string, string> DefaultFieldNamer = name =>
+        {
+            return name[..1].ToLowerInvariant() + name[1..];
+        };
+        /// <summary>
+        /// Function to name fields when reading the properties from reflection. Default is camelCase
+        /// </summary>
+        public Func<string, string> FieldNamer { get; set; } = DefaultFieldNamer;
+        /// <summary>
+        /// If true (default) schema introspection will be enabled for the schema
+        /// </summary>
+        public bool IntrospectionEnabled { get; set; } = true;
+        /// <summary>
+        /// 
+        /// </summary>
+        public IGqlAuthorizationService AuthorizationService { get; set; } = new RoleBasedAuthorization();
+    }
+}

--- a/src/EntityGraphQL/Schema/SchemaProvider.cs
+++ b/src/EntityGraphQL/Schema/SchemaProvider.cs
@@ -48,7 +48,7 @@ namespace EntityGraphQL.Schema
         public SchemaProvider(IGqlAuthorizationService? authorizationService = null, Func<string, string>? fieldNamer = null, ILogger<SchemaProvider<TContextType>>? logger = null, bool introspectionEnabled = true)
         {
             AuthorizationService = authorizationService ?? new RoleBasedAuthorization();
-            SchemaFieldNamer = fieldNamer ?? SchemaBuilder.DefaultNamer;
+            SchemaFieldNamer = fieldNamer ?? SchemaBuilderSchemaOptions.DefaultFieldNamer;
             this.logger = logger;
             this.graphQLCompiler = new GraphQLCompiler(this);
             this.introspectionEnabled = introspectionEnabled;
@@ -761,11 +761,12 @@ namespace EntityGraphQL.Schema
         /// <summary>
         /// Build the Query schema by reflection on the context type. Same as SchemaBuilder.FromObject<T>()
         /// </summary>
-        /// <param name="autoCreateIdArguments"></param>
-        /// <param name="autoCreateEnumTypes"></param>
-        public void PopulateFromContext(bool autoCreateIdArguments, bool autoCreateEnumTypes)
+        /// <param name="options"></param>
+        public void PopulateFromContext(SchemaBuilderOptions? options = null)
         {
-            SchemaBuilder.FromObject(this, autoCreateIdArguments, autoCreateEnumTypes, SchemaFieldNamer);
+            if (options == null)
+                options = new SchemaBuilderOptions();
+            SchemaBuilder.FromObject(this, options);
         }
     }
 }

--- a/src/EntityGraphQL/Schema/SchemaType.cs
+++ b/src/EntityGraphQL/Schema/SchemaType.cs
@@ -45,10 +45,9 @@ namespace EntityGraphQL.Schema
         /// Using reflection, add all the public Fields and Properties from the dotnet type as fields on the 
         /// schema type. Quick helper method to build out schemas
         /// </summary>
-        /// <param name="autoCreateNewComplexTypes"></param>
-        /// <param name="autoCreateEnumTypes"></param>
+        /// <param name="options">Default SchemaBuilderOptions are used if null (default)</param>
         /// <returns>The schema type the fields were added to</returns>
-        public override ISchemaType AddAllFields(bool autoCreateNewComplexTypes = false, bool autoCreateEnumTypes = true)
+        public override ISchemaType AddAllFields(SchemaBuilderOptions? options = null)
         {
             if (GqlType == GqlTypeEnum.Enum)
             {
@@ -72,7 +71,9 @@ namespace EntityGraphQL.Schema
             }
             else
             {
-                var fields = SchemaBuilder.GetFieldsFromObject(TypeDotnet, Schema, autoCreateEnumTypes, false, Schema.SchemaFieldNamer, autoCreateNewComplexTypes, true);
+                if (options == null)
+                    options = new SchemaBuilderOptions();
+                var fields = SchemaBuilder.GetFieldsFromObject(TypeDotnet, Schema, options, GqlType == GqlTypeEnum.Input);
                 AddFields(fields);
             }
             return this;

--- a/src/tests/EntityGraphQL.AspNet.Tests/PoliciesTests.cs
+++ b/src/tests/EntityGraphQL.AspNet.Tests/PoliciesTests.cs
@@ -14,7 +14,7 @@ namespace EntityGraphQL.AspNet.Tests
             var serviceCollection = new ServiceCollection();
             serviceCollection.AddSingleton<IAuthorizationService, DummyAuthService>();
             var services = serviceCollection.BuildServiceProvider();
-            var schema = SchemaBuilder.FromObject<PolicyDataContext>(new PolicyOrRoleBasedAuthorization(services.GetService<IAuthorizationService>()!));
+            var schema = SchemaBuilder.FromObject<PolicyDataContext>(new SchemaBuilderSchemaOptions { AuthorizationService = new PolicyOrRoleBasedAuthorization(services.GetService<IAuthorizationService>()!) });
             Assert.Single(schema.Type<Project>().RequiredAuthorization!.Policies);
             Assert.Equal("admin", schema.Type<Project>().RequiredAuthorization!.Policies.ElementAt(0).ElementAt(0));
         }
@@ -40,7 +40,7 @@ namespace EntityGraphQL.AspNet.Tests
             serviceCollection.AddSingleton<IAuthorizationService, DummyAuthService>();
             var services = serviceCollection.BuildServiceProvider();
 
-            var schema = SchemaBuilder.FromObject<PolicyDataContext>(new PolicyOrRoleBasedAuthorization(services.GetService<IAuthorizationService>()!));
+            var schema = SchemaBuilder.FromObject<PolicyDataContext>(new SchemaBuilderSchemaOptions { AuthorizationService = new PolicyOrRoleBasedAuthorization(services.GetService<IAuthorizationService>()!) });
 
             Assert.Empty(schema.Type<Task>().RequiredAuthorization!.Policies);
 
@@ -57,7 +57,7 @@ namespace EntityGraphQL.AspNet.Tests
             serviceCollection.AddSingleton<IAuthorizationService, DummyAuthService>();
             var services = serviceCollection.BuildServiceProvider();
 
-            var schema = SchemaBuilder.FromObject<PolicyDataContext>(new PolicyOrRoleBasedAuthorization(services.GetService<IAuthorizationService>()!));
+            var schema = SchemaBuilder.FromObject<PolicyDataContext>(new SchemaBuilderSchemaOptions { AuthorizationService = new PolicyOrRoleBasedAuthorization(services.GetService<IAuthorizationService>()!) });
 
             Assert.Single(schema.Type<Project>().GetField("type", null).RequiredAuthorization!.Policies);
             Assert.Equal("can-type", schema.Type<Project>().GetField("type", null).RequiredAuthorization!.Policies.ElementAt(0).ElementAt(0));
@@ -122,7 +122,7 @@ namespace EntityGraphQL.AspNet.Tests
             serviceCollection.AddSingleton<IAuthorizationService>(new DummyAuthService(new Dictionary<string, Func<ClaimsPrincipal, bool>> { { "admin", adminPolicy }, { "can-type", canType } }));
             var services = serviceCollection.BuildServiceProvider();
 
-            var schema = SchemaBuilder.FromObject<PolicyDataContext>(new PolicyOrRoleBasedAuthorization(services.GetService<IAuthorizationService>()!));
+            var schema = SchemaBuilder.FromObject<PolicyDataContext>(new SchemaBuilderSchemaOptions { AuthorizationService = new PolicyOrRoleBasedAuthorization(services.GetService<IAuthorizationService>()!) });
 
             var claims = new ClaimsIdentity(new[] { new Claim(ClaimTypes.Role, "admin") }, "authed");
             var gql = new QueryRequest
@@ -150,7 +150,7 @@ namespace EntityGraphQL.AspNet.Tests
             serviceCollection.AddSingleton<IAuthorizationService>(new DummyAuthService(new Dictionary<string, Func<ClaimsPrincipal, bool>> { { "admin", adminPolicy } }));
             var services = serviceCollection.BuildServiceProvider();
 
-            var schema = SchemaBuilder.FromObject<PolicyDataContext>(new PolicyOrRoleBasedAuthorization(services.GetService<IAuthorizationService>()!));
+            var schema = SchemaBuilder.FromObject<PolicyDataContext>(new SchemaBuilderSchemaOptions { AuthorizationService = new PolicyOrRoleBasedAuthorization(services.GetService<IAuthorizationService>()!) });
 
             var claims = new ClaimsIdentity(new[] { new Claim(ClaimTypes.Role, "not-admin") }, "authed");
             var gql = new QueryRequest
@@ -178,7 +178,7 @@ namespace EntityGraphQL.AspNet.Tests
             serviceCollection.AddSingleton<IAuthorizationService>(new DummyAuthService(new Dictionary<string, Func<ClaimsPrincipal, bool>> { { "admin", adminPolicy } }));
             var services = serviceCollection.BuildServiceProvider();
 
-            var schema = SchemaBuilder.FromObject<PolicyDataContext>(new PolicyOrRoleBasedAuthorization(services.GetService<IAuthorizationService>()!));
+            var schema = SchemaBuilder.FromObject<PolicyDataContext>(new SchemaBuilderSchemaOptions { AuthorizationService = new PolicyOrRoleBasedAuthorization(services.GetService<IAuthorizationService>()!) });
 
             var claims = new ClaimsIdentity(new[] { new Claim(ClaimTypes.Role, "not-admin") }, "authed");
             var gql = new QueryRequest

--- a/src/tests/EntityGraphQL.Tests/EntityQuery/GraphQLEntityQueryExtensionTests.cs
+++ b/src/tests/EntityGraphQL.Tests/EntityQuery/GraphQLEntityQueryExtensionTests.cs
@@ -165,7 +165,7 @@ namespace EntityGraphQL.Tests
         [Fact]
         public void SupportUseFilterWithOrStatement()
         {
-            var schema = SchemaBuilder.FromObject<TestDataContext>(false);
+            var schema = SchemaBuilder.FromObject<TestDataContext>(new SchemaBuilderOptions { AutoCreateFieldWithIdArguments = false });
             schema.Type<TestDataContext>().GetField("users", null)
                 .UseFilter();
             var gql = new QueryRequest
@@ -186,7 +186,7 @@ namespace EntityGraphQL.Tests
         [Fact]
         public void SupportUseFilterWithAndStatement()
         {
-            var schema = SchemaBuilder.FromObject<TestDataContext>(false);
+            var schema = SchemaBuilder.FromObject<TestDataContext>(new SchemaBuilderOptions { AutoCreateFieldWithIdArguments = false });
             schema.Type<TestDataContext>().GetField("users", null)
                 .UseFilter();
             var gql = new QueryRequest
@@ -207,7 +207,7 @@ namespace EntityGraphQL.Tests
         [Fact]
         public void SupportUseFilterWithnotEqualStatement()
         {
-            var schema = SchemaBuilder.FromObject<TestDataContext>(false);
+            var schema = SchemaBuilder.FromObject<TestDataContext>(new SchemaBuilderOptions { AutoCreateFieldWithIdArguments = false });
             schema.Type<TestDataContext>().GetField("users", null)
                 .UseFilter();
             var gql = new QueryRequest

--- a/src/tests/EntityGraphQL.Tests/EntityQuery/GraphQLEntityQueryExtensionTests.cs
+++ b/src/tests/EntityGraphQL.Tests/EntityQuery/GraphQLEntityQueryExtensionTests.cs
@@ -13,7 +13,7 @@ namespace EntityGraphQL.Tests
         [Fact]
         public void SupportEntityQuery()
         {
-            var schemaProvider = SchemaBuilder.FromObject<TestDataContext>(false);
+            var schemaProvider = SchemaBuilder.FromObject<TestDataContext>();
             schemaProvider.Query().ReplaceField("users", new { filter = EntityQuery<User>() }, (ctx, p) => ctx.Users.WhereWhen(p.filter, p.filter.HasValue), "Return filtered users");
             var gql = new QueryRequest
             {
@@ -34,7 +34,7 @@ namespace EntityGraphQL.Tests
         [Fact]
         public void SupportEntityQueryEmptyString()
         {
-            var schemaProvider = SchemaBuilder.FromObject<TestDataContext>(false);
+            var schemaProvider = SchemaBuilder.FromObject<TestDataContext>();
             schemaProvider.Query().ReplaceField("users", new { filter = EntityQuery<User>() }, (ctx, p) => ctx.Users.WhereWhen(p.filter, p.filter.HasValue), "Return filtered users");
             var gql = new QueryRequest
             {
@@ -53,7 +53,7 @@ namespace EntityGraphQL.Tests
         [Fact]
         public void SupportEntityQueryStringWhitespace()
         {
-            var schemaProvider = SchemaBuilder.FromObject<TestDataContext>(false);
+            var schemaProvider = SchemaBuilder.FromObject<TestDataContext>();
             schemaProvider.Query().ReplaceField("users", new { filter = EntityQuery<User>() }, (ctx, p) => ctx.Users.WhereWhen(p.filter, p.filter.HasValue), "Return filtered users");
             var gql = new QueryRequest
             {
@@ -72,7 +72,7 @@ namespace EntityGraphQL.Tests
         [Fact]
         public void SupportEntityQueryArgument()
         {
-            var schemaProvider = SchemaBuilder.FromObject<TestDataContext>(false);
+            var schemaProvider = SchemaBuilder.FromObject<TestDataContext>();
             schemaProvider.Query().ReplaceField("users", new { filter = EntityQuery<User>() }, (ctx, p) => ctx.Users.WhereWhen(p.filter, p.filter.HasValue), "Return filtered users");
             var gql = new QueryRequest
             {
@@ -94,7 +94,7 @@ namespace EntityGraphQL.Tests
         [Fact]
         public void FilterExpressionWithNoValue()
         {
-            var schemaProvider = SchemaBuilder.FromObject<TestDataContext>(false);
+            var schemaProvider = SchemaBuilder.FromObject<TestDataContext>();
             schemaProvider.Query().ReplaceField("users", new { filter = EntityQuery<User>() }, (ctx, p) => ctx.Users.WhereWhen(p.filter, p.filter.HasValue), "Return filtered users");
             var gql = new QueryRequest
             {
@@ -119,7 +119,7 @@ namespace EntityGraphQL.Tests
         [Fact]
         public void FilterExpressionWithNoValueNoDocVar()
         {
-            var schemaProvider = SchemaBuilder.FromObject<TestDataContext>(false);
+            var schemaProvider = SchemaBuilder.FromObject<TestDataContext>();
             schemaProvider.Query().ReplaceField("users", new { filter = EntityQuery<User>() }, (ctx, p) => ctx.Users.WhereWhen(p.filter, p.filter.HasValue), "Return filtered users");
             var gql = new QueryRequest
             {
@@ -144,7 +144,7 @@ namespace EntityGraphQL.Tests
         [Fact]
         public void SupportUseFilter()
         {
-            var schema = SchemaBuilder.FromObject<TestDataContext>(false);
+            var schema = SchemaBuilder.FromObject<TestDataContext>();
             schema.Type<TestDataContext>().GetField("users", null)
                 .UseFilter();
             var gql = new QueryRequest
@@ -164,7 +164,7 @@ namespace EntityGraphQL.Tests
         [Fact]
         public void SupportUseFilterOnNonRoot()
         {
-            var schema = SchemaBuilder.FromObject<TestDataContext>(false);
+            var schema = SchemaBuilder.FromObject<TestDataContext>();
             schema.Type<Project>().GetField("tasks", null)
                 .UseFilter();
             var gql = new QueryRequest

--- a/src/tests/EntityGraphQL.Tests/ErrorTests.cs
+++ b/src/tests/EntityGraphQL.Tests/ErrorTests.cs
@@ -11,7 +11,7 @@ namespace EntityGraphQL.Tests
         [Fact]
         public void MutationReportsError()
         {
-            var schemaProvider = SchemaBuilder.FromObject<TestDataContext>(false);
+            var schemaProvider = SchemaBuilder.FromObject<TestDataContext>();
             schemaProvider.AddMutationsFrom<PeopleMutations>();
             // Add a argument field with a require parameter
             var gql = new QueryRequest
@@ -36,7 +36,7 @@ namespace EntityGraphQL.Tests
         [Fact]
         public void QueryReportsError()
         {
-            var schemaProvider = SchemaBuilder.FromObject<TestDataContext>(false);
+            var schemaProvider = SchemaBuilder.FromObject<TestDataContext>();
             // Add a argument field with a require parameter
             var gql = new QueryRequest
             {
@@ -54,7 +54,7 @@ namespace EntityGraphQL.Tests
         [Fact]
         public void TestErrorFieldNotIncludedInResponseWhenNoErrors()
         {
-            var schemaProvider = SchemaBuilder.FromObject<TestDataContext>(false);
+            var schemaProvider = SchemaBuilder.FromObject<TestDataContext>();
             schemaProvider.AddMutationsFrom<PeopleMutations>();
             var gql = new QueryRequest
             {
@@ -74,7 +74,7 @@ namespace EntityGraphQL.Tests
         [Fact]
         public void TestExtensionException()
         {
-            var schemaProvider = SchemaBuilder.FromObject<TestDataContext>(false);
+            var schemaProvider = SchemaBuilder.FromObject<TestDataContext>();
             var gql = new QueryRequest
             {
                 Query = @"{

--- a/src/tests/EntityGraphQL.Tests/IntrospectionTests/MetaDataTests.cs
+++ b/src/tests/EntityGraphQL.Tests/IntrospectionTests/MetaDataTests.cs
@@ -16,7 +16,7 @@ namespace EntityGraphQL.Tests
         [Fact]
         public void Supports__typename()
         {
-            var schemaProvider = SchemaBuilder.FromObject<TestDataContext>(false);
+            var schemaProvider = SchemaBuilder.FromObject<TestDataContext>();
             // Add a argument field with a require parameter
             var tree = new GraphQLCompiler(schemaProvider).Compile(@"query {
 	users { __typename id }

--- a/src/tests/EntityGraphQL.Tests/MutationTests/MutationMethodParameterTests.cs
+++ b/src/tests/EntityGraphQL.Tests/MutationTests/MutationMethodParameterTests.cs
@@ -1,9 +1,5 @@
 ﻿using Xunit;
-using System.Linq;
 using EntityGraphQL.Schema;
-using Microsoft.Extensions.DependencyInjection;
-using System.Reflection;
-using System.Collections.Generic;
 using System;
 
 namespace EntityGraphQL.Tests
@@ -13,7 +9,7 @@ namespace EntityGraphQL.Tests
         [Fact]
         public void TestSeparateArguments_PrimitivesOnly()
         {
-            var schemaProvider = SchemaBuilder.FromObject<TestDataContext>(false);
+            var schemaProvider = SchemaBuilder.FromObject<TestDataContext>();
             schemaProvider.AddScalarType<DateTime>("DateTime", "");
             schemaProvider.AddScalarType<decimal>("decimal", "");
             schemaProvider.AddMutationsFrom<PeopleMutations>(false);
@@ -38,7 +34,7 @@ namespace EntityGraphQL.Tests
         [Fact]
         public void TestSeparateArguments_PrimitivesOnly_WithInlineDefaults()
         {
-            var schemaProvider = SchemaBuilder.FromObject<TestDataContext>(false);
+            var schemaProvider = SchemaBuilder.FromObject<TestDataContext>();
             schemaProvider.AddScalarType<DateTime>("DateTime", "");
             schemaProvider.AddScalarType<decimal>("decimal", "");
             schemaProvider.AddMutationsFrom<PeopleMutations>(false);
@@ -61,7 +57,7 @@ namespace EntityGraphQL.Tests
         [Fact]
         public void TestSeparateArguments()
         {
-            var schemaProvider = SchemaBuilder.FromObject<TestDataContext>(false);
+            var schemaProvider = SchemaBuilder.FromObject<TestDataContext>();
             schemaProvider.AddInputType<InputObject>("InputObject", "");
             schemaProvider.AddMutationsFrom<PeopleMutations>(false);
             // Add a argument field with a require parameter
@@ -84,7 +80,7 @@ namespace EntityGraphQL.Tests
         [Fact]
         public void TestSingleArgument()
         {
-            var schemaProvider = SchemaBuilder.FromObject<TestDataContext>(false);
+            var schemaProvider = SchemaBuilder.FromObject<TestDataContext>();
             schemaProvider.AddInputType<InputObject>("InputObject", "");
             schemaProvider.AddMutationsFrom<PeopleMutations>(false);
             // Add a argument field with a require parameter
@@ -104,7 +100,7 @@ namespace EntityGraphQL.Tests
         [Fact]
         public void TestSingleArgument_AutoAddInputTypes()
         {
-            var schemaProvider = SchemaBuilder.FromObject<TestDataContext>(false);
+            var schemaProvider = SchemaBuilder.FromObject<TestDataContext>();
             schemaProvider.AddMutationsFrom<PeopleMutations>(true);
             // Add a argument field with a require parameter
             var gql = new QueryRequest
@@ -123,7 +119,7 @@ namespace EntityGraphQL.Tests
         [Fact]
         public void TestSeparateArguments_AutoAddInputTypes()
         {
-            var schemaProvider = SchemaBuilder.FromObject<TestDataContext>(false);
+            var schemaProvider = SchemaBuilder.FromObject<TestDataContext>();
             schemaProvider.AddMutationsFrom<PeopleMutations>(true);
             // Add a argument field with a require parameter
             var gql = new QueryRequest

--- a/src/tests/EntityGraphQL.Tests/MutationTests/MutationTests.cs
+++ b/src/tests/EntityGraphQL.Tests/MutationTests/MutationTests.cs
@@ -16,7 +16,7 @@ namespace EntityGraphQL.Tests
         [Fact]
         public void MissingRequiredVar()
         {
-            var schemaProvider = SchemaBuilder.FromObject<TestDataContext>(false);
+            var schemaProvider = SchemaBuilder.FromObject<TestDataContext>();
             schemaProvider.AddMutationsFrom<PeopleMutations>();
             // Add a argument field with a require parameter
             var gql = new QueryRequest
@@ -35,7 +35,7 @@ namespace EntityGraphQL.Tests
         [Fact]
         public void SupportsMutationOptional()
         {
-            var schemaProvider = SchemaBuilder.FromObject<TestDataContext>(false);
+            var schemaProvider = SchemaBuilder.FromObject<TestDataContext>();
             schemaProvider.AddMutationsFrom<PeopleMutations>();
             // Add a argument field with a require parameter
             var gql = new QueryRequest
@@ -63,7 +63,7 @@ namespace EntityGraphQL.Tests
         [Fact]
         public void SupportsMutationArrayArg()
         {
-            var schemaProvider = SchemaBuilder.FromObject<TestDataContext>(false);
+            var schemaProvider = SchemaBuilder.FromObject<TestDataContext>();
             schemaProvider.AddMutationsFrom<PeopleMutations>();
             // Add a argument field with a require parameter
             var gql = new QueryRequest
@@ -97,7 +97,7 @@ namespace EntityGraphQL.Tests
             // This tests that whena mutation returns an Expression
             // ctx => ctx.People.First(p => p.Id == myNewPerson.Id)
             // that myNewPerson.Id does not get replace by something dumb like p.Id == p.Id
-            var schemaProvider = SchemaBuilder.FromObject<TestDataContext>(false);
+            var schemaProvider = SchemaBuilder.FromObject<TestDataContext>();
             schemaProvider.AddMutationsFrom<PeopleMutations>();
             // Add a argument field with a require parameter
             var query = @"mutation AddPerson($names: [String]) {
@@ -148,7 +148,7 @@ namespace EntityGraphQL.Tests
         [Fact]
         public void TestErrorOnVariableTypeMismatch()
         {
-            var schemaProvider = SchemaBuilder.FromObject<TestDataContext>(false);
+            var schemaProvider = SchemaBuilder.FromObject<TestDataContext>();
             schemaProvider.AddInputType<InputObject>("InputObject", "Using an object in the arguments");
             schemaProvider.AddMutationsFrom<PeopleMutations>();
             // Add a argument field with a require parameter
@@ -172,7 +172,7 @@ namespace EntityGraphQL.Tests
         [Fact]
         public void TestErrorOnVariableTypeMismatch2()
         {
-            var schemaProvider = SchemaBuilder.FromObject<TestDataContext>(false);
+            var schemaProvider = SchemaBuilder.FromObject<TestDataContext>();
             schemaProvider.AddInputType<InputObject>("InputObject", "Using an object in the arguments");
             schemaProvider.AddMutationsFrom<PeopleMutations>();
             // Add a argument field with a require parameter
@@ -196,7 +196,7 @@ namespace EntityGraphQL.Tests
         [Fact]
         public void SupportsMutationVariablesAnonObject()
         {
-            var schemaProvider = SchemaBuilder.FromObject<TestDataContext>(false);
+            var schemaProvider = SchemaBuilder.FromObject<TestDataContext>();
             schemaProvider.AddInputType<InputObject>("InputObject", "Using an object in the arguments");
             schemaProvider.AddMutationsFrom<PeopleMutations>();
             // Add a argument field with a require parameter
@@ -228,7 +228,7 @@ namespace EntityGraphQL.Tests
         [Fact]
         public void SupportsMutationVariablesObject()
         {
-            var schemaProvider = SchemaBuilder.FromObject<TestDataContext>(false);
+            var schemaProvider = SchemaBuilder.FromObject<TestDataContext>();
             schemaProvider.AddInputType<InputObject>("InputObject", "Using an object in the arguments");
             schemaProvider.AddMutationsFrom<PeopleMutations>();
             // Add a argument field with a require parameter
@@ -260,7 +260,7 @@ namespace EntityGraphQL.Tests
         [Fact]
         public void SupportsMutationVariablesDictionary()
         {
-            var schemaProvider = SchemaBuilder.FromObject<TestDataContext>(false);
+            var schemaProvider = SchemaBuilder.FromObject<TestDataContext>();
             schemaProvider.AddInputType<InputObject>("InputObject", "Using an object in the arguments");
             schemaProvider.AddMutationsFrom<PeopleMutations>();
             // Add a argument field with a require parameter
@@ -295,7 +295,7 @@ namespace EntityGraphQL.Tests
         [Fact]
         public void SupportsSelectionFromConstant()
         {
-            var schemaProvider = SchemaBuilder.FromObject<TestDataContext>(false);
+            var schemaProvider = SchemaBuilder.FromObject<TestDataContext>();
             schemaProvider.AddMutationsFrom<PeopleMutations>();
             // Add a argument field with a require parameter
             var gql = new QueryRequest
@@ -325,7 +325,7 @@ namespace EntityGraphQL.Tests
         [Fact]
         public void SupportsSelectionWithServiceFieldInFragment()
         {
-            var schemaProvider = SchemaBuilder.FromObject<TestDataContext>(false);
+            var schemaProvider = SchemaBuilder.FromObject<TestDataContext>();
             schemaProvider.UpdateType<Person>(type =>
             {
                 type.AddField("age", "Person's age")
@@ -367,7 +367,7 @@ namespace EntityGraphQL.Tests
         [Fact]
         public void MutationReturnsCollectionExpressionWithService()
         {
-            var schemaProvider = SchemaBuilder.FromObject<TestDataContext>(false);
+            var schemaProvider = SchemaBuilder.FromObject<TestDataContext>();
             schemaProvider.UpdateType<Person>(type =>
             {
                 type.AddField("age", "Person's age")
@@ -408,7 +408,7 @@ namespace EntityGraphQL.Tests
         [Fact]
         public void MutationReturnsCollectionConst()
         {
-            var schemaProvider = SchemaBuilder.FromObject<TestDataContext>(false);
+            var schemaProvider = SchemaBuilder.FromObject<TestDataContext>();
             schemaProvider.AddMutationsFrom<PeopleMutations>();
             // Add a argument field with a require parameter
             var gql = new QueryRequest
@@ -440,7 +440,7 @@ namespace EntityGraphQL.Tests
         [Fact]
         public void TestAsyncMutationNonObjectReturn()
         {
-            var schemaProvider = SchemaBuilder.FromObject<TestDataContext>(false);
+            var schemaProvider = SchemaBuilder.FromObject<TestDataContext>();
             schemaProvider.AddMutationsFrom<PeopleMutations>();
             // Add a argument field with a require parameter
             var gql = new QueryRequest
@@ -461,7 +461,7 @@ namespace EntityGraphQL.Tests
         [Fact]
         public void TestUnnamedMutationOp()
         {
-            var schemaProvider = SchemaBuilder.FromObject<TestDataContext>(false);
+            var schemaProvider = SchemaBuilder.FromObject<TestDataContext>();
             schemaProvider.AddMutationsFrom<PeopleMutations>();
             // Add a argument field with a require parameter
             var gql = new QueryRequest
@@ -482,7 +482,7 @@ namespace EntityGraphQL.Tests
         [Fact]
         public void TestRequiredGuid()
         {
-            var schemaProvider = SchemaBuilder.FromObject<TestDataContext>(false);
+            var schemaProvider = SchemaBuilder.FromObject<TestDataContext>();
             schemaProvider.AddMutationsFrom<PeopleMutations>();
             // Add a argument field with a require parameter
             var gql = new QueryRequest
@@ -503,7 +503,7 @@ namespace EntityGraphQL.Tests
         [Fact]
         public void TestNonNullIsRequired()
         {
-            var schemaProvider = SchemaBuilder.FromObject<TestDataContext>(false);
+            var schemaProvider = SchemaBuilder.FromObject<TestDataContext>();
             schemaProvider.AddMutationsFrom<PeopleMutations>();
             // Add a argument field with a require parameter
             var gql = new QueryRequest
@@ -521,7 +521,7 @@ namespace EntityGraphQL.Tests
         [Fact]
         public void TestListArgInputType()
         {
-            var schemaProvider = SchemaBuilder.FromObject<TestDataContext>(false);
+            var schemaProvider = SchemaBuilder.FromObject<TestDataContext>();
             schemaProvider.AddMutationsFrom<PeopleMutations>();
             schemaProvider.AddInputType<InputObject>("InputObject", "Input data").AddAllFields();
             // Add a argument field with a require parameter
@@ -542,7 +542,7 @@ namespace EntityGraphQL.Tests
         [Fact]
         public void TestListArgInputTypeUsingVariables()
         {
-            var schemaProvider = SchemaBuilder.FromObject<TestDataContext>(false);
+            var schemaProvider = SchemaBuilder.FromObject<TestDataContext>();
             schemaProvider.AddMutationsFrom<PeopleMutations>();
             schemaProvider.AddInputType<InputObject>("InputObject", "Input data").AddAllFields();
             // Add a argument field with a require parameter
@@ -566,7 +566,7 @@ namespace EntityGraphQL.Tests
         public void
         TestListIntArgInputType()
         {
-            var schemaProvider = SchemaBuilder.FromObject<TestDataContext>(false);
+            var schemaProvider = SchemaBuilder.FromObject<TestDataContext>();
             schemaProvider.AddMutationsFrom<PeopleMutations>();
             schemaProvider.AddInputType<InputObjectId>("InputObjectId", "InputObjectId").AddAllFields();
             // Add a argument field with a require parameter
@@ -586,7 +586,7 @@ namespace EntityGraphQL.Tests
         [Fact]
         public void TestFloatArgInputType()
         {
-            var schemaProvider = SchemaBuilder.FromObject<TestDataContext>(false);
+            var schemaProvider = SchemaBuilder.FromObject<TestDataContext>();
             schemaProvider.AddMutationsFrom<PeopleMutations>();
             schemaProvider.AddInputType<FloatInput>("FloatInput", "FloatInput").AddAllFields();
             var gql = new QueryRequest
@@ -605,7 +605,7 @@ namespace EntityGraphQL.Tests
         [Fact]
         public void TestDoubleArgInputType()
         {
-            var schemaProvider = SchemaBuilder.FromObject<TestDataContext>(false);
+            var schemaProvider = SchemaBuilder.FromObject<TestDataContext>();
             schemaProvider.AddMutationsFrom<PeopleMutations>();
             schemaProvider.AddInputType<DoubleInput>("DoubleInput", "DoubleInput").AddAllFields();
             var gql = new QueryRequest
@@ -624,7 +624,7 @@ namespace EntityGraphQL.Tests
         [Fact]
         public void TestDecimalArgInputType()
         {
-            var schemaProvider = SchemaBuilder.FromObject<TestDataContext>(false);
+            var schemaProvider = SchemaBuilder.FromObject<TestDataContext>();
             schemaProvider.AddMutationsFrom<PeopleMutations>();
             schemaProvider.AddInputType<DecimalInput>("DecimalInput", "DecimalInput").AddAllFields();
             var gql = new QueryRequest
@@ -643,7 +643,7 @@ namespace EntityGraphQL.Tests
         [Fact]
         public void TestComplexReturn()
         {
-            var schemaProvider = SchemaBuilder.FromObject<TestDataContext>(false);
+            var schemaProvider = SchemaBuilder.FromObject<TestDataContext>();
             schemaProvider.AddMutationsFrom<PeopleMutations>();
             schemaProvider.AddInputType<DecimalInput>("DecimalInput", "DecimalInput").AddAllFields();
             var gql = new QueryRequest
@@ -662,7 +662,7 @@ namespace EntityGraphQL.Tests
         [Fact]
         public void TestStaticMethod()
         {
-            var schemaProvider = SchemaBuilder.FromObject<TestDataContext>(false);
+            var schemaProvider = SchemaBuilder.FromObject<TestDataContext>();
             schemaProvider.Mutation().AddFrom<PeopleMutations>();
             // Add a argument field with a require parameter
             var gql = new QueryRequest
@@ -681,7 +681,7 @@ namespace EntityGraphQL.Tests
         [Fact]
         public void TestClassMethod()
         {
-            var schemaProvider = SchemaBuilder.FromObject<TestDataContext>(false);
+            var schemaProvider = SchemaBuilder.FromObject<TestDataContext>();
             // test example where you might have a builder class set things up
             schemaProvider.Mutation().Add("doGreatThingsHere", DoGreatThingsHere);
             // Add a argument field with a require parameter
@@ -701,7 +701,7 @@ namespace EntityGraphQL.Tests
         [Fact]
         public void TestNoArgMutationWithService()
         {
-            var schemaProvider = SchemaBuilder.FromObject<TestDataContext>(false);
+            var schemaProvider = SchemaBuilder.FromObject<TestDataContext>();
             schemaProvider.AddMutationsFrom<PeopleMutations>();
             // Add a argument field with a require parameter
             var gql = new QueryRequest
@@ -724,7 +724,7 @@ namespace EntityGraphQL.Tests
         [Fact]
         public void TestNullableGuid()
         {
-            var schemaProvider = SchemaBuilder.FromObject<TestDataContext>(false);
+            var schemaProvider = SchemaBuilder.FromObject<TestDataContext>();
             schemaProvider.AddMutationsFrom<PeopleMutations>();
             var gql = new QueryRequest
             {
@@ -753,7 +753,7 @@ namespace EntityGraphQL.Tests
         [Fact]
         public void TestNullableGuidEmptyString()
         {
-            var schemaProvider = SchemaBuilder.FromObject<TestDataContext>(false);
+            var schemaProvider = SchemaBuilder.FromObject<TestDataContext>();
             schemaProvider.AddMutationsFrom<PeopleMutations>();
             var gql = new QueryRequest
             {
@@ -776,7 +776,7 @@ namespace EntityGraphQL.Tests
         [Fact]
         public void TestListGuidTypeUsingVariables()
         {
-            var schemaProvider = SchemaBuilder.FromObject<TestDataContext>(false);
+            var schemaProvider = SchemaBuilder.FromObject<TestDataContext>();
             schemaProvider.AddMutationsFrom<PeopleMutations>();
             // Add a argument field with a require parameter
             var gql = new QueryRequest
@@ -799,7 +799,7 @@ namespace EntityGraphQL.Tests
         [Fact]
         public void TestListGuidTypeUsingVariablesRequired()
         {
-            var schemaProvider = SchemaBuilder.FromObject<TestDataContext>(false);
+            var schemaProvider = SchemaBuilder.FromObject<TestDataContext>();
             schemaProvider.AddMutationsFrom<PeopleMutations>();
             // Add a argument field with a require parameter
             var gql = new QueryRequest
@@ -827,7 +827,7 @@ namespace EntityGraphQL.Tests
         [Fact]
         public void TestAddFromMultipleClassesImplementingInterface()
         {
-            var schemaProvider = SchemaBuilder.FromObject<TestDataContext>(false);
+            var schemaProvider = SchemaBuilder.FromObject<TestDataContext>();
             schemaProvider.Mutation().AddFrom<IMutations>();
 
 
@@ -845,7 +845,7 @@ namespace EntityGraphQL.Tests
         [Fact]
         public void TestAddFromMultipleClassesImplementingInterfaceByDefault()
         {
-            var schemaProvider = SchemaBuilder.FromObject<TestDataContext>(false);
+            var schemaProvider = SchemaBuilder.FromObject<TestDataContext>();
             schemaProvider.Mutation().AddFrom<NonAttributeMarkedMethod>();
 
 
@@ -855,7 +855,7 @@ namespace EntityGraphQL.Tests
         [Fact]
         public void TestAddFromMultipleClassesImplementingInterfaceWhenEnabled()
         {
-            var schemaProvider = SchemaBuilder.FromObject<TestDataContext>(false);
+            var schemaProvider = SchemaBuilder.FromObject<TestDataContext>();
             schemaProvider.Mutation().AddFrom<NonAttributeMarkedMethod>(addNonAttributedMethods: true);
 
             Assert.NotEmpty(schemaProvider.Mutation().SchemaType.GetFields());
@@ -881,7 +881,7 @@ namespace EntityGraphQL.Tests
         [Fact]
         public void TestRightValueReturnedFromActivatorCreateMutationClass()
         {
-            var schemaProvider = SchemaBuilder.FromObject<TestDataContext>(false);
+            var schemaProvider = SchemaBuilder.FromObject<TestDataContext>();
             schemaProvider.Mutation().AddFrom<MutationClassInstantiationTest>(addNonAttributedMethods: true);
 
             var gql = new QueryRequest

--- a/src/tests/EntityGraphQL.Tests/QueryTests/ArgumentTests.cs
+++ b/src/tests/EntityGraphQL.Tests/QueryTests/ArgumentTests.cs
@@ -31,7 +31,7 @@ namespace EntityGraphQL.Tests
         [Fact]
         public void SupportsManyArguments()
         {
-            var schema = SchemaBuilder.FromObject<TestDataContext>(null, new SchemaBuilderOptions { AutoCreateFieldWithIdArguments = false });
+            var schema = SchemaBuilder.FromObject<TestDataContext>(new SchemaBuilderOptions { AutoCreateFieldWithIdArguments = false });
             // Add a argument field with a require parameter
             schema.Query().AddField("user", new { id = ArgumentHelper.Required<int>(), something = true }, (ctx, param) => ctx.Users.Where(u => u.Id == param.id).FirstOrDefault(), "Return a user by ID");
             var tree = new GraphQLCompiler(schema).Compile(@"query {
@@ -47,7 +47,7 @@ namespace EntityGraphQL.Tests
         [Fact]
         public void ThrowsOnMissingRequiredArgument()
         {
-            var schema = SchemaBuilder.FromObject<TestDataContext>(null, new SchemaBuilderOptions { AutoCreateFieldWithIdArguments = false });
+            var schema = SchemaBuilder.FromObject<TestDataContext>(new SchemaBuilderOptions { AutoCreateFieldWithIdArguments = false });
             // Add a argument field with a require parameter
             schema.Query().AddField("user", new { id = ArgumentHelper.Required<int>() }, (ctx, param) => ctx.Users.FirstOrDefault(u => u.Id == param.id), "Return a user by ID");
             var gql = new QueryRequest
@@ -64,7 +64,7 @@ namespace EntityGraphQL.Tests
         [Fact]
         public void ThrowsOnMissingRequiredArguments()
         {
-            var schema = SchemaBuilder.FromObject<TestDataContext>(null, new SchemaBuilderOptions { AutoCreateFieldWithIdArguments = false });
+            var schema = SchemaBuilder.FromObject<TestDataContext>(new SchemaBuilderOptions { AutoCreateFieldWithIdArguments = false });
             // Add a argument field with a require parameter
             schema.Query().AddField("user", new { id = ArgumentHelper.Required<int>(), h = ArgumentHelper.Required<string>() }, (ctx, param) => ctx.Users.FirstOrDefault(u => u.Id == param.id), "Return a user by ID");
             var gql = new QueryRequest

--- a/src/tests/EntityGraphQL.Tests/QueryTests/ArgumentTests.cs
+++ b/src/tests/EntityGraphQL.Tests/QueryTests/ArgumentTests.cs
@@ -31,7 +31,7 @@ namespace EntityGraphQL.Tests
         [Fact]
         public void SupportsManyArguments()
         {
-            var schema = SchemaBuilder.FromObject<TestDataContext>(false);
+            var schema = SchemaBuilder.FromObject<TestDataContext>(null, new SchemaBuilderOptions { AutoCreateIdArguments = false });
             // Add a argument field with a require parameter
             schema.Query().AddField("user", new { id = ArgumentHelper.Required<int>(), something = true }, (ctx, param) => ctx.Users.Where(u => u.Id == param.id).FirstOrDefault(), "Return a user by ID");
             var tree = new GraphQLCompiler(schema).Compile(@"query {
@@ -47,7 +47,7 @@ namespace EntityGraphQL.Tests
         [Fact]
         public void ThrowsOnMissingRequiredArgument()
         {
-            var schema = SchemaBuilder.FromObject<TestDataContext>(false);
+            var schema = SchemaBuilder.FromObject<TestDataContext>(null, new SchemaBuilderOptions { AutoCreateIdArguments = false });
             // Add a argument field with a require parameter
             schema.Query().AddField("user", new { id = ArgumentHelper.Required<int>() }, (ctx, param) => ctx.Users.FirstOrDefault(u => u.Id == param.id), "Return a user by ID");
             var gql = new QueryRequest
@@ -64,7 +64,7 @@ namespace EntityGraphQL.Tests
         [Fact]
         public void ThrowsOnMissingRequiredArguments()
         {
-            var schema = SchemaBuilder.FromObject<TestDataContext>(false);
+            var schema = SchemaBuilder.FromObject<TestDataContext>(null, new SchemaBuilderOptions { AutoCreateIdArguments = false });
             // Add a argument field with a require parameter
             schema.Query().AddField("user", new { id = ArgumentHelper.Required<int>(), h = ArgumentHelper.Required<string>() }, (ctx, param) => ctx.Users.FirstOrDefault(u => u.Id == param.id), "Return a user by ID");
             var gql = new QueryRequest

--- a/src/tests/EntityGraphQL.Tests/QueryTests/ArgumentTests.cs
+++ b/src/tests/EntityGraphQL.Tests/QueryTests/ArgumentTests.cs
@@ -31,7 +31,7 @@ namespace EntityGraphQL.Tests
         [Fact]
         public void SupportsManyArguments()
         {
-            var schema = SchemaBuilder.FromObject<TestDataContext>(null, new SchemaBuilderOptions { AutoCreateIdArguments = false });
+            var schema = SchemaBuilder.FromObject<TestDataContext>(null, new SchemaBuilderOptions { AutoCreateFieldWithIdArguments = false });
             // Add a argument field with a require parameter
             schema.Query().AddField("user", new { id = ArgumentHelper.Required<int>(), something = true }, (ctx, param) => ctx.Users.Where(u => u.Id == param.id).FirstOrDefault(), "Return a user by ID");
             var tree = new GraphQLCompiler(schema).Compile(@"query {
@@ -47,7 +47,7 @@ namespace EntityGraphQL.Tests
         [Fact]
         public void ThrowsOnMissingRequiredArgument()
         {
-            var schema = SchemaBuilder.FromObject<TestDataContext>(null, new SchemaBuilderOptions { AutoCreateIdArguments = false });
+            var schema = SchemaBuilder.FromObject<TestDataContext>(null, new SchemaBuilderOptions { AutoCreateFieldWithIdArguments = false });
             // Add a argument field with a require parameter
             schema.Query().AddField("user", new { id = ArgumentHelper.Required<int>() }, (ctx, param) => ctx.Users.FirstOrDefault(u => u.Id == param.id), "Return a user by ID");
             var gql = new QueryRequest
@@ -64,7 +64,7 @@ namespace EntityGraphQL.Tests
         [Fact]
         public void ThrowsOnMissingRequiredArguments()
         {
-            var schema = SchemaBuilder.FromObject<TestDataContext>(null, new SchemaBuilderOptions { AutoCreateIdArguments = false });
+            var schema = SchemaBuilder.FromObject<TestDataContext>(null, new SchemaBuilderOptions { AutoCreateFieldWithIdArguments = false });
             // Add a argument field with a require parameter
             schema.Query().AddField("user", new { id = ArgumentHelper.Required<int>(), h = ArgumentHelper.Required<string>() }, (ctx, param) => ctx.Users.FirstOrDefault(u => u.Id == param.id), "Return a user by ID");
             var gql = new QueryRequest

--- a/src/tests/EntityGraphQL.Tests/QueryTests/InheritanceTests.cs
+++ b/src/tests/EntityGraphQL.Tests/QueryTests/InheritanceTests.cs
@@ -1,6 +1,7 @@
 using Xunit;
 using EntityGraphQL.Compiler;
 using EntityGraphQL.Tests.ApiVersion1;
+using EntityGraphQL.Schema;
 
 namespace EntityGraphQL.Tests
 {
@@ -31,6 +32,16 @@ query {
 
             Assert.Equal("Dog", animals[0].__typename);
             Assert.Equal("Cat", animals[1].__typename);
+        }
+
+        [Fact]
+        public void TestAutoInheritance()
+        {
+            var schema = SchemaBuilder.FromObject<TestAbstractDataContextNoAnimals>(new SchemaBuilderOptions { AutoCreateInterfaceTypes = true });
+            Assert.True(schema.HasType(typeof(Dog)));
+            Assert.True(schema.HasType(typeof(Cat)));
+            Assert.True(schema.HasType(typeof(Animal)));
+            Assert.True(schema.GetSchemaType(typeof(Animal), null).IsInterface);
         }
 
         [Fact]

--- a/src/tests/EntityGraphQL.Tests/QueryTests/QueryTests.cs
+++ b/src/tests/EntityGraphQL.Tests/QueryTests/QueryTests.cs
@@ -309,7 +309,7 @@ namespace EntityGraphQL.Tests
         [Fact]
         public void EnumTest()
         {
-            var schemaProvider = SchemaBuilder.FromObject<TestDataContext>(false);
+            var schemaProvider = SchemaBuilder.FromObject<TestDataContext>();
             var gql = new QueryRequest
             {
                 Query = @"{
@@ -349,7 +349,7 @@ query {
         [Fact]
         public void TestDeepQuery()
         {
-            var schemaProvider = SchemaBuilder.FromObject<DeepContext>(false);
+            var schemaProvider = SchemaBuilder.FromObject<DeepContext>();
             var gql = new QueryRequest
             {
                 Query = @"query deep { levelOnes { levelTwo { level3 { name }} }}",

--- a/src/tests/EntityGraphQL.Tests/QueryTests/VariableTests.cs
+++ b/src/tests/EntityGraphQL.Tests/QueryTests/VariableTests.cs
@@ -94,7 +94,7 @@ namespace EntityGraphQL.Tests
         [Fact]
         public void QueryVariableDefinitionRequiredBySchemaItIsNotRequired()
         {
-            var schemaProvider = SchemaBuilder.FromObject<TestDataContext>(false);
+            var schemaProvider = SchemaBuilder.FromObject<TestDataContext>();
             schemaProvider.AddMutationsFrom<PeopleMutations>();
             var gql = new QueryRequest
             {
@@ -117,7 +117,7 @@ namespace EntityGraphQL.Tests
         [Fact]
         public void QueryVariableArrayGetsAList()
         {
-            var schema = SchemaBuilder.FromObject<TestDataContext>(false);
+            var schema = SchemaBuilder.FromObject<TestDataContext>();
             schema.Query().AddField("test", new { ids = (Guid[])null }, (db, args) => db.People.Where(p => args.ids.Any(a => a == p.Guid)), "test field");
             var gql = new QueryRequest
             {

--- a/src/tests/EntityGraphQL.Tests/SchemaTests/GraphQLSchemaGenerateTests.cs
+++ b/src/tests/EntityGraphQL.Tests/SchemaTests/GraphQLSchemaGenerateTests.cs
@@ -16,7 +16,7 @@ namespace EntityGraphQL.Tests
         [Fact]
         public void TestIgnoreQueryFails()
         {
-            var schemaProvider = SchemaBuilder.FromObject<IgnoreTestSchema>(false);
+            var schemaProvider = SchemaBuilder.FromObject<IgnoreTestSchema>();
             // Add a argument field with a require parameter
             var gql = new QueryRequest
             {
@@ -29,7 +29,7 @@ namespace EntityGraphQL.Tests
         [Fact]
         public void TestIgnoreQueryPasses()
         {
-            var schemaProvider = SchemaBuilder.FromObject<IgnoreTestSchema>(false);
+            var schemaProvider = SchemaBuilder.FromObject<IgnoreTestSchema>();
             // Add a argument field with a require parameter
             var gql = new QueryRequest
             {
@@ -42,7 +42,7 @@ namespace EntityGraphQL.Tests
         [Fact]
         public void TestIgnoreInputFails()
         {
-            var schemaProvider = SchemaBuilder.FromObject<IgnoreTestSchema>(false);
+            var schemaProvider = SchemaBuilder.FromObject<IgnoreTestSchema>();
             schemaProvider.
             AddMutationsFrom<IgnoreTestMutations>();
             // Add a argument field with a require parameter
@@ -66,7 +66,7 @@ namespace EntityGraphQL.Tests
         [Fact]
         public void TestIgnoreInputPasses()
         {
-            var schemaProvider = SchemaBuilder.FromObject<IgnoreTestSchema>(false);
+            var schemaProvider = SchemaBuilder.FromObject<IgnoreTestSchema>();
             schemaProvider.AddMutationsFrom<IgnoreTestMutations>();
             // Add a argument field with a require parameter
             var gql = new QueryRequest
@@ -91,7 +91,7 @@ namespace EntityGraphQL.Tests
         [Fact]
         public void TestIgnoreAllInInput()
         {
-            var schemaProvider = SchemaBuilder.FromObject<IgnoreTestSchema>(false);
+            var schemaProvider = SchemaBuilder.FromObject<IgnoreTestSchema>();
             schemaProvider.AddMutationsFrom<IgnoreTestMutations>();
             // Add a argument field with a require parameter
             var gql = new QueryRequest
@@ -114,7 +114,7 @@ namespace EntityGraphQL.Tests
         [Fact]
         public void TestIgnoreAllInQuery()
         {
-            var schemaProvider = SchemaBuilder.FromObject<IgnoreTestSchema>(false);
+            var schemaProvider = SchemaBuilder.FromObject<IgnoreTestSchema>();
             // Add a argument field with a require parameter
             var gql = new QueryRequest
             {
@@ -133,7 +133,7 @@ namespace EntityGraphQL.Tests
         [Fact]
         public void TestIgnoreWithSchema()
         {
-            var schemaProvider = SchemaBuilder.FromObject<IgnoreTestSchema>(false);
+            var schemaProvider = SchemaBuilder.FromObject<IgnoreTestSchema>();
             schemaProvider.AddMutationsFrom<IgnoreTestMutations>();
             schemaProvider.Type<Album>().RemoveField("old");
             var schema = schemaProvider.ToGraphQLSchemaString();
@@ -161,7 +161,7 @@ namespace EntityGraphQL.Tests
         [Fact]
         public void TestNotNullTypes()
         {
-            var schemaProvider = SchemaBuilder.FromObject<IgnoreTestSchema>(false);
+            var schemaProvider = SchemaBuilder.FromObject<IgnoreTestSchema>();
             schemaProvider.Type<Album>().RemoveField("old");
             schemaProvider.AddMutationsFrom<IgnoreTestMutations>();
             var schema = schemaProvider.ToGraphQLSchemaString();
@@ -177,7 +177,7 @@ namespace EntityGraphQL.Tests
         [Fact]
         public void TestNullableEnumInType()
         {
-            var schemaProvider = SchemaBuilder.FromObject<IgnoreTestSchema>(false);
+            var schemaProvider = SchemaBuilder.FromObject<IgnoreTestSchema>();
             var schema = schemaProvider.ToGraphQLSchemaString();
             // this exists as it is not null
             Assert.Contains(@"type Artist {
@@ -189,7 +189,7 @@ namespace EntityGraphQL.Tests
         [Fact]
         public void TestNotNullArgs()
         {
-            var schemaProvider = SchemaBuilder.FromObject<IgnoreTestSchema>(false);
+            var schemaProvider = SchemaBuilder.FromObject<IgnoreTestSchema>();
             schemaProvider.AddMutationsFrom<IgnoreTestMutations>();
             var schema = schemaProvider.ToGraphQLSchemaString();
             // this exists as it is not null
@@ -199,7 +199,7 @@ namespace EntityGraphQL.Tests
         [Fact]
         public void TestNotNullEnumerableElementByDefault()
         {
-            var schemaProvider = SchemaBuilder.FromObject<IgnoreTestSchema>(false);
+            var schemaProvider = SchemaBuilder.FromObject<IgnoreTestSchema>();
             schemaProvider.AddMutationsFrom<IgnoreTestMutations>();
             var schema = schemaProvider.ToGraphQLSchemaString();
             // this exists as it is not null
@@ -208,7 +208,7 @@ namespace EntityGraphQL.Tests
         [Fact]
         public void TestNullEnumerableElement()
         {
-            var schemaProvider = SchemaBuilder.FromObject<IgnoreTestSchema>(false);
+            var schemaProvider = SchemaBuilder.FromObject<IgnoreTestSchema>();
             schemaProvider.AddMutationsFrom<IgnoreTestMutations>();
             var schema = schemaProvider.ToGraphQLSchemaString();
             // this exists as it is not null
@@ -218,7 +218,7 @@ namespace EntityGraphQL.Tests
         [Fact]
         public void TestDeprecatedField()
         {
-            var schemaProvider = SchemaBuilder.FromObject<IgnoreTestSchema>(false);
+            var schemaProvider = SchemaBuilder.FromObject<IgnoreTestSchema>();
             var schema = schemaProvider.ToGraphQLSchemaString();
             // this exists as it is not null
             Assert.Contains("old: Int! @deprecated(reason: \"because\")", schema);
@@ -226,7 +226,7 @@ namespace EntityGraphQL.Tests
         [Fact]
         public void TestDeprecatedMutationField()
         {
-            var schemaProvider = SchemaBuilder.FromObject<IgnoreTestSchema>(false);
+            var schemaProvider = SchemaBuilder.FromObject<IgnoreTestSchema>();
             schemaProvider.AddMutationsFrom<IgnoreTestMutations>();
             var schema = schemaProvider.ToGraphQLSchemaString();
             // this exists as it is not null
@@ -235,7 +235,7 @@ namespace EntityGraphQL.Tests
         [Fact]
         public void TestDeprecatedEnumField()
         {
-            var schemaProvider = SchemaBuilder.FromObject<IgnoreTestSchema>(false);
+            var schemaProvider = SchemaBuilder.FromObject<IgnoreTestSchema>();
             var schema = schemaProvider.ToGraphQLSchemaString();
             // this exists as it is not null
             Assert.Contains("Obsolete @deprecated(reason: \"This is an obsolete genre\")", schema);
@@ -244,7 +244,7 @@ namespace EntityGraphQL.Tests
         [Fact]
         public void TestNullableRefTypeMutationField()
         {
-            var schemaProvider = SchemaBuilder.FromObject<IgnoreTestSchema>(false);
+            var schemaProvider = SchemaBuilder.FromObject<IgnoreTestSchema>();
             schemaProvider.AddMutationsFrom<NullableRefTypeMutations>();
             var schema = schemaProvider.ToGraphQLSchemaString();
             // this exists as it is not null
@@ -313,7 +313,7 @@ namespace EntityGraphQL.Tests
         [Fact]
         public void TestAbstractClassToGraphQLSchemaString()
         {
-            var schemaProvider = SchemaBuilder.FromObject<AbstractClassTestSchema>(false);
+            var schemaProvider = SchemaBuilder.FromObject<AbstractClassTestSchema>();
 
             schemaProvider.AddType<AbstractClassTestSchema.Dog>("Dogs are animals").ImplementAllBaseTypes().AddAllFields();
             schemaProvider.AddType<AbstractClassTestSchema.Cat>("Cats are animals").Implements<Animal>().AddAllFields();
@@ -333,7 +333,7 @@ namespace EntityGraphQL.Tests
         [Fact]
         public void TestMultipleInheritanceToGraphQLSchemaString()
         {
-            var schemaProvider = SchemaBuilder.FromObject<AbstractClassTestSchema>(false);
+            var schemaProvider = SchemaBuilder.FromObject<AbstractClassTestSchema>();
 
             schemaProvider.AddType<AbstractClassTestSchema.ISwim>("").AddAllFields();
             schemaProvider.AddType<AbstractClassTestSchema.Dog>("Dogs are animals").ImplementAllBaseTypes().AddAllFields();
@@ -353,7 +353,7 @@ namespace EntityGraphQL.Tests
         [Fact]
         public void TestNoMutations()
         {
-            var schemaProvider = SchemaBuilder.FromObject<AbstractClassTestSchema>(false);
+            var schemaProvider = SchemaBuilder.FromObject<AbstractClassTestSchema>();
 
             var schema = schemaProvider.ToGraphQLSchemaString();
             Assert.DoesNotContain("mutation:", schema);

--- a/src/tests/EntityGraphQL.Tests/SchemaTests/SchemaBuilderTests.cs
+++ b/src/tests/EntityGraphQL.Tests/SchemaTests/SchemaBuilderTests.cs
@@ -165,11 +165,6 @@ namespace EntityGraphQL.Tests
                     }"
             };
 
-            var context = new TestDataContext
-            {
-                Projects = new List<Project>()
-            };
-
             var res = schemaProvider.ExecuteRequest(gql, new TestSchema3(), null, null);
             Assert.Null(res.Errors);
 

--- a/src/tests/EntityGraphQL.Tests/SchemaTests/SchemaBuilderTests.cs
+++ b/src/tests/EntityGraphQL.Tests/SchemaTests/SchemaBuilderTests.cs
@@ -95,7 +95,7 @@ namespace EntityGraphQL.Tests
         public void DoesNotSupportSameFieldDifferentArguments()
         {
             // Grpahql doesn't support "field overloading"
-            var schemaProvider = SchemaBuilder.FromObject<TestSchema>(true);
+            var schemaProvider = SchemaBuilder.FromObject<TestSchema>();
             // user(id: ID) already created
             var ex = Assert.Throws<EntityQuerySchemaException>(() => schemaProvider.Query().AddField("people", new { monkey = ArgumentHelper.Required<int>() }, (ctx, param) => ctx.People.Where(u => u.Id == param.monkey).FirstOrDefault(), "Return a user by ID"));
             Assert.Equal("Field people already exists on type Query. Use ReplaceField() if this is intended.", ex.Message);

--- a/src/tests/EntityGraphQL.Tests/SerializationTests.cs
+++ b/src/tests/EntityGraphQL.Tests/SerializationTests.cs
@@ -19,7 +19,7 @@ namespace EntityGraphQL.AspNet.Tests
         [Fact]
         public void JsonNewtonsoft()
         {
-            var schemaProvider = SchemaBuilder.FromObject<TestDataContext>(false);
+            var schemaProvider = SchemaBuilder.FromObject<TestDataContext>();
             schemaProvider.AddInputType<InputObject>("InputObject", "Using an object in the arguments");
             schemaProvider.AddMutationsFrom<PeopleMutations>();
             schemaProvider.AddCustomTypeConverter(new JObjectTypeConverter());
@@ -54,7 +54,7 @@ namespace EntityGraphQL.AspNet.Tests
         public void JsonNewtonsoftArray()
         {
             // test that even though we don't know about JArray they are IEnumerable and can easily be handled
-            var schemaProvider = SchemaBuilder.FromObject<TestDataContext>(false);
+            var schemaProvider = SchemaBuilder.FromObject<TestDataContext>();
             schemaProvider.AddMutationsFrom<PeopleMutations>();
             schemaProvider.AddCustomTypeConverter(new JObjectTypeConverter());
             schemaProvider.AddCustomTypeConverter(new JTokenTypeConverter());
@@ -79,7 +79,7 @@ namespace EntityGraphQL.AspNet.Tests
         public void JsonNewtonsoftArray2()
         {
             // test that even though we don't know about JArray they are IEnumerable and can easily be handled
-            var schemaProvider = SchemaBuilder.FromObject<TestDataContext>(false);
+            var schemaProvider = SchemaBuilder.FromObject<TestDataContext>();
             schemaProvider.AddMutationsFrom<PeopleMutations>();
             schemaProvider.AddCustomTypeConverter(new JObjectTypeConverter());
             schemaProvider.AddCustomTypeConverter(new JTokenTypeConverter());
@@ -128,7 +128,7 @@ namespace EntityGraphQL.AspNet.Tests
         [Fact]
         public void TextJsonJsonElement()
         {
-            var schemaProvider = SchemaBuilder.FromObject<TestDataContext>(false);
+            var schemaProvider = SchemaBuilder.FromObject<TestDataContext>();
             schemaProvider.AddInputType<InputObject>("InputObject", "Using an object in the arguments");
             schemaProvider.AddMutationsFrom<PeopleMutations>();
             // Simulate a JSON request with System.Text.Json

--- a/src/tests/EntityGraphQL.Tests/SortTests/SortTests.cs
+++ b/src/tests/EntityGraphQL.Tests/SortTests/SortTests.cs
@@ -11,7 +11,7 @@ namespace EntityGraphQL.Tests
         [Fact]
         public void SupportUseSort()
         {
-            var schema = SchemaBuilder.FromObject<TestDataContext>(false);
+            var schema = SchemaBuilder.FromObject<TestDataContext>();
             schema.Type<TestDataContext>().GetField("people", null)
                 .UseSort();
             var gql = new QueryRequest
@@ -71,7 +71,7 @@ namespace EntityGraphQL.Tests
         [Fact]
         public void SupportUseSortSelectSortFields()
         {
-            var schema = SchemaBuilder.FromObject<TestDataContext>(false);
+            var schema = SchemaBuilder.FromObject<TestDataContext>();
             schema.Type<TestDataContext>().GetField("people", null)
                 .UseSort((Person person) => new
                 {
@@ -109,7 +109,7 @@ namespace EntityGraphQL.Tests
         [Fact]
         public void SupportUseSortDefaultWithSelectSortFields()
         {
-            var schema = SchemaBuilder.FromObject<TestDataContext>(false);
+            var schema = SchemaBuilder.FromObject<TestDataContext>();
             schema.Type<TestDataContext>().GetField("people", null)
                 .UseSort((Person person) => new
                 {
@@ -145,7 +145,7 @@ namespace EntityGraphQL.Tests
         [Fact]
         public void SupportUseSortDefault()
         {
-            var schema = SchemaBuilder.FromObject<TestDataContext>(false);
+            var schema = SchemaBuilder.FromObject<TestDataContext>();
             schema.Type<TestDataContext>().GetField("people", null)
                 .UseSort((Person person) => person.Height, SortDirectionEnum.ASC);
             var gql = new QueryRequest
@@ -173,7 +173,7 @@ namespace EntityGraphQL.Tests
         [Fact]
         public void SupportUseSortOnNonRoot()
         {
-            var schema = SchemaBuilder.FromObject<TestDataContext>(false);
+            var schema = SchemaBuilder.FromObject<TestDataContext>();
             schema.Type<Project>().GetField("tasks", null)
                 .UseSort();
             var gql = new QueryRequest
@@ -202,7 +202,7 @@ namespace EntityGraphQL.Tests
         [Fact]
         public void SupportUseSortOnNonRootVariableWithClass()
         {
-            var schema = SchemaBuilder.FromObject<TestDataContext>(false);
+            var schema = SchemaBuilder.FromObject<TestDataContext>();
             schema.Type<Project>().GetField("tasks", null)
                 .UseSort();
             var gql = new QueryRequest

--- a/src/tests/EntityGraphQL.Tests/TestAbstractDataContext.cs
+++ b/src/tests/EntityGraphQL.Tests/TestAbstractDataContext.cs
@@ -10,6 +10,14 @@ namespace EntityGraphQL.Tests
     public class TestAbstractDataContext
     {
         public List<Animal> Animals { get; set; } = new List<Animal>();
+        public List<Cat> Cats { get; set; } = new List<Cat>();
+        public List<Dog> Dogs { get; set; } = new List<Dog>();
+    }
+
+    public class TestAbstractDataContextNoAnimals
+    {
+        public List<Cat> Cats { get; set; } = new List<Cat>();
+        public List<Dog> Dogs { get; set; } = new List<Dog>();
     }
 
     public abstract class Animal


### PR DESCRIPTION
Close #157 

- [x] Move `SchemaBuilder` option parameters to an options class as they are growing long
- [x] Add new option to create interfaces etc during the reflection of `SchemaBuilder.FromObject`

