### PR TITLE
Fix/170

### DIFF
--- a/src/EntityGraphQL/Compiler/EntityGraphQLQueryWalker.cs
+++ b/src/EntityGraphQL/Compiler/EntityGraphQLQueryWalker.cs
@@ -198,7 +198,8 @@ namespace EntityGraphQL.Compiler
                 }
                 else
                 {
-                    fieldResult = new GraphQLScalarField(schemaProvider, actualField, resultName, actualField.ResolveExpression!, context.NextFieldContext as ParameterExpression ?? context.RootParameter, context, args);
+                    var rootParam = context.NextFieldContext?.NodeType == ExpressionType.Parameter ? actualField.FieldParam : context.RootParameter;
+                    fieldResult = new GraphQLScalarField(schemaProvider, actualField, resultName, actualField.ResolveExpression!, rootParam, context, args);
                 }
 
                 if (node.Directives?.Any() == true)
@@ -248,7 +249,7 @@ namespace EntityGraphQL.Compiler
             var elementType = returnType.TypeDotnet;
             var fieldParam = Expression.Parameter(elementType, $"p_{elementType.Name}");
 
-            var gqlNode = new GraphQLListSelectionField(schemaProvider, actualField, resultName, fieldParam, context.RootParameter, nodeExpression, context, arguments);
+            var gqlNode = new GraphQLListSelectionField(schemaProvider, actualField, resultName, fieldParam, actualField.FieldParam ?? context.RootParameter, nodeExpression, context, arguments);
 
             // visit child fields. Will be more fields
             base.VisitSelectionSet(selection, gqlNode);
@@ -269,7 +270,9 @@ namespace EntityGraphQL.Compiler
                 throw new EntityGraphQLCompilerException("context should not be null visiting field");
             if (context.NextFieldContext == null && context.RootParameter == null)
                 throw new EntityGraphQLCompilerException("context.NextFieldContext and context.RootParameter should not be null visiting field");
-            var graphQLNode = new GraphQLObjectProjectionField(schemaProvider, actualField, name, nodeExpression, context.NextFieldContext as ParameterExpression ?? context.RootParameter!, context, arguments);
+
+            var rootParam = context.NextFieldContext?.NodeType == ExpressionType.Parameter ? actualField.FieldParam : context.RootParameter!;
+            var graphQLNode = new GraphQLObjectProjectionField(schemaProvider, actualField, name, nodeExpression, rootParam ?? context.RootParameter!, context, arguments);
 
             base.VisitSelectionSet(selection, graphQLNode);
 

--- a/src/EntityGraphQL/Compiler/GqlNodes/BaseGraphQLField.cs
+++ b/src/EntityGraphQL/Compiler/GqlNodes/BaseGraphQLField.cs
@@ -35,6 +35,7 @@ namespace EntityGraphQL.Compiler
         public List<BaseGraphQLField> QueryFields { get; } = new();
         public Expression? NextFieldContext { get; }
         public IGraphQLNode? ParentNode { get; set; }
+
         public ParameterExpression? RootParameter { get; set; }
         /// <summary>
         /// Arguments from inline in the query - not $ variables
@@ -97,6 +98,19 @@ namespace EntityGraphQL.Compiler
         public abstract Expression? GetNodeExpression(CompileContext compileContext, IServiceProvider? serviceProvider, List<GraphQLFragmentStatement> fragments, ParameterExpression? docParam, object? docVariables, ParameterExpression schemaContext, bool withoutServiceFields, Expression? replacementNextFieldContext, bool isRoot, bool contextChanged, ParameterReplacer replacer);
 
         public abstract IEnumerable<BaseGraphQLField> Expand(CompileContext compileContext, List<GraphQLFragmentStatement> fragments, bool withoutServiceFields, Expression fieldContext, ParameterExpression? docParam, object? docVariables);
+
+        /// <summary>
+        /// Bring up any context based expression from services
+        /// </summary>
+        /// <returns></returns>
+        /// <exception cref="NotImplementedException"></exception>
+        internal virtual IEnumerable<BaseGraphQLField> ExpandFromServices(bool withoutServiceFields, BaseGraphQLField? field)
+        {
+            if (withoutServiceFields && Field?.ExtractedFieldsFromServices != null)
+                return Field.ExtractedFieldsFromServices.ToList();
+
+            return withoutServiceFields && HasServices ? new List<BaseGraphQLField>() : new List<BaseGraphQLField> { field ?? this };
+        }
 
         public void AddField(BaseGraphQLField field)
         {
@@ -168,6 +182,32 @@ namespace EntityGraphQL.Compiler
                 node = node.ParentNode;
             }
             return result;
+        }
+        protected Expression ReplaceContext(Expression replacementNextFieldContext, bool isRoot, ParameterReplacer replacer, Expression nextFieldContext)
+        {
+            var possibleField = replacementNextFieldContext.Type.GetField(Name);
+            if (possibleField != null)
+                nextFieldContext = Expression.Field(replacementNextFieldContext, possibleField);
+            else // need to replace context expressions in the service expression with the new context
+            {
+                // If this is a root field, we replace teh whole expresison
+                if (isRoot)
+                    nextFieldContext = replacementNextFieldContext;
+                else if (HasServices)
+                {
+                    // if we have services we need to replace any context expressions in the service expression with the new context
+                    var expressionsToReplace = ExpandFromServices(true, null).Cast<GraphQLExtractedField>();
+                    var expReplacer = new ExpressionReplacer(expressionsToReplace, replacementNextFieldContext);
+                    nextFieldContext = expReplacer.Replace(nextFieldContext!);
+                }
+                // may need to replace the field's original parameter
+                if (Field?.FieldParam != null)
+                {
+                    nextFieldContext = replacer.Replace(nextFieldContext, Field.FieldParam, replacementNextFieldContext);
+                }
+            }
+
+            return nextFieldContext;
         }
     }
 }

--- a/src/EntityGraphQL/Compiler/GqlNodes/GraphQLExtractedField.cs
+++ b/src/EntityGraphQL/Compiler/GqlNodes/GraphQLExtractedField.cs
@@ -1,19 +1,22 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Linq.Expressions;
 using EntityGraphQL.Compiler.Util;
 using EntityGraphQL.Schema;
 
 namespace EntityGraphQL.Compiler;
 
-internal class GraphQLExtractedField : BaseGraphQLField
+public class GraphQLExtractedField : BaseGraphQLField
 {
-    private readonly Expression fieldContext;
+    private readonly ParameterExpression originalParam;
+    public IEnumerable<Expression> FieldExpressions { get; }
 
-    public GraphQLExtractedField(ISchemaProvider schema, string name, Expression fieldExpression, Expression fieldContext)
-    : base(schema, null, name, fieldExpression, null, null, null)
+    public GraphQLExtractedField(ISchemaProvider schema, string name, IEnumerable<Expression> fieldExpressions, ParameterExpression originalParam)
+    : base(schema, null, name, null, null, null, null)
     {
-        this.fieldContext = fieldContext;
+        this.originalParam = originalParam;
+        this.FieldExpressions = fieldExpressions;
     }
 
     public override IEnumerable<BaseGraphQLField> Expand(CompileContext compileContext, List<GraphQLFragmentStatement> fragments, bool withoutServiceFields, Expression fieldContext, ParameterExpression? docParam, object? docVariables)
@@ -23,7 +26,18 @@ internal class GraphQLExtractedField : BaseGraphQLField
 
     public override Expression GetNodeExpression(CompileContext compileContext, IServiceProvider? serviceProvider, List<GraphQLFragmentStatement> fragments, ParameterExpression? docParam, object? docVariables, ParameterExpression schemaContext, bool withoutServiceFields, Expression? replacementNextFieldContext, bool isRoot, bool contextChanged, ParameterReplacer replacer)
     {
-        var exp = replacer.ReplaceByType(NextFieldContext!, fieldContext.Type, fieldContext);
-        return exp;
+        if (withoutServiceFields)
+        {
+            // we don't need any other expression as they are the same. We just need to make sure we select the data
+            var fieldExp = replacer.Replace(FieldExpressions!.First(), originalParam, replacementNextFieldContext!);
+            return fieldExp;
+        }
+        return GetNodeExpression(replacementNextFieldContext!);
+    }
+
+    public Expression GetNodeExpression(Expression replacementNextFieldContext)
+    {
+        // extracted fields get flatten as they are selected in the first pass. The new expression  can be built
+        return Expression.PropertyOrField(replacementNextFieldContext!, Name);
     }
 }

--- a/src/EntityGraphQL/Compiler/GqlNodes/GraphQLFragmentField.cs
+++ b/src/EntityGraphQL/Compiler/GqlNodes/GraphQLFragmentField.cs
@@ -31,7 +31,7 @@ namespace EntityGraphQL.Compiler
             var fields = fragment.QueryFields.SelectMany(f => f.Expand(compileContext, fragments, withoutServiceFields, fieldContext, docParam, docVariables));
             // the current op did not know about services in the fragment as the fragment definition may be after the operation in the query
             // we now know  if there are services we need to know about for executing
-            var baseGraphQlFields = fields as BaseGraphQLField[] ?? fields.ToArray();
+            var baseGraphQlFields = (fields as BaseGraphQLField[] ?? fields.ToArray()).ToList();
             if (!withoutServiceFields)
             {
                 foreach (var field in baseGraphQlFields)
@@ -39,7 +39,17 @@ namespace EntityGraphQL.Compiler
                     GetServices(compileContext, field);
                 }
             }
+            baseGraphQlFields.AddRange(ExpandFromServices(withoutServiceFields, null));
             return baseGraphQlFields;
+        }
+
+        internal override IEnumerable<BaseGraphQLField> ExpandFromServices(bool withoutServiceFields, BaseGraphQLField? field)
+        {
+            if (withoutServiceFields && Field?.ExtractedFieldsFromServices != null)
+                return Field.ExtractedFieldsFromServices.ToList();
+
+            // we do not want to return the fragment field
+            return withoutServiceFields && HasServices ? new List<BaseGraphQLField>() : (field != null ? new List<BaseGraphQLField> { field } : new List<BaseGraphQLField>());
         }
 
         private void GetServices(CompileContext compileContext, BaseGraphQLField gqlField)

--- a/src/EntityGraphQL/Compiler/GqlNodes/IGraphQLNode.cs
+++ b/src/EntityGraphQL/Compiler/GqlNodes/IGraphQLNode.cs
@@ -6,8 +6,17 @@ namespace EntityGraphQL.Compiler
 {
     public interface IGraphQLNode
     {
+        /// <summary>
+        /// Name of the field
+        /// </summary>
         string Name { get; }
+        /// <summary>
+        /// The expression that represents the field. This will be the context for the next field selection
+        /// </summary>
         Expression? NextFieldContext { get; }
+        /// <summary>
+        /// Parent field. e.g. if we have a field manger like in `people { manager }` then the parent is people
+        /// </summary>
         IGraphQLNode? ParentNode { get; }
         ParameterExpression? RootParameter { get; }
 

--- a/src/EntityGraphQL/Compiler/Util/ExpressionExtractor.cs
+++ b/src/EntityGraphQL/Compiler/Util/ExpressionExtractor.cs
@@ -1,30 +1,38 @@
 using System.Collections.Generic;
 using System.Linq.Expressions;
+using System.Text.RegularExpressions;
 using EntityGraphQL.Extensions;
 
 namespace EntityGraphQL.Compiler.Util
 {
     /// <summary>
     /// Extracts expression with the root context as the provided ParameterExpression.
-    /// Useful for getting required fields out of a WithService() call
+    /// Useful for getting required fields out of a ResolveWithService() call.
+    /// For example if the full expression is the below and the root context is ctx
+    ///     myService.CallThis(ctx.Field1, otherService.Call(ctx.Child.Field2))
+    /// We extract the following expressions:
+    ///    ctx.Field1
+    ///    ctx.Child.Field2
     /// </summary>
-    internal class ExpressionExtractor : ExpressionVisitor
+    public class ExpressionExtractor : ExpressionVisitor
     {
-        private Expression? rootContext;
-        private Dictionary<string, Expression>? extractedExpressions;
-        private Expression? currentExpression;
-        private string? contextParamFieldName;
-        private bool matchByType;
-        private string? rootFieldName;
+        private readonly Regex pattern = new("[\\.\\(\\)\\!]");
 
-        internal IDictionary<string, Expression>? Extract(Expression node, Expression rootContext, bool matchByType = false, string? rootFieldName = null)
+        private Expression? rootContext;
+        // We extract all expression - which may repeat - and we then replace them by matching the expression object
+        private Dictionary<string, List<Expression>>? extractedExpressions;
+        /// <summary>
+        /// Current expression we might extract. 
+        /// </summary>
+        private readonly Stack<Expression> currentExpression = new();
+        private bool matchByType;
+
+        public IDictionary<string, List<Expression>>? Extract(Expression node, Expression rootContext, bool matchByType = false, string? rootFieldName = null)
         {
             this.rootContext = rootContext;
-            extractedExpressions = new Dictionary<string, Expression>();
-            currentExpression = null;
-            contextParamFieldName = null;
+            extractedExpressions = new Dictionary<string, List<Expression>>();
+            currentExpression.Clear();
             this.matchByType = matchByType;
-            this.rootFieldName = rootFieldName;
             Visit(node);
             return extractedExpressions.Count > 0 ? extractedExpressions : null;
         }
@@ -34,70 +42,74 @@ namespace EntityGraphQL.Compiler.Util
             if (rootContext == null)
                 throw new EntityGraphQLCompilerException("Root context not set for ExpressionExtractor");
 
-            if (rootContext == currentExpression)
-                throw new EntityGraphQLCompilerException($"The context parameter {node.Name} used in a WithService() field is not allowed. Please select the specific fields required from the context parameter.");
-            if ((rootContext == node || (matchByType && rootContext.Type == node.Type)) && currentExpression != null && contextParamFieldName != null)
-                extractedExpressions![contextParamFieldName] = currentExpression;
+            if (currentExpression.Count > 0 && rootContext == currentExpression.Peek())
+                throw new EntityGraphQLCompilerException($"The context parameter {node.Name} used in a ResolveWithService() field is not allowed. Please select the specific fields required from the context parameter.");
+            if ((rootContext == node || (matchByType && rootContext.Type == node.Type)) && currentExpression.Count > 0)
+            {
+                var expressionItem = currentExpression.Peek();
+                // use the expression as the extracted field name as it will be unique
+                var name = pattern.Replace(expressionItem.ToString(), "_");
+                if (!extractedExpressions!.ContainsKey(name))
+                    extractedExpressions![name] = new List<Expression> { expressionItem };
+                else
+                    extractedExpressions![name].Add(expressionItem);
+            }
             return base.VisitParameter(node);
-        }
-        protected override Expression VisitBinary(BinaryExpression node)
-        {
-            // reset currents
-            currentExpression = null;
-            contextParamFieldName = null;
-            var left = base.Visit(node.Left);
-
-            currentExpression = null;
-            contextParamFieldName = null;
-            var right = base.Visit(node.Right);
-            return Expression.MakeBinary(node.NodeType, left, right);
         }
         protected override Expression VisitMember(MemberExpression node)
         {
-            var weCaptured = false;
             // if is is a nullable type we want to extract the nullable field not the nullableField.HasValue/Value
             // node.Expression can be null if it is a static member - e.g. DateTime.MaxValue
-            if (currentExpression == null && !node.Expression?.Type.IsNullableType() == true)
+            // if it is empty this is the end of an expression too
+            if (currentExpression.Count == 0 && node.Expression?.Type.IsNullableType() == false)
             {
-                currentExpression = node;
-                contextParamFieldName = node.Member.Name;
-                weCaptured = true;
+                currentExpression.Push(node);
+                var result = base.VisitMember(node);
+                currentExpression.Pop();
+                return result;
             }
-            var result = base.VisitMember(node);
-            if (weCaptured)
-            {
-                currentExpression = null;
-                contextParamFieldName = null;
-            }
-            return result;
+            return base.VisitMember(node);
         }
 
         protected override Expression VisitMethodCall(MethodCallExpression node)
         {
             if (node.Object != null)
             {
-                var prevExp = currentExpression;
-                currentExpression = null;
-                Visit(node.Object);
-                currentExpression = prevExp;
+                if (currentExpression.Count == 0)
+                {
+                    // only need to extract if this is not part of a larger expression
+                    currentExpression.Push(node);
+                    Visit(node.Object);
+                    currentExpression.Pop();
+                }
+                else
+                    Visit(node.Object);
             }
             var startAt = 0;
-            if (node.Object is null) // static method
+            // only need to extract if this is not part of a larger expression
+            if (node.Object is null) // static/extension method
             {
                 startAt = 1;
-                currentExpression = node;
-                contextParamFieldName = rootFieldName;
-                Visit(node.Arguments[0]);
+                if (currentExpression.Count == 0)
+                {
+                    currentExpression.Push(node);
+                    Visit(node.Arguments[0]);
+                    currentExpression.Pop();
+                }
+                else
+                    Visit(node.Arguments[0]);
             }
             for (int i = startAt; i < node.Arguments.Count; i++)
             {
+                // each arg might be extractable but we should end up back in a acll or member access again
                 Expression arg = node.Arguments[i];
-                currentExpression = null;
-                contextParamFieldName = null;
+                var shouldAdd = arg.NodeType == ExpressionType.MemberAccess && ((MemberExpression)arg).Expression?.Type.IsNullableType() == false;
+                if (shouldAdd)
+                    currentExpression.Push(arg);
                 Visit(arg);
+                if (shouldAdd)
+                    currentExpression.Pop();
             }
-            currentExpression = null;
-            contextParamFieldName = null;
             return node;
         }
     }

--- a/src/EntityGraphQL/Compiler/Util/ExpressionReplacer.cs
+++ b/src/EntityGraphQL/Compiler/Util/ExpressionReplacer.cs
@@ -1,0 +1,80 @@
+using System.Collections.Generic;
+using System.Linq.Expressions;
+
+namespace EntityGraphQL.Compiler.Util
+{
+    /// <summary>
+    /// Used to replace whole expressions in a service field expression
+    /// </summary>
+    public class ExpressionReplacer : ExpressionVisitor
+    {
+        private readonly Expression newContext;
+        private readonly Dictionary<Expression, GraphQLExtractedField> expressionsToReplace = new();
+
+        public ExpressionReplacer(IEnumerable<GraphQLExtractedField> expressionsToReplace, Expression newContext)
+        {
+            this.newContext = newContext;
+            foreach (var field in expressionsToReplace)
+            {
+                foreach (var exp in field.FieldExpressions)
+                {
+                    this.expressionsToReplace.Add(exp, field);
+                }
+            }
+        }
+
+        public Expression Replace(Expression baseExpression)
+        {
+            return base.Visit(baseExpression);
+        }
+
+
+        protected override Expression VisitParameter(ParameterExpression node)
+        {
+            if (expressionsToReplace.ContainsKey(node))
+                return expressionsToReplace[node].GetNodeExpression(newContext);
+            return base.VisitParameter(node);
+        }
+
+        protected override Expression VisitLambda<T>(Expression<T> node)
+        {
+            if (expressionsToReplace.ContainsKey(node))
+                return expressionsToReplace[node].GetNodeExpression(newContext);
+            return base.VisitLambda(node);
+        }
+
+        protected override Expression VisitUnary(UnaryExpression node)
+        {
+            if (expressionsToReplace.ContainsKey(node))
+                return expressionsToReplace[node].GetNodeExpression(newContext);
+            return base.VisitUnary(node);
+        }
+
+        protected override Expression VisitMember(MemberExpression node)
+        {
+            if (expressionsToReplace.ContainsKey(node))
+                return expressionsToReplace[node].GetNodeExpression(newContext);
+            return base.VisitMember(node);
+        }
+
+        protected override Expression VisitConstant(ConstantExpression node)
+        {
+            if (expressionsToReplace.ContainsKey(node))
+                return expressionsToReplace[node].GetNodeExpression(newContext);
+            return base.VisitConstant(node);
+        }
+
+        protected override Expression VisitMethodCall(MethodCallExpression node)
+        {
+            if (expressionsToReplace.ContainsKey(node))
+                return expressionsToReplace[node].GetNodeExpression(newContext);
+            return base.VisitMethodCall(node);
+        }
+        protected override Expression VisitBinary(BinaryExpression node)
+        {
+            if (expressionsToReplace.ContainsKey(node))
+                return expressionsToReplace[node].GetNodeExpression(newContext);
+            return base.VisitBinary(node);
+        }
+    }
+}

--- a/src/EntityGraphQL/Compiler/Util/ParameterReplacer.cs
+++ b/src/EntityGraphQL/Compiler/Util/ParameterReplacer.cs
@@ -39,6 +39,15 @@ namespace EntityGraphQL.Compiler.Util
             return Visit(node);
         }
 
+        /// <summary>
+        /// Replace an expression of type with newParam.
+        /// Try to avoid using this if possible as there might be multiple of the type in the expression that you do not want to replace.
+        /// </summary>
+        /// <param name="node"></param>
+        /// <param name="toReplaceType"></param>
+        /// <param name="newParam"></param>
+        /// <param name="newContextFieldName"></param>
+        /// <returns></returns>
         public Expression ReplaceByType(Expression node, Type toReplaceType, Expression newParam, string? newContextFieldName = null)
         {
             this.newParam = newParam;
@@ -49,7 +58,6 @@ namespace EntityGraphQL.Compiler.Util
             replaceWholeExpression = false;
             return Visit(node);
         }
-
         protected override Expression VisitParameter(ParameterExpression node)
         {
             if (toReplace != null && toReplace == node)

--- a/src/EntityGraphQL/Schema/BaseField.cs
+++ b/src/EntityGraphQL/Schema/BaseField.cs
@@ -48,6 +48,8 @@ namespace EntityGraphQL.Schema
         public ISchemaProvider Schema { get; set; }
         public Type? ArgumentsType { get; set; }
 
+        public List<GraphQLExtractedField>? ExtractedFieldsFromServices { get; protected set; }
+
         protected List<Action<ArgumentValidatorContext>> argumentValidators = new();
 
         protected BaseField(ISchemaProvider schema, string name, string? description, GqlTypeInfo returnType)

--- a/src/EntityGraphQL/Schema/FieldExtensions/ConnectionPaging/ConnectionEdgeExtension.cs
+++ b/src/EntityGraphQL/Schema/FieldExtensions/ConnectionPaging/ConnectionEdgeExtension.cs
@@ -13,8 +13,6 @@ internal class ConnectionEdgeExtension : BaseFieldExtension
     /// <summary>
     /// This is passed down from the original field
     /// </summary>
-    private readonly ParameterExpression argsExpression;
-
     private readonly ParameterExpression argumentParam;
     private readonly ParameterExpression originalFieldParam;
     private readonly int? defaultPageSize;
@@ -24,12 +22,11 @@ internal class ConnectionEdgeExtension : BaseFieldExtension
     private readonly bool isQueryable;
     private readonly List<IFieldExtension> extensions;
 
-    public ConnectionEdgeExtension(Type listType, bool isQueryable, ParameterExpression argsExpression, ParameterExpression argumentParam, List<IFieldExtension> extensions, ParameterExpression fieldParam, int? defaultPageSize, int? maxPageSize)
+    public ConnectionEdgeExtension(Type listType, bool isQueryable, ParameterExpression argumentParam, List<IFieldExtension> extensions, ParameterExpression fieldParam, int? defaultPageSize, int? maxPageSize)
     {
         this.listType = listType;
         this.isQueryable = isQueryable;
         this.extensions = extensions;
-        this.argsExpression = argsExpression;
         firstSelectParam = Expression.Parameter(listType, "edgeNode");
         this.argumentParam = argumentParam;
         this.originalFieldParam = fieldParam;
@@ -152,7 +149,7 @@ internal class ConnectionEdgeExtension : BaseFieldExtension
                     new List<MemberBinding>
                     {
                         Expression.Bind(edgeType.GetProperty("Node")!, Expression.PropertyOrField(edgeParam, "Node")),
-                        Expression.Bind(edgeType.GetProperty("Cursor")!, Expression.Call(typeof(ConnectionHelper), "GetCursor", null, argsExpression, idxParam))
+                        Expression.Bind(edgeType.GetProperty("Cursor")!, Expression.Call(typeof(ConnectionHelper), "GetCursor", null, argumentParam, idxParam))
                     }
                 ),
                 edgeParam,

--- a/src/EntityGraphQL/Schema/FieldExtensions/ConnectionPaging/ConnectionEdgeExtension.cs
+++ b/src/EntityGraphQL/Schema/FieldExtensions/ConnectionPaging/ConnectionEdgeExtension.cs
@@ -40,7 +40,7 @@ internal class ConnectionEdgeExtension : BaseFieldExtension
     public override Expression? GetExpression(IField field, Expression expression, ParameterExpression? argExpression, dynamic? arguments, Expression context, IGraphQLNode? parentNode, bool servicesPass, ParameterReplacer parameterReplacer)
     {
         // field.Resolve will be built with the original field context and needs to be updated
-        expression = servicesPass ? expression : parameterReplacer.Replace(field.ResolveExpression!, originalFieldParam, parentNode!.RootParameter!);
+        expression = servicesPass ? expression : parameterReplacer.Replace(field.ResolveExpression!, originalFieldParam, parentNode!.ParentNode!.NextFieldContext!);
         // expression here is the adjusted Connection<T>(). This field (edges) is where we deal with the list again - field.Resolve
         foreach (var extension in extensions)
         {

--- a/src/EntityGraphQL/Schema/FieldExtensions/ConnectionPaging/ConnectionPagingExtension.cs
+++ b/src/EntityGraphQL/Schema/FieldExtensions/ConnectionPaging/ConnectionPagingExtension.cs
@@ -93,7 +93,7 @@ namespace EntityGraphQL.Schema.FieldExtensions
             field.Extensions = field.Extensions.Skip(extensionsBeforePaging.Count).ToList();
 
             // We use this extension to update the Edges context by inserting the Select() which we get from the above extension
-            var edgesExtension = new ConnectionEdgeExtension(listType, isQueryable, field.ArgumentParam!, field.ArgumentParam!, extensionsBeforePaging, field.FieldParam!, defaultPageSize, maxPageSize);
+            var edgesExtension = new ConnectionEdgeExtension(listType, isQueryable, field.ArgumentParam!, extensionsBeforePaging, field.FieldParam!, defaultPageSize, maxPageSize);
             edgesField.AddExtension(edgesExtension);
             edgesField.UseArgumentsFrom(field);
 

--- a/src/EntityGraphQL/Schema/FieldExtensions/OffsetPaging/OffsetPagingItemsExtension.cs
+++ b/src/EntityGraphQL/Schema/FieldExtensions/OffsetPaging/OffsetPagingItemsExtension.cs
@@ -25,7 +25,7 @@ public class OffsetPagingItemsExtension : BaseFieldExtension
     public override Expression? GetExpression(IField field, Expression expression, ParameterExpression? argExpression, dynamic? arguments, Expression context, IGraphQLNode? parentNode, bool servicesPass, ParameterReplacer parameterReplacer)
     {
         // other extensions expect to run on the collection not our new shape
-        Expression newItemsExp = servicesPass ? expression : parameterReplacer.Replace(field.ResolveExpression!, this.originalFieldParam, parentNode!.RootParameter!);
+        Expression newItemsExp = servicesPass ? expression : parameterReplacer.Replace(field.ResolveExpression!, this.originalFieldParam, parentNode!.ParentNode!.NextFieldContext!);
         // apply other expressions 
         foreach (var extension in extensions)
         {

--- a/src/EntityGraphQL/Schema/FieldToResolve.cs
+++ b/src/EntityGraphQL/Schema/FieldToResolve.cs
@@ -10,36 +10,36 @@ public class FieldToResolveWithArgs<TContext, TParams> : Field
 
     public Field Resolve(Expression<Func<TContext, TParams, object>> fieldExpression)
     {
-        SetUpField(fieldExpression);
+        SetUpField(fieldExpression, true);
         return this;
     }
     public Field ResolveWithService<TService>(Expression<Func<TContext, TParams, TService, object>> fieldExpression)
     {
-        SetUpField(fieldExpression);
+        SetUpField(fieldExpression, true);
         Services = new[] { typeof(TService) };
         return this;
     }
     public Field ResolveWithServices<TService1, TService2>(Expression<Func<TContext, TParams, TService1, TService2, object>> fieldExpression)
     {
-        SetUpField(fieldExpression);
+        SetUpField(fieldExpression, true);
         Services = new[] { typeof(TService1), typeof(TService2) };
         return this;
     }
     public Field ResolveWithServices<TService1, TService2, TService3>(Expression<Func<TContext, TParams, TService1, TService2, TService3, object>> fieldExpression)
     {
-        SetUpField(fieldExpression);
+        SetUpField(fieldExpression, true);
         Services = new[] { typeof(TService1), typeof(TService2), typeof(TService3) };
         return this;
     }
     public Field ResolveWithServices<TService1, TService2, TService3, TService4>(Expression<Func<TContext, TParams, TService1, TService2, TService3, TService4, object>> fieldExpression)
     {
-        SetUpField(fieldExpression);
+        SetUpField(fieldExpression, true);
         Services = new[] { typeof(TService1), typeof(TService2), typeof(TService3), typeof(TService4) };
         return this;
     }
     public Field ResolveWithServices<TService1, TService2, TService3, TService4, TService5>(Expression<Func<TContext, TParams, TService1, TService2, TService3, TService4, TService5, object>> fieldExpression)
     {
-        SetUpField(fieldExpression);
+        SetUpField(fieldExpression, true);
         Services = new[] { typeof(TService1), typeof(TService2), typeof(TService3), typeof(TService4), typeof(TService5) };
         return this;
     }
@@ -53,37 +53,37 @@ public class FieldToResolve<TContext> : Field
 
     public Field Resolve(Expression<Func<TContext, object>> fieldExpression)
     {
-        SetUpField(fieldExpression);
+        SetUpField(fieldExpression, true);
         return this;
     }
 
     public Field ResolveWithService<TService>(Expression<Func<TContext, TService, object>> fieldExpression)
     {
-        SetUpField(fieldExpression);
+        SetUpField(fieldExpression, true);
         Services = new[] { typeof(TService) };
         return this;
     }
     public Field ResolveWithServices<TService1, TService2>(Expression<Func<TContext, TService1, TService2, object>> fieldExpression)
     {
-        SetUpField(fieldExpression);
+        SetUpField(fieldExpression, true);
         Services = new[] { typeof(TService1), typeof(TService2) };
         return this;
     }
     public Field ResolveWithServices<TService1, TService2, TService3>(Expression<Func<TContext, TService1, TService2, TService3, object>> fieldExpression)
     {
-        SetUpField(fieldExpression);
+        SetUpField(fieldExpression, true);
         Services = new[] { typeof(TService1), typeof(TService2), typeof(TService3) };
         return this;
     }
     public Field ResolveWithServices<TService1, TService2, TService3, TService4>(Expression<Func<TContext, TService1, TService2, TService3, TService4, object>> fieldExpression)
     {
-        SetUpField(fieldExpression);
+        SetUpField(fieldExpression, true);
         Services = new[] { typeof(TService1), typeof(TService2), typeof(TService3), typeof(TService4) };
         return this;
     }
     public Field ResolveWithServices<TService1, TService2, TService3, TService4, TService5>(Expression<Func<TContext, TService1, TService2, TService3, TService4, TService5, object>> fieldExpression)
     {
-        SetUpField(fieldExpression);
+        SetUpField(fieldExpression, true);
         Services = new[] { typeof(TService1), typeof(TService2), typeof(TService3), typeof(TService4), typeof(TService5) };
         return this;
     }

--- a/src/EntityGraphQL/Schema/IField.cs
+++ b/src/EntityGraphQL/Schema/IField.cs
@@ -20,6 +20,7 @@ namespace EntityGraphQL.Schema
         GraphQLQueryFieldType FieldType { get; }
         ISchemaProvider Schema { get; }
         ParameterExpression? FieldParam { get; set; }
+        List<GraphQLExtractedField>? ExtractedFieldsFromServices { get; }
         string? Description { get; }
         IDictionary<string, ArgType> Arguments { get; }
         ParameterExpression? ArgumentParam { get; }

--- a/src/EntityGraphQL/Schema/SchemaBuilder.cs
+++ b/src/EntityGraphQL/Schema/SchemaBuilder.cs
@@ -122,7 +122,7 @@ namespace EntityGraphQL.Schema
             body = ExpressionUtil.MakeCallOnQueryable("FirstOrDefault", new Type[] { arrayContextType }, body);
             var contextParam = Expression.Parameter(contextType, $"cxt_{contextType.Name}");
             var lambdaParams = new[] { contextParam, argTypeParam };
-            body = new ParameterReplacer().ReplaceByType(body, contextType, contextParam);
+            body = new ParameterReplacer().Replace(body, fieldProp.FieldParam!, contextParam);
             var selectionExpression = Expression.Lambda(body, lambdaParams);
             var name = fieldProp.Name.Singularize();
             if (name == null)

--- a/src/tests/EntityGraphQL.Tests/QueryTests/FragmentTests.cs
+++ b/src/tests/EntityGraphQL.Tests/QueryTests/FragmentTests.cs
@@ -71,17 +71,17 @@ fragment info on Person {
             var gql = new QueryRequest
             {
                 Query = @"query {
-  activeProjects {
-    ...frag
-  }
-  oldProjects {
-    ...frag
-  }
-}
+                    activeProjects {
+                        ...frag
+                    }
+                    oldProjects {
+                        ...frag
+                    }
+                }
 
-fragment frag on Project {
-  id
-}"
+                fragment frag on Project {
+                    id
+                }"
             };
 
             var context = new TestDataContext().FillWithTestData();

--- a/src/tests/EntityGraphQL.Tests/TestDataContext.cs
+++ b/src/tests/EntityGraphQL.Tests/TestDataContext.cs
@@ -98,6 +98,7 @@ namespace EntityGraphQL.Tests
         public string Description { get; set; }
         public bool IsActive { get; set; }
         public DateTime? Updated { get; set; }
+        public IEnumerable<Project> Children { get; set; }
     }
 
     public class Task

--- a/src/tests/EntityGraphQL.Tests/Util/ExpressionExtractorTests.cs
+++ b/src/tests/EntityGraphQL.Tests/Util/ExpressionExtractorTests.cs
@@ -1,0 +1,92 @@
+using System;
+using System.Linq;
+using System.Linq.Expressions;
+using EntityGraphQL.Compiler.Util;
+using Xunit;
+using static EntityGraphQL.Tests.ServiceFieldTests;
+
+namespace EntityGraphQL.Tests.Util;
+
+public class ExpressionExtractorTests
+{
+    [Fact]
+    public void ExtractMemberExpression()
+    {
+        Expression<Func<TestDataContext, int>> expression = x => x.TotalPeople;
+        var extractor = new ExpressionExtractor();
+        var extracted = extractor.Extract(expression.Body, expression.Parameters[0], false);
+
+        Assert.Single(extracted);
+        Assert.Equal("x_TotalPeople", extracted.First().Key);
+        Assert.Equal(expression.Body, extracted.First().Value.First());
+    }
+
+    [Fact]
+    public void ExtractMemberExpressionInMethod()
+    {
+        // Calling a service using EF fields
+        Expression<Func<Person, AgeService, int>> expression = (person, ager) => ager.GetAge(person.Birthday);
+        var extractor = new ExpressionExtractor();
+        var extracted = extractor.Extract(expression.Body, expression.Parameters[0], false);
+
+        Assert.Single(extracted);
+        Assert.Equal("person_Birthday", extracted.First().Key);
+        Assert.Equal(((MethodCallExpression)expression.Body).Arguments[0], extracted.First().Value.First());
+    }
+
+    [Fact]
+    public void ExtractLongMemberExpressionSameNameInMethod()
+    {
+        // Calling a service using EF fields
+        Expression<Func<Project, ConfigService, string>> expression = (p, srv) => srv.Get(p.Name, p.Children.FirstOrDefault().Name);
+        var extractor = new ExpressionExtractor();
+        var extracted = extractor.Extract(expression.Body, expression.Parameters[0], false);
+
+        Assert.Equal(2, extracted.Count);
+        Assert.Equal("p_Name", extracted.First().Key);
+        Assert.Equal(((MethodCallExpression)expression.Body).Arguments[0], extracted.First().Value.First());
+        Assert.Equal("p_Children_FirstOrDefault___Name", extracted.ElementAt(1).Key);
+        Assert.Equal(((MethodCallExpression)expression.Body).Arguments[1], extracted.ElementAt(1).Value.First());
+    }
+
+    [Fact]
+    public void ExtractExpressionInAsync()
+    {
+        // Calling a service using EF fields
+        Expression<Func<Person, AgeService, int>> expression = (ctx, srv) => srv.GetAgeAsync(ctx.Birthday).GetAwaiter().GetResult();
+        var extractor = new ExpressionExtractor();
+        var extracted = extractor.Extract(expression.Body, expression.Parameters[0], false);
+
+        Assert.Single(extracted);
+        Assert.Equal("ctx_Birthday", extracted.First().Key);
+        Assert.Equal(((MethodCallExpression)((MethodCallExpression)((MethodCallExpression)expression.Body).Object).Object).Arguments[0], extracted.First().Value.First());
+    }
+    [Fact]
+    public void ExtractExpressionConditional()
+    {
+        // Calling a service using EF fields
+        Expression<Func<Project, AgeService, DateTime>> expression = (project, ageSrv) => project.Updated == null ? DateTime.MinValue : new DateTime(ageSrv.GetAgeAsync(project.Updated).Result);
+        var extractor = new ExpressionExtractor();
+        var extracted = extractor.Extract(expression.Body, expression.Parameters[0], false);
+
+        Assert.Single(extracted);
+        Assert.Equal("project_Updated", extracted.First().Key);
+        Assert.Equal(2, extracted.First().Value.Count);
+        Assert.Equal(((BinaryExpression)((ConditionalExpression)expression.Body).Test).Left, extracted.First().Value.First());
+        Assert.Equal(((MethodCallExpression)((MemberExpression)((UnaryExpression)((NewExpression)((ConditionalExpression)expression.Body).IfFalse).Arguments[0]).Operand).Expression).Arguments[0], extracted.First().Value.ElementAt(1));
+    }
+    [Fact]
+    public void ExtractExpressionNullableType()
+    {
+        // Calling a service using EF fields
+        Expression<Func<User, TestDataContext, Person>> expression = (user, ctx) => user.RelationId.HasValue ? ctx.People.FirstOrDefault(u => u.Id == user.RelationId.Value) : null;
+        var extractor = new ExpressionExtractor();
+        var extracted = extractor.Extract(expression.Body, expression.Parameters[0], false);
+
+        Assert.Single(extracted);
+        Assert.Equal("user_RelationId", extracted.First().Key);
+        Assert.Equal(2, extracted.First().Value.Count);
+        Assert.Equal(((MemberExpression)((ConditionalExpression)expression.Body).Test).Expression, extracted.First().Value.First());
+        Assert.Equal(((MemberExpression)((BinaryExpression)((LambdaExpression)((MethodCallExpression)((ConditionalExpression)expression.Body).IfTrue).Arguments[1]).Body).Right).Expression, extracted.First().Value.ElementAt(1));
+    }
+}


### PR DESCRIPTION
- extract query context params out on schema creation
- Replace them by matching the expression not by type

This allows more complex expressions used to pass data into service fields