### PR TITLE
bugfix: support for nested nullable objects

### DIFF
--- a/src/EntityGraphQL/Compiler/Util/ExpressionUtil.cs
+++ b/src/EntityGraphQL/Compiler/Util/ExpressionUtil.cs
@@ -78,6 +78,12 @@ namespace EntityGraphQL.Compiler.Util
             if (typeof(JsonElement).IsAssignableFrom(fromType))
             {
                 var jsonEle = (JsonElement)value;
+                
+                if (jsonEle.ValueKind == JsonValueKind.Null)
+                {
+                    return null;
+                }
+                
                 if (jsonEle.ValueKind == JsonValueKind.Object)
                 {
                     value = Activator.CreateInstance(toType);

--- a/src/tests/EntityGraphQL.Tests/MutationTests/PeopleMutations.cs
+++ b/src/tests/EntityGraphQL.Tests/MutationTests/PeopleMutations.cs
@@ -221,6 +221,7 @@ namespace EntityGraphQL.Tests
     {
         public string Name { get; set; }
         public string LastName { get; set; }
+        public DateTime? Birthday { get; set; }
     }
     public class InputObjectId
     {

--- a/src/tests/EntityGraphQL.Tests/SerializationTests.cs
+++ b/src/tests/EntityGraphQL.Tests/SerializationTests.cs
@@ -30,11 +30,11 @@ namespace EntityGraphQL.AspNet.Tests
             {
                 ""query"": ""mutation AddPerson($names: InputObject) {
                     addPersonInput(nameInput: $names) {
-                        id name lastName
+                        id name lastName birthday
                     }
                 }"",
                 ""variables"": {
-                    ""names"": { ""name"": ""Lisa"", ""lastName"": ""Simpson"" }
+                    ""names"": { ""name"": ""Lisa"", ""lastName"": ""Simpson"", ""birthDate"": null  }
                 }
             }");
             var result = schemaProvider.ExecuteRequest(gql, new TestDataContext(), null, null);
@@ -42,12 +42,13 @@ namespace EntityGraphQL.AspNet.Tests
             dynamic addPersonResult = result.Data!["addPersonInput"]!;
             // we only have the fields requested
             var resultFields = ((List<FieldInfo>)Enumerable.ToList(addPersonResult.GetType().GetFields())).Select(f => f.Name);
-            Assert.Equal(3, resultFields.Count());
+            Assert.Equal(4, resultFields.Count());
             Assert.Contains("id", resultFields);
             Assert.Equal(0, addPersonResult.id);
             Assert.Contains("name", resultFields);
             Assert.Equal("Lisa", addPersonResult.name);
             Assert.Equal("Simpson", addPersonResult.lastName);
+            Assert.Equal(null, addPersonResult.birthday);
         }
 
         [Fact]
@@ -134,9 +135,9 @@ namespace EntityGraphQL.AspNet.Tests
             // Simulate a JSON request with System.Text.Json
             // variables will end up having JsonElements
             var q = @"{
-                ""query"": ""mutation AddPerson($names: InputObject) { addPersonInput(nameInput: $names) { id name lastName } }"",
+                ""query"": ""mutation AddPerson($names: InputObject) { addPersonInput(nameInput: $names) { id name lastName birthday } }"",
                 ""variables"": {
-                    ""names"": { ""name"": ""Lisa"", ""lastName"": ""Simpson"" }
+                    ""names"": { ""name"": ""Lisa"", ""lastName"": ""Simpson"", ""birthDay"": null }
                 }
             }";
             var gql = System.Text.Json.JsonSerializer.Deserialize<QueryRequest>(q, new JsonSerializerOptions { PropertyNameCaseInsensitive = true })!;
@@ -145,12 +146,13 @@ namespace EntityGraphQL.AspNet.Tests
             dynamic addPersonResult = result.Data!["addPersonInput"]!;
             // we only have the fields requested
             var resultFields = ((List<FieldInfo>)Enumerable.ToList(addPersonResult.GetType().GetFields())).Select(f => f.Name);
-            Assert.Equal(3, resultFields.Count());
+            Assert.Equal(4, resultFields.Count());
             Assert.Contains("id", resultFields);
             Assert.Equal(0, addPersonResult.id);
             Assert.Contains("name", resultFields);
             Assert.Equal("Lisa", addPersonResult.name);
             Assert.Equal("Simpson", addPersonResult.lastName);
+            Assert.Equal(null, addPersonResult.birthday);
         }
 
     }


### PR DESCRIPTION
If a property in a nested object is nullable

eg Birthdate in below example

```
 var body = @"{
                ""query"": ""mutation AddPerson($names: InputObject){ addPersonInput(nameInput: $names) { id name lastName } }"",
                ""variables"": { ""names"": { ""name"": ""Lisa"", ""lastName"": ""Simpson"", ""Birthdate"": null } }
            }";
```

ExpressionUtil fails to convert it as it defaults it back to empty string then can't convert it to DateTime?


Pretty sure I'd submitted this fix before, but maybe it was a tag along in one of the PRs that got scrapped.
