### PR TITLE
bugfix: add != to filter language, fix operator precedence

### DIFF
--- a/docs/content/field-extensions/02-filtering.md
+++ b/docs/content/field-extensions/02-filtering.md
@@ -89,6 +89,7 @@ The expression language supports the following operators:
 - `%` - Mod
 - `^` - Power
 - `==` - Equals
+- `!=` - Not Equals
 - `<=` - Less than or equal to
 - `>=` - Greater than or equal to
 - `<` - Less than

--- a/src/EntityGraphQL/Compiler/Grammer/EntityQL.g4
+++ b/src/EntityGraphQL/Compiler/Grammer/EntityQL.g4
@@ -3,7 +3,7 @@ grammar EntityQL;
 // Core building blocks
 ID: [a-z_A-Z]+ [a-z_A-Z0-9-]*;
 DIGIT: [0-9];
-STRING_CHARS: [a-zA-Z0-9 \t`~!@#$%^&*()_+={}|\\:\"'\u005B\u005D;<>?,./-];
+STRING_CHARS: [a-zA-Z0-9 \t`~!@#$%^&*()_+={}|\\:"'\u005B\u005D;<>?,./-];
 
 // identity includes keywords too
 identity: ID
@@ -38,13 +38,16 @@ operator: '-'
 	| '^'
 	| '*'
 	| '=='
+	| '!='
 	| '<='
 	| '>='
 	| '<'
 	| '>'
-	| '/'
-	| 'or'
-	| '||'
+	| '/';
+
+logicOperator:
+	'or'
+	| '||' 
 	| 'and'
 	| '&&';
 
@@ -52,8 +55,9 @@ expression:
 	'if ' (' ' | '\t')* test = expression (' ' | '\t')* 'then ' (' ' | '\t')* ifTrue = expression (' ' | '\t')* 'else ' (' ' | '\t')* ifFalse = expression # ifThenElse
 	| test = expression ' '* '?' ' '* ifTrue = expression ' '* ':' ' '* ifFalse = expression #ifThenElseInline
 	| left = expression ' '* op = operator ' '* right = expression	# binary
+	| left = expression ' '* op = logicOperator ' '* right = expression	# logic
 	| '(' body = expression ')'										# expr
 	| callPath														# callOrId
-	| constant														# const;
-
+	| constant														# const; 
+	 
 eqlStart: expression;

--- a/src/EntityGraphQL/EntityGraphQL.csproj
+++ b/src/EntityGraphQL/EntityGraphQL.csproj
@@ -30,13 +30,13 @@
     <PackageReference Include="HotChocolate.Language" Version="12.7.0" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="../../README.md" Pack="true" PackagePath=""/>
+    <None Include="../../README.md" Pack="true" PackagePath="" />
   </ItemGroup>
   <ItemGroup>
     <Antlr4 Update="Compiler/Grammer/EntityQL.g4">
       <Generator>MSBuild:Compile</Generator>
       <CustomToolNamespace>EntityQL.Grammer</CustomToolNamespace>
-      <Listener>False</Listener>
+      <Listener>false</Listener>
       <Visitor>True</Visitor>
     </Antlr4>
   </ItemGroup>

--- a/src/tests/EntityGraphQL.Tests/EntityQuery/GraphQLEntityQueryExtensionTests.cs
+++ b/src/tests/EntityGraphQL.Tests/EntityQuery/GraphQLEntityQueryExtensionTests.cs
@@ -161,6 +161,70 @@ namespace EntityGraphQL.Tests
             var user = Enumerable.First(users);
             Assert.Equal("2", user.field2);
         }
+
+        [Fact]
+        public void SupportUseFilterWithOrStatement()
+        {
+            var schema = SchemaBuilder.FromObject<TestDataContext>(false);
+            schema.Type<TestDataContext>().GetField("users", null)
+                .UseFilter();
+            var gql = new QueryRequest
+            {
+                Query = @"query Query($filter: String!) {
+                    users(filter: $filter) { field2 }
+                }",
+                Variables = new QueryVariables { { "filter", "field2 == \"2\" or field2 == \"3\"" } }
+            };
+            var tree = schema.ExecuteRequest(gql, new TestDataContext().FillWithTestData(), null, null);
+            Assert.Null(tree.Errors);
+            dynamic users = ((IDictionary<string, object>)tree.Data)["users"];
+            Assert.Equal(1, Enumerable.Count(users));
+            var user = Enumerable.First(users);
+            Assert.Equal("2", user.field2);
+        }
+
+        [Fact]
+        public void SupportUseFilterWithAndStatement()
+        {
+            var schema = SchemaBuilder.FromObject<TestDataContext>(false);
+            schema.Type<TestDataContext>().GetField("users", null)
+                .UseFilter();
+            var gql = new QueryRequest
+            {
+                Query = @"query Query($filter: String!) {
+                    users(filter: $filter) { field2 }
+                }",
+                Variables = new QueryVariables { { "filter", "field2 == \"2\" and field2 == \"2\"" } }
+            };
+            var tree = schema.ExecuteRequest(gql, new TestDataContext().FillWithTestData(), null, null);
+            Assert.Null(tree.Errors);
+            dynamic users = ((IDictionary<string, object>)tree.Data)["users"];
+            Assert.Equal(1, Enumerable.Count(users));
+            var user = Enumerable.First(users);
+            Assert.Equal("2", user.field2);
+        }
+
+        [Fact]
+        public void SupportUseFilterWithnotEqualStatement()
+        {
+            var schema = SchemaBuilder.FromObject<TestDataContext>(false);
+            schema.Type<TestDataContext>().GetField("users", null)
+                .UseFilter();
+            var gql = new QueryRequest
+            {
+                Query = @"query Query($filter: String!) {
+                    users(filter: $filter) { field2 }
+                }",
+                Variables = new QueryVariables { { "filter", "field2 != \"3\"" } }
+            };
+            var tree = schema.ExecuteRequest(gql, new TestDataContext().FillWithTestData(), null, null);
+            Assert.Null(tree.Errors);
+            dynamic users = ((IDictionary<string, object>)tree.Data)["users"];
+            Assert.Equal(1, Enumerable.Count(users));
+            var user = Enumerable.First(users);
+            Assert.Equal("2", user.field2);
+        }
+
         [Fact]
         public void SupportUseFilterOnNonRoot()
         {


### PR DESCRIPTION
small tweaks to filter language 

support for != operator

split logic operators out so precedence is correct

eg you can now do

field2 == "2" or field2 == "2"

instead of just 

(field2 == "2") or (field2 == "2")