### PR TITLE
feature: Data annotations validator: validating nested objects

### DIFF
--- a/src/EntityGraphQL/Compiler/EntityGraphQLValidationException.cs
+++ b/src/EntityGraphQL/Compiler/EntityGraphQLValidationException.cs
@@ -10,7 +10,7 @@ public class EntityGraphQLValidationException : Exception
 
     public EntityGraphQLValidationException(IEnumerable<string> validationErrors)
     {
-        ValidationErrors = validationErrors.ToList();
+        ValidationErrors = validationErrors.Distinct().ToList();
     }
 
 }

--- a/src/EntityGraphQL/Compiler/EntityGraphQLValidationException.cs
+++ b/src/EntityGraphQL/Compiler/EntityGraphQLValidationException.cs
@@ -10,7 +10,7 @@ public class EntityGraphQLValidationException : Exception
 
     public EntityGraphQLValidationException(IEnumerable<string> validationErrors)
     {
-        ValidationErrors = validationErrors.Distinct().ToList();
+        ValidationErrors = validationErrors.Distinct(StringComparer.OrdinalIgnoreCase).ToList();
     }
 
 }

--- a/src/EntityGraphQL/Compiler/GqlNodes/GraphQLDirective.cs
+++ b/src/EntityGraphQL/Compiler/GqlNodes/GraphQLDirective.cs
@@ -21,13 +21,27 @@ public class GraphQLDirective
 
     public Expression? Process(ISchemaProvider schema, Expression fieldExpression, Dictionary<string, object> args, ParameterExpression? docParam, object? docVariables)
     {
-        var arguments = ArgumentUtil.BuildArgumentsObject(schema, name, null, inlineArgValues.MergeNew(args), processor.GetArguments(schema), processor.GetArgumentsType(), docParam, docVariables);
+        var validationErrors = new List<string>();
+        var arguments = ArgumentUtil.BuildArgumentsObject(schema, name, null, inlineArgValues.MergeNew(args), processor.GetArguments(schema), processor.GetArgumentsType(), docParam, docVariables, validationErrors);
+
+        if (validationErrors.Count > 0)
+        {
+            throw new EntityGraphQLValidationException(validationErrors);
+        }
+
         return processor.ProcessExpression(fieldExpression, arguments);
     }
 
     public BaseGraphQLField? ProcessField(ISchemaProvider schema, BaseGraphQLField field, IReadOnlyDictionary<string, object> args, ParameterExpression? docParam, object? docVariables)
     {
-        var arguments = ArgumentUtil.BuildArgumentsObject(schema, name, null, inlineArgValues.MergeNew(args), processor.GetArguments(schema), processor.GetArgumentsType(), docParam, docVariables);
+        var validationErrors = new List<string>();
+        var arguments = ArgumentUtil.BuildArgumentsObject(schema, name, null, inlineArgValues.MergeNew(args), processor.GetArguments(schema), processor.GetArgumentsType(), docParam, docVariables, validationErrors);
+
+        if (validationErrors.Count > 0)
+        {
+            throw new EntityGraphQLValidationException(validationErrors);
+        }
+
         return processor.ProcessField(field, arguments);
     }
 }

--- a/src/EntityGraphQL/Schema/ArgType.cs
+++ b/src/EntityGraphQL/Schema/ArgType.cs
@@ -20,9 +20,6 @@ namespace EntityGraphQL.Schema
         public MemberInfo? MemberInfo { get; internal set; }
 
         private RequiredAttribute? requiredAttribute;
-        private RangeAttribute? rangeAttribute;
-        private StringLengthAttribute? stringLengthAttribute;
-
         public bool IsRequired { get; set; }
         public Type RawType { get; private set; }
 
@@ -71,8 +68,6 @@ namespace EntityGraphQL.Schema
                 IsRequired = markedRequired
             };
 
-            arg.rangeAttribute = field.GetCustomAttribute(typeof(RangeAttribute), false) as RangeAttribute;
-            arg.stringLengthAttribute = field.GetCustomAttribute(typeof(StringLengthAttribute), false) as StringLengthAttribute;
             arg.requiredAttribute = field.GetCustomAttribute(typeof(RequiredAttribute), false) as RequiredAttribute;
             if (arg.requiredAttribute != null || GraphQLNotNullAttribute.IsMemberMarkedNotNull(field))
             {
@@ -105,12 +100,6 @@ namespace EntityGraphQL.Schema
                 validationErrors.Add(requiredAttribute.ErrorMessage != null ? $"Field '{fieldName}' - {requiredAttribute.ErrorMessage}" : $"Field '{fieldName}' - missing required argument '{Name}'");
             else if (IsRequired && val == null && DefaultValue == null)
                 validationErrors.Add($"Field '{fieldName}' - missing required argument '{Name}'");
-
-            if (rangeAttribute != null && !rangeAttribute.IsValid(val))
-                validationErrors.Add(rangeAttribute.ErrorMessage != null ? $"Field '{fieldName}' - {rangeAttribute.ErrorMessage}" : $"Field '{fieldName}' - failed the range validation.");
-
-            if (stringLengthAttribute != null && !stringLengthAttribute.IsValid(val))
-                validationErrors.Add(stringLengthAttribute.ErrorMessage != null ? $"Field '{fieldName}' - {stringLengthAttribute.ErrorMessage}" : $"Field '{fieldName}' - failed the string length validation.");
         }
     }
 }

--- a/src/EntityGraphQL/Schema/ArgType.cs
+++ b/src/EntityGraphQL/Schema/ArgType.cs
@@ -73,8 +73,6 @@ namespace EntityGraphQL.Schema
             {
                 DefaultValue = defaultValue,
                 IsRequired = markedRequired,
-                rangeAttribute = field.GetCustomAttribute(typeof(RangeAttribute), false) as RangeAttribute,
-                stringLengthAttribute = field.GetCustomAttribute(typeof(StringLengthAttribute), false) as StringLengthAttribute,
                 requiredAttribute = field.GetCustomAttribute(typeof(RequiredAttribute), false) as RequiredAttribute
             };
 

--- a/src/EntityGraphQL/Schema/BaseField.cs
+++ b/src/EntityGraphQL/Schema/BaseField.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using EntityGraphQL.Compiler;
 using EntityGraphQL.Compiler.Util;
 using EntityGraphQL.Schema.FieldExtensions;
+using EntityGraphQL.Schema.Validators;
 
 namespace EntityGraphQL.Schema
 {
@@ -56,6 +57,7 @@ namespace EntityGraphQL.Schema
             Name = name;
             ReturnType = returnType;
             Extensions = new List<IFieldExtension>();
+            AddValidator<DataAnnotationsValidator>();
         }
 
         /// <summary>

--- a/src/EntityGraphQL/Schema/Field.cs
+++ b/src/EntityGraphQL/Schema/Field.cs
@@ -149,7 +149,14 @@ namespace EntityGraphQL.Schema
             Expression? result = fieldExpression;
             if (field.ArgumentsType != null && FieldParam != null)
             {
-                argumentValues = ArgumentUtil.BuildArgumentsObject(field.Schema, field.Name, field, args, field.Arguments.Values, field.ArgumentsType, docParam, docVariables);
+
+                var validationErrors = new List<string>();
+                argumentValues = ArgumentUtil.BuildArgumentsObject(field.Schema, field.Name, field, args, field.Arguments.Values, field.ArgumentsType, docParam, docVariables, validationErrors);
+
+                if (validationErrors.Count > 0)
+                {
+                    throw new EntityGraphQLValidationException(validationErrors);
+                }
             }
             if (Extensions.Count > 0)
             {

--- a/src/EntityGraphQL/Schema/Field.cs
+++ b/src/EntityGraphQL/Schema/Field.cs
@@ -147,16 +147,10 @@ namespace EntityGraphQL.Schema
         {
             object? argumentValues = null;
             Expression? result = fieldExpression;
+            var validationErrors = new List<string>();
             if (field.ArgumentsType != null && FieldParam != null)
             {
-
-                var validationErrors = new List<string>();
                 argumentValues = ArgumentUtil.BuildArgumentsObject(field.Schema, field.Name, field, args, field.Arguments.Values, field.ArgumentsType, docParam, docVariables, validationErrors);
-
-                if (validationErrors.Count > 0)
-                {
-                    throw new EntityGraphQLValidationException(validationErrors);
-                }
             }
             if (Extensions.Count > 0)
             {
@@ -175,9 +169,16 @@ namespace EntityGraphQL.Schema
                     m(invokeContext);
                     argumentValues = invokeContext.Arguments;
                 }
-                if (invokeContext.Errors.Any())
-                    throw new EntityGraphQLValidationException(invokeContext.Errors);
+
+                validationErrors.AddRange(invokeContext.Errors);                
             }
+
+
+            if (validationErrors.Count > 0)
+            {
+                throw new EntityGraphQLValidationException(validationErrors);
+            }
+
             return (result, argumentValues);
         }
 

--- a/src/EntityGraphQL/Schema/MutationField.cs
+++ b/src/EntityGraphQL/Schema/MutationField.cs
@@ -104,7 +104,7 @@ namespace EntityGraphQL.Schema
 
             if (argumentValidators.Count > 0)
             {
-                var validatorContext = new ArgumentValidatorContext(this, argInstance);
+                var validatorContext = new ArgumentValidatorContext(this, argInstance ?? allArgs);
                 foreach (var argValidator in argumentValidators)
                 {
                     argValidator(validatorContext);

--- a/src/EntityGraphQL/Schema/MutationField.cs
+++ b/src/EntityGraphQL/Schema/MutationField.cs
@@ -104,7 +104,7 @@ namespace EntityGraphQL.Schema
 
             if (argumentValidators.Count > 0)
             {
-                var validatorContext = new ArgumentValidatorContext(this, argInstance ?? allArgs);
+                var validatorContext = new ArgumentValidatorContext(this, argInstance ?? allArgs, method);
                 foreach (var argValidator in argumentValidators)
                 {
                     argValidator(validatorContext);

--- a/src/EntityGraphQL/Schema/MutationField.cs
+++ b/src/EntityGraphQL/Schema/MutationField.cs
@@ -68,10 +68,11 @@ namespace EntityGraphQL.Schema
             // args in the mutation method
             var allArgs = new List<object>();
             object? argInstance = null;
+            var validationErrors = new List<string>();
 
             if (Arguments.Count > 0)
             {
-                argInstance = ArgumentUtil.BuildArgumentsObject(Schema, Name, this, gqlRequestArgs ?? new Dictionary<string, object>(), Arguments.Values, ArgumentsType, variableParameter, docVariables);
+                argInstance = ArgumentUtil.BuildArgumentsObject(Schema, Name, this, gqlRequestArgs ?? new Dictionary<string, object>(), Arguments.Values, ArgumentsType, variableParameter, docVariables, validationErrors);
             }
 
             // add parameters and any DI services
@@ -109,10 +110,15 @@ namespace EntityGraphQL.Schema
                     argValidator(validatorContext);
                     argInstance = validatorContext.Arguments;
                 }
-                if (validatorContext.Errors.Count > 0)
+                if (validatorContext.Errors != null && validatorContext.Errors.Count > 0)
                 {
-                    throw new EntityGraphQLValidationException(validatorContext.Errors);
+                    validationErrors.AddRange(validatorContext.Errors);
                 }
+            }
+
+            if (validationErrors.Count > 0)
+            {
+                throw new EntityGraphQLValidationException(validationErrors.Distinct());
             }
 
             object? instance = null;

--- a/src/EntityGraphQL/Schema/MutationField.cs
+++ b/src/EntityGraphQL/Schema/MutationField.cs
@@ -118,7 +118,7 @@ namespace EntityGraphQL.Schema
 
             if (validationErrors.Count > 0)
             {
-                throw new EntityGraphQLValidationException(validationErrors.Distinct());
+                throw new EntityGraphQLValidationException(validationErrors);
             }
 
             object? instance = null;

--- a/src/EntityGraphQL/Schema/Validators/ArgumentValidatorContext.cs
+++ b/src/EntityGraphQL/Schema/Validators/ArgumentValidatorContext.cs
@@ -1,19 +1,27 @@
 using System.Collections.Generic;
+using System.Reflection;
 
 namespace EntityGraphQL.Schema;
 public class ArgumentValidatorContext
 {
     private readonly List<string> errors = new();
-    public ArgumentValidatorContext(IField field, object? argumentValues)
+    public ArgumentValidatorContext(IField field, object? argumentValues, MethodInfo? method = null)
     {
         Field = field;
         Arguments = argumentValues;
+        Method = method;
     }
 
     /// <summary>
     /// The value of the argments for the field.
     /// </summary>
     public object? Arguments { get; set; }
+
+    /// <summary>
+    /// The method (mutation) about to be called
+    /// </summary>
+    public MethodInfo? Method { get; }
+
     /// <summary>
     /// Information about the field as defined in the schema.
     /// </summary>

--- a/src/EntityGraphQL/Schema/Validators/DataAnnotationsValidator.cs
+++ b/src/EntityGraphQL/Schema/Validators/DataAnnotationsValidator.cs
@@ -1,0 +1,83 @@
+﻿using EntityGraphQL.Extensions;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace EntityGraphQL.Schema.Validators
+{
+    public class DataAnnotationsValidator : IArgumentValidator
+    {
+        public Task ValidateAsync(ArgumentValidatorContext context)
+        {
+            ValidateObjectRecursive(context, context.Arguments);
+            return Task.CompletedTask;
+        }
+
+        private void ValidateObjectRecursive(ArgumentValidatorContext context, object? obj)
+        {
+            if (obj == null)
+                return;
+
+            var results = new List<ValidationResult>();
+            if (!Validator.TryValidateObject(obj, new ValidationContext(obj), results, true))
+            {
+                results.ForEach(result =>
+                {
+                    if (!string.IsNullOrWhiteSpace(result.ErrorMessage))
+                    {
+                        context.AddError(result.ErrorMessage);
+                    }
+                });
+            }
+
+            var properties = obj!.GetType().GetProperties().Where(prop => prop.CanRead
+                && prop.GetIndexParameters().Length == 0).ToList();
+
+            foreach (var property in properties)
+            {
+                var value = property.GetValue(obj, null);
+
+                if (property.PropertyType == typeof(string) || property.PropertyType.IsValueType)
+                {
+                    continue;
+                }
+
+                if (property.PropertyType.GetGenericArguments().Any() && property.PropertyType.GetGenericTypeDefinition() == typeof(RequiredField<>))
+                {
+                    if(value == null)
+                    {
+                        context.AddError($"missing required argument '{property.Name}'");
+                    }
+                    continue;
+                }
+
+                if (property.PropertyType.GetGenericArguments().Any() && property.PropertyType.GetGenericTypeDefinition() == typeof(EntityQueryType<>))
+                {
+                    continue;
+                }
+
+                if (value == null)
+                {
+                    continue;
+                }
+
+                if (value is IEnumerable asEnumerable)
+                {
+                    foreach (var enumObj in asEnumerable)
+                    {
+                        ValidateObjectRecursive(context, enumObj);
+                    }
+                }
+                else
+                {
+                    ValidateObjectRecursive(context, value);
+                }
+            }
+        }
+    }
+}

--- a/src/tests/EntityGraphQL.Tests/MutationTests/MutationTests.cs
+++ b/src/tests/EntityGraphQL.Tests/MutationTests/MutationTests.cs
@@ -500,6 +500,47 @@ namespace EntityGraphQL.Tests
             Assert.Equal("Field 'needsGuid' - missing required argument 'id'", results.Errors[0].Message);
         }
 
+
+
+        [Fact]
+        public void TestRegExValidationAttribute()
+        {
+            var schemaProvider = SchemaBuilder.FromObject<TestDataContext>(false);
+            schemaProvider.AddMutationsFrom<PeopleMutations>();
+            var gql = new QueryRequest
+            {
+                Query = @"mutation {
+                regexValidation(title: ""name"" author: ""steve"" ) 
+            }",
+            };
+
+            var testSchema = new TestDataContext();
+            var results = schemaProvider.ExecuteRequest(gql, testSchema, null, null);
+            Assert.NotNull(results.Errors);
+            Assert.Single(results.Errors);
+            Assert.Equal("Field 'regexValidation' - Title does not match required format", results.Errors[0].Message);
+        }
+
+        [Fact]
+        public void TestRegExValidationAttribute2()
+        {
+            var schemaProvider = SchemaBuilder.FromObject<TestDataContext>(false);
+            schemaProvider.AddMutationsFrom<PeopleMutations>();
+            var gql = new QueryRequest
+            {
+                Query = @"mutation {
+                regexValidation(title: ""neme"" author: ""stave"" ) 
+            }",
+            };
+
+            var testSchema = new TestDataContext();
+            var results = schemaProvider.ExecuteRequest(gql, testSchema, null, null);
+            Assert.NotNull(results.Errors);
+            Assert.Single(results.Errors);
+            Assert.Equal("Field 'regexValidation' - Author does not match required format", results.Errors[0].Message);
+        }
+
+
         [Fact]
         public void TestNonNullIsRequired()
         {
@@ -831,7 +872,7 @@ namespace EntityGraphQL.Tests
             schemaProvider.Mutation().AddFrom<IMutations>();
 
 
-            Assert.Equal(20, schemaProvider.Mutation().SchemaType.GetFields().Count());
+            Assert.Equal(21, schemaProvider.Mutation().SchemaType.GetFields().Count());
         }
 
         public class NonAttributeMarkedMethod

--- a/src/tests/EntityGraphQL.Tests/MutationTests/MutationTests.cs
+++ b/src/tests/EntityGraphQL.Tests/MutationTests/MutationTests.cs
@@ -505,7 +505,7 @@ namespace EntityGraphQL.Tests
         [Fact]
         public void TestRegExValidationAttribute()
         {
-            var schemaProvider = SchemaBuilder.FromObject<TestDataContext>(false);
+            var schemaProvider = SchemaBuilder.FromObject<TestDataContext>();
             schemaProvider.AddMutationsFrom<PeopleMutations>();
             var gql = new QueryRequest
             {
@@ -524,7 +524,7 @@ namespace EntityGraphQL.Tests
         [Fact]
         public void TestRegExValidationAttribute2()
         {
-            var schemaProvider = SchemaBuilder.FromObject<TestDataContext>(false);
+            var schemaProvider = SchemaBuilder.FromObject<TestDataContext>();
             schemaProvider.AddMutationsFrom<PeopleMutations>();
             var gql = new QueryRequest
             {
@@ -906,7 +906,7 @@ namespace EntityGraphQL.Tests
             var schemaProvider = SchemaBuilder.FromObject<TestDataContext>();
             schemaProvider.Mutation().AddFrom<IMutations>();
 
-            Assert.Equal(23, schemaProvider.Mutation().SchemaType.GetFields().Count());
+            Assert.Equal(24, schemaProvider.Mutation().SchemaType.GetFields().Count());
         }
 
         public class NonAttributeMarkedMethod

--- a/src/tests/EntityGraphQL.Tests/MutationTests/PeopleMutations.cs
+++ b/src/tests/EntityGraphQL.Tests/MutationTests/PeopleMutations.cs
@@ -147,6 +147,15 @@ namespace EntityGraphQL.Tests
         }
 
         [GraphQLMutation]
+        public async Task<bool> regexValidation(RegexArgs args)
+        {
+            return await Task<bool>.Run(() =>
+            {
+                return true;
+            });
+        }
+
+        [GraphQLMutation]
         static public bool NullableGuidArgs(NullableGuidArgs args)
         {
             if (args.Id != null)
@@ -216,6 +225,15 @@ namespace EntityGraphQL.Tests
     public class GuidNonNullArgs
     {
         public Guid Id { get; set; }
+    }
+
+    [MutationArguments]
+    public class RegexArgs
+    {
+        [RegularExpression("[^a]+", ErrorMessage = "Title does not match required format")]
+        public string Title { get; set; }
+        [RegularExpression("steve", ErrorMessage = "Author does not match required format")]
+        public string Author { get; set; }
     }
     public class InputObject
     {

--- a/src/tests/EntityGraphQL.Tests/ValidationTests.cs
+++ b/src/tests/EntityGraphQL.Tests/ValidationTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Linq;
 using System.Linq.Expressions;
@@ -14,7 +15,7 @@ public class ValidationTests
     public void TestValidationAttributesOnMutationArgs()
     {
         var schema = SchemaBuilder.FromObject<ValidationTestsContext>();
-        schema.AddMutationsFrom<ValidationTestsMutations>();
+        schema.AddMutationsFrom<ValidationTestsMutations>(true);
         var gql = new QueryRequest
         {
             Query = @"mutation Mutate {
@@ -33,6 +34,28 @@ public class ValidationTests
         Assert.Equal("Field 'addMovie' - Genre must be specified", results.Errors[2].Message);
         Assert.Equal("Field 'addMovie' - Price must be between $1 and $100", results.Errors[3].Message);
         Assert.Equal("Field 'addMovie' - Rating must be less than 5 characters", results.Errors[4].Message);
+    }
+
+    [Fact]
+    public void TestValidationAttributesOnNestedMutationArgs()
+    {
+        var schema = SchemaBuilder.FromObject<ValidationTestsContext>();
+        schema.AddMutationsFrom<ValidationTestsMutations>(true);
+        var gql = new QueryRequest
+        {
+            Query = @"mutation Mutate {
+                addMovie(title: ""movie name"" releaseDate: ""2020-01-01"" genre: ""Comedy"" price: 99 rating: ""short"", cast: [{ actor: """" character: ""Barney"" }]) {
+                    id
+                }
+            }",
+        };
+
+        var testContext = new ValidationTestsContext();
+        var results = schema.ExecuteRequest(gql, testContext, null, null);
+        Assert.NotNull(results.Errors);
+        Assert.Equal(2, results.Errors.Count);
+        Assert.Equal("Field 'addMovie' - Actor is required", results.Errors[0].Message);
+        Assert.Equal("Field 'addMovie' - Character must be less than 5 characters", results.Errors[1].Message);
     }
 
     [Fact]
@@ -420,6 +443,17 @@ internal class MovieArg
 
     [StringLength(5, ErrorMessage = "Rating must be less than 5 characters")]
     public string Rating { get; set; }
+
+    public IList<CastMemberArg> Cast { get; set; }
+}
+
+internal class CastMemberArg
+{
+    [Required(ErrorMessage = "Actor is required")]
+    [StringLength(20, ErrorMessage = "Actor Name must be less than 20 characters")]
+    public string Actor { get; set; }
+    [StringLength(5, ErrorMessage = "Character must be less than 5 characters")]
+    public string Character { get; set; }
 }
 
 [MutationArguments]

--- a/src/tests/EntityGraphQL.Tests/ValidationTests.cs
+++ b/src/tests/EntityGraphQL.Tests/ValidationTests.cs
@@ -19,7 +19,7 @@ public class ValidationTests
         var gql = new QueryRequest
         {
             Query = @"mutation Mutate {
-                addMovie(price: 150 rating: ""this is too long"") {
+                addMovie(price: 150 rating: ""this is too long"", cast: [{ actor: """" character: ""Barney"" }]) {
                     id
                 }
             }",
@@ -28,12 +28,14 @@ public class ValidationTests
         var testContext = new ValidationTestsContext();
         var results = schema.ExecuteRequest(gql, testContext, null, null);
         Assert.NotNull(results.Errors);
-        Assert.Equal(5, results.Errors.Count);
+        Assert.Equal(7, results.Errors.Count);
         Assert.Equal("Field 'addMovie' - Title is required", results.Errors[0].Message);
         Assert.Equal("Field 'addMovie' - Date is required", results.Errors[1].Message);
         Assert.Equal("Field 'addMovie' - Genre must be specified", results.Errors[2].Message);
         Assert.Equal("Field 'addMovie' - Price must be between $1 and $100", results.Errors[3].Message);
         Assert.Equal("Field 'addMovie' - Rating must be less than 5 characters", results.Errors[4].Message);
+        Assert.Equal("Field 'addMovie' - Actor is required", results.Errors[5].Message);
+        Assert.Equal("Field 'addMovie' - Character must be less than 5 characters", results.Errors[6].Message);
     }
 
     [Fact]

--- a/src/tests/EntityGraphQL.Tests/ValidationTests.cs
+++ b/src/tests/EntityGraphQL.Tests/ValidationTests.cs
@@ -168,9 +168,9 @@ public class ValidationTests
         var results = schema.ExecuteRequest(gql, testContext, null, null);
         Assert.NotNull(results.Errors);
         Assert.Equal(3, results.Errors.Count);
-        Assert.Equal("Field 'movies' - Title must be less than 5 characters", results.Errors[0].Message);
-        Assert.Equal("Field 'movies' - Price must be between $1 and $100", results.Errors[1].Message);
-        Assert.Equal("Field 'movies' - Genre is required", results.Errors[2].Message);
+        Assert.Equal("Field 'movies' - Genre is required", results.Errors[0].Message);
+        Assert.Equal("Field 'movies' - Title must be less than 5 characters", results.Errors[1].Message);
+        Assert.Equal("Field 'movies' - Price must be between $1 and $100", results.Errors[2].Message);        
     }
 
     [Fact]


### PR DESCRIPTION
Had a bit of a go at making validation of nested objects and lists working.

* Implemented IArgumentValidator with a basic class that does recursive validation
* Auto register this validator type with BaseField
* should cover all validation attribute types not just the ones you had before

I played around with removing the validation attributes from ArgTypes since it should cover the same things however

* couldn't replace required field validation on non nullable fields as it didn't have access to raw arguments (eg it was getting an object with default values which are technically valid), could probably remove the range/length attribute checking from argtype though just means they'd be caught later
* couldn't find a nice way to remove the throw statements from ArgumentUtil as it would allow all fields to be validated instead of bailing early for certain types of errors (eg required fields always checked first as per above).

