### PR TITLE
PoC: Summarize Field Extension

### DIFF
--- a/src/EntityGraphQL/Compiler/Util/ExpressionUtil.cs
+++ b/src/EntityGraphQL/Compiler/Util/ExpressionUtil.cs
@@ -521,7 +521,7 @@ namespace EntityGraphQL.Compiler.Util
             return mi;
         }
 
-        private static Expression CreateNewExpression(string fieldDescription, Dictionary<string, Expression> fieldExpressions)
+        public static Expression CreateNewExpression(string fieldDescription, Dictionary<string, Expression> fieldExpressions)
         {
             var fieldExpressionsByName = new Dictionary<string, Expression>();
             foreach (var item in fieldExpressions)

--- a/src/EntityGraphQL/Schema/FieldExtensions/Summarize/SummarizeArgs.cs
+++ b/src/EntityGraphQL/Schema/FieldExtensions/Summarize/SummarizeArgs.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace EntityGraphQL.Schema.FieldExtensions
+{
+    public class SummarizeInput
+    {
+        public List<string>? GroupBy { get; set; } = new List<string>();
+    }
+}

--- a/src/EntityGraphQL/Schema/FieldExtensions/Summarize/SummarizeExtension.cs
+++ b/src/EntityGraphQL/Schema/FieldExtensions/Summarize/SummarizeExtension.cs
@@ -1,0 +1,82 @@
+﻿using EntityGraphQL.Compiler;
+using EntityGraphQL.Compiler.Util;
+using EntityGraphQL.Extensions;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Text;
+
+namespace EntityGraphQL.Schema.FieldExtensions
+{
+    public class SummarizeExtension : BaseFieldExtension
+    {
+        private Type? listType;
+        private Type? methodType;
+        //private Func<string, string>? fieldNamer;
+
+        public SummarizeExtension()
+        {
+        }
+
+        public override void Configure(ISchemaProvider schema, IField field)
+        {
+            if (field.ResolveExpression == null)
+                throw new EntityGraphQLCompilerException($"SortExtension requires a Resolve function set on the field");
+
+            if (!field.ResolveExpression.Type.IsEnumerableOrArray())
+                throw new ArgumentException($"Expression for field {field.Name} must be a collection to use SortExtension. Found type {field.ReturnType.TypeDotnet}");
+
+            listType = field.ReturnType.TypeDotnet.GetEnumerableOrArrayType()!;
+
+            methodType = typeof(IQueryable).IsAssignableFrom(field.ReturnType.TypeDotnet) ?
+                typeof(Queryable) : typeof(Enumerable);
+
+
+            var summaryTypeName = $"{listType.Name}Summary";
+            ISchemaType summarySchemaType;
+            var type = typeof(Summary<>).MakeGenericType(listType);
+
+            if (!schema.HasType(summaryTypeName))
+            {
+                var isQueryable = typeof(IQueryable).IsAssignableFrom(field.ResolveExpression.Type);
+                var queryableType = isQueryable ? typeof(Queryable) : typeof(Enumerable);
+
+                summarySchemaType = schema.AddType(type, summaryTypeName, $"Aggregate data for {listType}").AddAllFields();
+                
+                summarySchemaType.GetField("count", null).UpdateExpression(
+                    Expression.Call(queryableType, "Count", new Type[] { listType! }, field.ResolveExpression)
+                );
+
+                //summarySchemaType.GetField("max", null).UpdateExpression(
+                //    Expression.Lambda(
+                //        Expression.MemberInit(Expression.New(listType.GetConstructor(Type.EmptyTypes))),
+                //        Expression.Parameter(listType)
+                //    )
+                //    //Expression.Call(queryableType, "Count", new Type[] { listType! }, field.ResolveExpression)
+                //);
+            }
+            else
+            {
+                summarySchemaType = schema.GetSchemaType(summaryTypeName, null);
+            }
+
+            var gqlTypeInfo = new GqlTypeInfo(() => summarySchemaType, type);
+
+
+            var contextParam = Expression.Parameter(listType);
+            var expression = Expression.Lambda(Expression.MemberInit(Expression.New(type.GetConstructor(Type.EmptyTypes))), contextParam);
+            
+            //todo argsType: new SummarizeInput()
+            var schemaField = new Field(schema, "summarize", expression, "", null, gqlTypeInfo, null);
+
+            var schemaType = schema.GetSchemaType(listType, null);
+            schemaType.AddField(schemaField);
+        }
+
+        public override Expression? GetExpression(IField field, Expression expression, ParameterExpression? argExpression, dynamic? arguments, Expression context, IGraphQLNode? parentNode, bool servicesPass, ParameterReplacer parameterReplacer)
+        {
+            return expression;
+        }
+    }
+}

--- a/src/EntityGraphQL/Schema/FieldExtensions/Summarize/Summary.cs
+++ b/src/EntityGraphQL/Schema/FieldExtensions/Summarize/Summary.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace EntityGraphQL.Schema.FieldExtensions
+{
+    public class Summary<T>
+    {
+        public int? Count { get; set; }
+        public T? Min { get; set; }
+        public T? Max { get; set; }
+        public T? Sum { get; set; }
+        public T? Avg { get; set; }
+    }
+}

--- a/src/EntityGraphQL/Schema/FieldExtensions/Summarize/Summary.cs
+++ b/src/EntityGraphQL/Schema/FieldExtensions/Summarize/Summary.cs
@@ -10,6 +10,6 @@ namespace EntityGraphQL.Schema.FieldExtensions
         public T? Min { get; set; }
         public T? Max { get; set; }
         public T? Sum { get; set; }
-        public T? Avg { get; set; }
+        public T? Average { get; set; }
     }
 }

--- a/src/EntityGraphQL/Schema/FieldExtensions/Summarize/UseSummarizeExtension.cs
+++ b/src/EntityGraphQL/Schema/FieldExtensions/Summarize/UseSummarizeExtension.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace EntityGraphQL.Schema.FieldExtensions
+{
+    public static class UseSummarizeExtension
+    {
+        /// <summary>
+        /// Update field to implement a sort argument that takes options to sort a collection
+        /// Only call on a field that returns an IEnumerable
+        /// </summary>
+        /// <param name="field"></param>
+        /// <returns></returns>
+        public static Field UseSummarize(this Field field)
+        {
+            field.AddExtension(new SummarizeExtension());
+            return field;
+        }
+    }
+
+    public class UseSummarizeAttribute : FieldExtensionAttribute
+    {
+        public UseSummarizeAttribute() { }
+
+        public override void ApplyExtension(Field field)
+        {
+            field.UseSummarize();
+        }
+    }
+}

--- a/src/tests/EntityGraphQL.Tests/SummarizeTests/SummarizeTests.cs
+++ b/src/tests/EntityGraphQL.Tests/SummarizeTests/SummarizeTests.cs
@@ -1,0 +1,93 @@
+using Xunit;
+using System.Collections.Generic;
+using System.Linq;
+using EntityGraphQL.Schema;
+using EntityGraphQL.Schema.FieldExtensions;
+
+namespace EntityGraphQL.Tests
+{
+    public class SummarizeTests
+    {
+        [Fact]
+        public void SupportUseSummarize()
+        {
+            var schema = SchemaBuilder.FromObject<TestDataContext>(false);
+            schema.Type<TestDataContext>().GetField("people", null)
+                .UseSummarize();
+
+            Assert.True(schema.HasType("PersonSummary"));
+
+            var type = schema.GetSchemaType("PersonSummary", null);
+            Assert.True(type.HasField("sum", null));
+            Assert.True(type.HasField("max", null));
+            Assert.True(type.HasField("min", null));
+            Assert.True(type.HasField("avg", null));
+            Assert.True(type.HasField("count", null));
+        }
+
+        [Fact]
+        public void SupportUseSummaryCount()
+        {
+            var schema = SchemaBuilder.FromObject<TestDataContext>(false);
+            schema.Type<TestDataContext>().GetField("people", null)
+               .UseSummarize();
+
+            var gql = new QueryRequest
+            {
+                Query = @"query() {
+                    people() { 
+                        summarize { count }
+                    }
+                }",
+                Variables = new QueryVariables{}
+            };
+            var context = new TestDataContext().FillWithTestData();
+            context.People.Add(new Person
+            {
+                LastName = "Zoo",
+                Height = 1
+            });
+
+
+            var tree = schema.ExecuteRequest(gql, context, null, null);
+            Assert.Null(tree.Errors);
+            dynamic people = ((IDictionary<string, object>)tree.Data)["people"];
+            Assert.Equal(2, Enumerable.Count(people));
+            var person = Enumerable.First(people);
+            Assert.Equal(2, person.summarize.count);            
+        }
+
+        //[Fact]
+        //public void SupportUseSummaryMax()
+        //{
+        //    var schema = SchemaBuilder.FromObject<TestDataContext>(false);
+        //    schema.Type<TestDataContext>().GetField("people", null)
+        //       .UseSummarize();
+
+        //    var gql = new QueryRequest
+        //    {
+        //        Query = @"query() {
+        //            people() { 
+        //                summarize { max { height } }
+        //            }
+        //        }",
+        //        Variables = new QueryVariables { }
+        //    };
+        //    var context = new TestDataContext().FillWithTestData();
+        //    context.People.Add(new Person
+        //    {
+        //        LastName = "Zoo",
+        //        Height = 1
+        //    });
+
+
+        //    var tree = schema.ExecuteRequest(gql, context, null, null);
+        //    Assert.Null(tree.Errors);
+        //    dynamic people = ((IDictionary<string, object>)tree.Data)["people"];
+        //    Assert.Equal(2, Enumerable.Count(people));
+        //    var person = Enumerable.First(people);
+        //    Assert.Equal(2, person.summarize.max.height);
+        //}
+
+    }
+}

--- a/src/tests/EntityGraphQL.Tests/SummarizeTests/SummarizeTests.cs
+++ b/src/tests/EntityGraphQL.Tests/SummarizeTests/SummarizeTests.cs
@@ -21,7 +21,7 @@ namespace EntityGraphQL.Tests
             Assert.True(type.HasField("sum", null));
             Assert.True(type.HasField("max", null));
             Assert.True(type.HasField("min", null));
-            Assert.True(type.HasField("avg", null));
+            Assert.True(type.HasField("average", null));
             Assert.True(type.HasField("count", null));
         }
 
@@ -41,6 +41,38 @@ namespace EntityGraphQL.Tests
                 }",
                 Variables = new QueryVariables{}
             };
+
+            var context = new TestDataContext().FillWithTestData();
+            context.People.Add(new Person
+            {
+                LastName = "Zoo",
+                Height = 1
+            });
+
+            var tree = schema.ExecuteRequest(gql, context, null, null);
+            Assert.Null(tree.Errors);
+            dynamic people = ((IDictionary<string, object>)tree.Data)["people"];
+            Assert.Equal(2, Enumerable.Count(people));
+            var person = Enumerable.First(people);
+            Assert.Equal(2, person.summarize.count);            
+        }
+
+        [Fact]
+        public void SupportUseSummaryMax()
+        {
+            var schema = SchemaBuilder.FromObject<TestDataContext>(false);
+            schema.Type<TestDataContext>().GetField("people", null)
+               .UseSummarize();
+
+            var gql = new QueryRequest
+            {
+                Query = @"query() {
+                    people() { 
+                        summarize { max { height } }
+                    }
+                }",
+                Variables = new QueryVariables { }
+            };
             var context = new TestDataContext().FillWithTestData();
             context.People.Add(new Person
             {
@@ -54,40 +86,104 @@ namespace EntityGraphQL.Tests
             dynamic people = ((IDictionary<string, object>)tree.Data)["people"];
             Assert.Equal(2, Enumerable.Count(people));
             var person = Enumerable.First(people);
-            Assert.Equal(2, person.summarize.count);            
+            Assert.Equal(183, person.summarize.max.height);
         }
 
-        //[Fact]
-        //public void SupportUseSummaryMax()
-        //{
-        //    var schema = SchemaBuilder.FromObject<TestDataContext>(false);
-        //    schema.Type<TestDataContext>().GetField("people", null)
-        //       .UseSummarize();
+        [Fact]
+        public void SupportUseSummaryMin()
+        {
+            var schema = SchemaBuilder.FromObject<TestDataContext>(false);
+            schema.Type<TestDataContext>().GetField("people", null)
+               .UseSummarize();
 
-        //    var gql = new QueryRequest
-        //    {
-        //        Query = @"query() {
-        //            people() { 
-        //                summarize { max { height } }
-        //            }
-        //        }",
-        //        Variables = new QueryVariables { }
-        //    };
-        //    var context = new TestDataContext().FillWithTestData();
-        //    context.People.Add(new Person
-        //    {
-        //        LastName = "Zoo",
-        //        Height = 1
-        //    });
+            var gql = new QueryRequest
+            {
+                Query = @"query() {
+                    people() { 
+                        summarize { min { height } }
+                    }
+                }",
+                Variables = new QueryVariables { }
+            };
+            var context = new TestDataContext().FillWithTestData();
+            context.People.Add(new Person
+            {
+                LastName = "Zoo",
+                Height = 1
+            });
 
 
-        //    var tree = schema.ExecuteRequest(gql, context, null, null);
-        //    Assert.Null(tree.Errors);
-        //    dynamic people = ((IDictionary<string, object>)tree.Data)["people"];
-        //    Assert.Equal(2, Enumerable.Count(people));
-        //    var person = Enumerable.First(people);
-        //    Assert.Equal(2, person.summarize.max.height);
-        //}
+            var tree = schema.ExecuteRequest(gql, context, null, null);
+            Assert.Null(tree.Errors);
+            dynamic people = ((IDictionary<string, object>)tree.Data)["people"];
+            Assert.Equal(2, Enumerable.Count(people));
+            var person = Enumerable.First(people);
+            Assert.Equal(1, person.summarize.min.height);
+        }
+
+        [Fact]
+        public void SupportUseSummarySum()
+        {
+            var schema = SchemaBuilder.FromObject<TestDataContext>(false);
+            schema.Type<TestDataContext>().GetField("people", null)
+               .UseSummarize();
+
+            var gql = new QueryRequest
+            {
+                Query = @"query() {
+                    people() { 
+                        summarize { sum { height } }
+                    }
+                }",
+                Variables = new QueryVariables { }
+            };
+            var context = new TestDataContext().FillWithTestData();
+            context.People.Add(new Person
+            {
+                LastName = "Zoo",
+                Height = 1
+            });
+
+
+            var tree = schema.ExecuteRequest(gql, context, null, null);
+            Assert.Null(tree.Errors);
+            dynamic people = ((IDictionary<string, object>)tree.Data)["people"];
+            Assert.Equal(2, Enumerable.Count(people));
+            var person = Enumerable.First(people);
+            Assert.Equal(184, person.summarize.sum.height);
+        }
+
+        [Fact]
+        public void SupportUseSummaryAverage()
+        {
+            var schema = SchemaBuilder.FromObject<TestDataContext>(false);
+            schema.Type<TestDataContext>().GetField("people", null)
+               .UseSummarize();
+
+            var gql = new QueryRequest
+            {
+                Query = @"query() {
+                    people() { 
+                        summarize { average { height } }
+                    }
+                }",
+                Variables = new QueryVariables { }
+            };
+            var context = new TestDataContext().FillWithTestData();
+            context.People.Add(new Person
+            {
+                LastName = "Zoo",
+                Height = 1
+            });
+
+
+            var tree = schema.ExecuteRequest(gql, context, null, null);
+            Assert.Null(tree.Errors);
+            dynamic people = ((IDictionary<string, object>)tree.Data)["people"];
+            Assert.Equal(2, Enumerable.Count(people));
+            var person = Enumerable.First(people);
+            Assert.Equal(92, person.summarize.average.height);
+        }
 
     }
 }


### PR DESCRIPTION
first take at a new field extension for providing summary/aggregate data.

```
query() {
      people() { 
          summarize { average { height } }
      }
  }
```

**Supports:**
* Min, Max, Average, Sum, Count
* Number fields only

**Could Potentially Support**
* Grouping before doing stats? (haven't really thought that one through yet)
* Filtering before doing stats
* Stats on other types (eg min/max string?)

**Notes**
* Naming very much open to change - eg could be aggregate or stats etc
* Tried adding minimal extra types 
** adds a field to existing type (eg people gets a summarize field which may not be the best)
** reuses the same type to put the stats on (mainly a shortcut, but isn't great when it means theres fields you can't query)


