### PR TITLE
Replicate bug #182

### DIFF
--- a/src/tests/EntityGraphQL.Tests/TestDataContext.cs
+++ b/src/tests/EntityGraphQL.Tests/TestDataContext.cs
@@ -90,6 +90,7 @@ namespace EntityGraphQL.Tests
     public class Project
     {
         public int Id { get; set; }
+        public char Code { get; set; }
         public string Name { get; set; }
         public int Type { get; set; }
         public Location Location { get; set; }


### PR DESCRIPTION
simple change to replicate #182 - this small change makes about half the tests in the project fail with no obvious fix

seems easy enough to fix, just wasn't sure if we want to auto register scalar types for primitives, ignore the type, or do something else.