### PR TITLE
Schema Directives refactoring

### DIFF
--- a/docs/docs/directives/_category_.json
+++ b/docs/docs/directives/_category_.json
@@ -1,0 +1,5 @@
+{
+    "label": "Directives",
+    "position": 4,
+    "collapsed": false
+  }

--- a/docs/docs/directives/operation-directives.md
+++ b/docs/docs/directives/operation-directives.md
@@ -1,0 +1,40 @@
+---
+sidebar_position: 1
+---
+
+# Operation Directives
+
+[Operation Directives](https://graphql.org/learn/queries/#directives) provide a way to dynamically change the structure and shape of our queries using variables. An example from the GraphQL website:
+
+```graphql
+query Hero($episode: Episode, $withFriends: Boolean!) {
+  hero(episode: $episode) {
+    name
+    friends @include(if: $withFriends) {
+      name
+    }
+  }
+}
+```
+
+Now if you set `withFriends` to `true` in the variables passed with the query POST you'll get the `friends` result. If you set it to `false` you will not. Thus dynamically changing the shape of your query.
+
+## Built-In Directives
+
+The GraphQL spec defines 2 directives that are supported out of the box in EntityGraphQL.
+
+- `@include(if: Boolean)` - Only include this field in the result if the argument is true.
+- `@skip(if: Boolean)` - Skip this field if the argument is true.
+
+## Custom Directives
+
+See the [IncludeDirective](https://github.com/lukemurray/EntityGraphQL/blob/master/src/EntityGraphQL/Directives/IncludeDirectiveProcessor.cs) implementation to see how you could implement a custom directive. You can add your directive to the schema with the following
+
+```cs
+// Example only, you don't need to actually add Include or Skip directives
+schema.AddDirective(new IncludeDirective());
+```
+
+These directives work on the internal representation of a field `GraphQLQueryNode`. This is working against the query graph not the data result.
+
+_There is more functionality planned for custom directives which can work on both the pre-execution query graph or the post-execution data._

--- a/docs/docs/directives/schema-directives.md
+++ b/docs/docs/directives/schema-directives.md
@@ -11,8 +11,8 @@ Schema Directives are used to decorate the schema to provide more information to
 The GraphQL spec defines directives that are supported out of the box in EntityGraphQL.
 
 - `@deprecated(reason: String)` - Tells the client that this type, field or enum value should no longer be used along with the reason why or a suggested alternative
-- `@oneOf` - Skip this field if the argument is true.
-- `@specifiedBy(url: String)` - Skip this field if the argument is true.
+- `@oneOf` - Mark the input type as a type where only one of it's fields should ever be non-null
+- `@specifiedBy(url: String)` - Used to provide a scalar specification URL for specifying the behavior of custom scalar types.
 
 ## Deprecated
 
@@ -50,7 +50,7 @@ Although each field on the input is nullable the `@oneOf` input type has one fur
 
 ## Specified By
 
-The [@specifiedBy](https://spec.graphql.org/draft/#sec--specifiedBy) directive is used to provide extra information about a custom scalar type.
+The [@specifiedBy](https://spec.graphql.org/draft/#sec--specifiedBy) directive is used to provide extra information about a custom scalar type. The URL should point to a human-readable specification of the data format, serialization, and coercion rules. It must not appear on built-in scalar types.
 
 ## Custom Directives
 

--- a/docs/docs/directives/schema-directives.md
+++ b/docs/docs/directives/schema-directives.md
@@ -1,0 +1,133 @@
+---
+sidebar_position: 1
+---
+
+# Schema Directives
+
+Schema Directives are used to decorate the schema to provide more information to clients, EntityGraphQL can also use this information to update the introspection model or provide extra functionality such as validation.
+
+## Built-In Directives
+
+The GraphQL spec defines directives that are supported out of the box in EntityGraphQL.
+
+- `@deprecated(reason: String)` - Tells the client that this type, field or enum value should no longer be used along with the reason why or a suggested alternative
+- `@oneOf` - Skip this field if the argument is true.
+- `@specifiedBy(url: String)` - Skip this field if the argument is true.
+
+## Deprecated
+
+Fields, Enum Values, Mutation Arguments and Types marked with the c# [ObsoleteAttribute] will have the [@deprecated](https://spec.graphql.org/draft/#sec--deprecated) directive automatically added.
+
+You can also use the Deprecate(string reason) extension method on a IField.
+
+## One Of Input Types
+
+EntityGraphQL supports [One Of Input Types](https://github.com/graphql/graphql-spec/pull/825).
+
+Mark an input type with `GraphQLOneOfAttribute` and EntityGraphQL will mark the type with `@oneOf` in the schema and validate the input meets the requiements on execution.
+
+```cs
+[GraphQLOneOf]
+private class OneOfInputType
+{
+    public int? One { get; set; }
+    public int? Two { get; set; }
+}
+```
+
+This will generate the follow graphql schema.
+
+```graphql
+input MutationArgs @oneOf {
+  one: Int
+  two: Int
+}
+```
+
+Although each field on the input is nullable the `@oneOf` input type has one further validation step.
+
+- Exactly one key must be specified
+
+## Specified By
+
+The [@specifiedBy](https://spec.graphql.org/draft/#sec--specifiedBy) directive is used to provide extra information about a custom scalar type.
+
+## Custom Directives
+
+Like [Field Extensions](../field-extensions/) you can extend the [ExtensionAttribute](../other-extensibility/extension-attribute) to apply extension to `IFields` and `ISchemaTypes` (see `GraphQLOneOfAttribute`).
+
+IFields and ISchema types also have a method `AddDirective` that is common to call in the attribute extension method or a custom extension method to register the directive.
+
+```
+public static class DeprecatedDirectiveExtensions
+{
+    public static void Deprecate(this IField field, string? reason)
+    {
+        field.AddDirective(new DeprecatedDirective(reason));
+    }
+}
+public class ObsoleteAttributeRegistration : IExtensionAttribute<ObsoleteAttribute>
+{
+    public void ApplyExtension(IField field, ObsoleteAttribute attribute)
+    {
+        field.Deprecate(attribute.Message);
+    }
+}
+```
+
+The `ISchemaDirective` method contains:
+
+* The `On` property for marking where it is valid to use this directive
+* The `ToGraphQLSchemaString()` method where you return the formatted directive including arguments (eg `return $"@deprecated(reason: \"{Reason}\")";`)
+* A series of methods the SchemaInstrospection class calls allowing you to modify the introspection result (primarily used because instrospection for @deprecated and @oneOf is done using specific fields and not yet in an extensible way)
+
+
+## Example Sample Directive
+
+Finds the ASP.NET [Authorize] attribute and adds @authorize(roles: String, policies: String) to the schema information
+
+```
+public class AuthorizeAttributeRegistration : 
+    IExtensionAttribute<AuthorizeAttribute>,
+    IExtensionAttribute<GraphQLAuthorizePolicyAttribute>
+{
+    public void ApplyExtension(IField field, AuthorizeAttribute attribute)
+    {
+        field.AddDirective(new AuthorizeDirective(attribute));
+    }
+    public void ApplyExtension(IField field, GraphQLAuthorizePolicyAttribute attribute)
+    {
+        field.AddDirective(new AuthorizeDirective(attribute));
+    }
+    public void ApplyExtension(ISchemaType type, AuthorizeAttribute attribute)
+    {
+        type.AddDirective(new AuthorizeDirective(attribute));
+    }
+    public void ApplyExtension(ISchemaType type, GraphQLAuthorizePolicyAttribute attribute)
+    {
+        type.AddDirective(new AuthorizeDirective(attribute));
+    }
+}
+public class AuthorizeDirective : ISchemaDirective
+{
+    public AuthorizeDirective(AuthorizeAttribute authorize)
+    {
+        Roles = authorize.Roles;
+        Policies = new List<string>() { authorize.Policy! };
+    }
+    public AuthorizeDirective(GraphQLAuthorizePolicyAttribute authorize)
+    {
+        Policies = authorize.Policies;
+    }
+    public IEnumerable<TypeSystemDirectiveLocation> On => new[] {                
+        TypeSystemDirectiveLocation.OBJECT,
+        TypeSystemDirectiveLocation.FIELD_DEFINITION            
+    };
+    public string? Roles { get; }
+    public List<string> Policies { get; }
+    public string ToGraphQLSchemaString()
+    {
+        return $"@authorize(roles: \"{Roles}\", policies: \"{string.Join(", ", Policies)}\")";
+    }
+}
+```

--- a/docs/docs/other-extensibility/_category_.json
+++ b/docs/docs/other-extensibility/_category_.json
@@ -1,0 +1,5 @@
+{
+    "label": "Other Extensibility",
+    "position": 7,
+    "collapsed": false
+  }

--- a/docs/docs/other-extensibility/event-system.md
+++ b/docs/docs/other-extensibility/event-system.md
@@ -1,0 +1,39 @@
+---
+sidebar_position: 6
+---
+
+# Event System
+
+A couple of events has been added to fields to support other functionality which could be used in other ways, there is an intention to build these events out further in the future.
+
+## ISchemaType
+
+* OnAddField - called before adding a field to a type, allows you to throw an exception if the field is invalid in some way
+* OnValidate - called when validating an InputType before being passed to a mutation
+
+The `@oneOf` [Schema Directive](../directives/schema-directives) uses both these events
+
+```
+public static class OneOfDirectiveExtensions
+{
+    public static void OneOf(this ISchemaType type)
+    {
+        type.AddDirective(new OneOfDirective());
+        type.OnAddField += (field) => { 
+            if (field.ReturnType.TypeNotNullable)
+            {
+                throw new EntityQuerySchemaException($"{type.TypeDotnet.Name} is a OneOf type but all its fields are not nullable. OneOf input types require all the field to be nullable.");
+            }
+        };
+        type.OnValidate += (value) => {
+            if (value != null)
+            {
+                var singleField = value.GetType().GetProperties().Count(x => x.GetValue(value) != null);
+                
+                if (singleField != 1) // we got multiple set
+                    throw new EntityGraphQLValidationException($"Exactly one field must be specified for argument of type {type.Name}.");
+            }
+        };
+    }
+}
+```

--- a/docs/docs/other-extensibility/extension-attribute.md
+++ b/docs/docs/other-extensibility/extension-attribute.md
@@ -1,0 +1,23 @@
+---
+sidebar_position: 6
+---
+
+# Extension Attribute
+
+
+[Field Extensions](../field-extensions/) and [Schema Directives](../directives/schema-directives) use the [ExtensionAttribute] or `IExtensionAttribute` interface to apply extensions to `IFields`and  `ISchemaTypes`. 
+
+`ExtensionAttribute` is useful when building new Attributes (see `GraphQLOneOfAttribute`) whereas `IExtensionAttribute` allows you to use existing attributes (see `ObsoleteAttributeRegistration` which marks items with the [ObsoleteAttribute] as @deprecated).
+
+```
+public abstract class ExtensionAttribute : Attribute
+{
+  public virtual void ApplyExtension(IField field) { }
+  public virtual void ApplyExtension(ISchemaType type) { }
+}
+public interface IExtensionAttribute<TAttribute> where TAttribute : Attribute
+{
+  public void ApplyExtension(IField field, TAttribute attribute) { } 
+  public void ApplyExtension(ISchemaType type, TAttribute attribute) { }
+}
+```

--- a/docs/docs/schema-creation/input-types.md
+++ b/docs/docs/schema-creation/input-types.md
@@ -130,30 +130,4 @@ POST localhost:5000/graphql
 }
 ```
 
-## One Of Input Types
-
-EntityGraphQL supports [One Of Input Types](https://github.com/graphql/graphql-spec/pull/825) (A proposal for the next specification).
-
-Mark an input type with `GraphQLOneOfAttribute` and EntityGraphQL will mark the type with `@oneOf` in the schema and validate the input meets the requiements on execution.
-
-```cs
-[GraphQLOneOf]
-private class OneOfInputType
-{
-    public int? One { get; set; }
-    public int? Two { get; set; }
-}
-```
-
-This will generate the follow grpahql schema.
-
-```graphql
-input MutationArgs @oneOf {
-  one: Int
-  two: Int
-}
-```
-
-Although each field on the input is nullable the `@oneOf` input type has one further validation step.
-
-- Exactly one key must be specified
+Input types can be modified using the [OneOf](../directives/schema-directives) Schema Directive to tell clients that only one field should contain a value.

--- a/src/EntityGraphQL/Compiler/EntityGraphQLQueryWalker.cs
+++ b/src/EntityGraphQL/Compiler/EntityGraphQLQueryWalker.cs
@@ -335,12 +335,7 @@ namespace EntityGraphQL.Compiler
 
             var argType = fieldArgumentContext.GetArgumentType(argName);
             var argVal = ProcessArgumentOrVariable(argName, schemaProvider, argument, argType.Type.TypeDotnet);
-            if (argType.Type.SchemaType.IsOneOf && argVal != null)
-            {
-                var singleField = argType.Type.SchemaType.GetFields().Count(f => Expression.Lambda(f.ResolveExpression!, f.FieldParam!).Compile().DynamicInvoke(argVal) != null);
-                if (singleField != 1) // we got multiple set
-                    throw new EntityGraphQLCompilerException($"Exactly one field must be specified for argument {argName} of type {argType.Type.SchemaType.Name}.");
-            }
+           
             return argVal;
         }
 

--- a/src/EntityGraphQL/Compiler/EntityGraphQLValidationException.cs
+++ b/src/EntityGraphQL/Compiler/EntityGraphQLValidationException.cs
@@ -12,5 +12,10 @@ public class EntityGraphQLValidationException : Exception
     {
         ValidationErrors = validationErrors.Distinct(StringComparer.OrdinalIgnoreCase).ToList();
     }
+    
+    public EntityGraphQLValidationException(string validationError)
+    {
+        ValidationErrors = new List<string> { validationError };
+    }
 
 }

--- a/src/EntityGraphQL/Schema/ArgType.cs
+++ b/src/EntityGraphQL/Schema/ArgType.cs
@@ -107,6 +107,8 @@ namespace EntityGraphQL.Schema
                 validationErrors.Add(requiredAttribute.ErrorMessage != null ? $"Field '{fieldName}' - {requiredAttribute.ErrorMessage}" : $"Field '{fieldName}' - missing required argument '{Name}'");
             else if (IsRequired && val == null && DefaultValue == null)
                 validationErrors.Add($"Field '{fieldName}' - missing required argument '{Name}'");
+
+            Type.SchemaType.Validate(val);
         }
     }
 }

--- a/src/EntityGraphQL/Schema/Attributes/GraphQLOneOfAttribute.cs
+++ b/src/EntityGraphQL/Schema/Attributes/GraphQLOneOfAttribute.cs
@@ -1,9 +1,0 @@
-﻿using System;
-
-namespace EntityGraphQL.Schema
-{
-    [AttributeUsage(AttributeTargets.Class, AllowMultiple = true, Inherited = true)]
-    public class GraphQLOneOfAttribute : Attribute
-    {
-    }
-}

--- a/src/EntityGraphQL/Schema/BaseSchemaTypeWithFields.cs
+++ b/src/EntityGraphQL/Schema/BaseSchemaTypeWithFields.cs
@@ -160,8 +160,8 @@ namespace EntityGraphQL.Schema
                 (GqlType == GqlTypeEnum.Object && !directive.On.Contains(TypeSystemDirectiveLocation.OBJECT)) ||
                 (GqlType == GqlTypeEnum.Interface && !directive.On.Contains(TypeSystemDirectiveLocation.INTERFACE)) ||
                 (GqlType == GqlTypeEnum.Enum && !directive.On.Contains(TypeSystemDirectiveLocation.ENUM)) ||
-                (GqlType == GqlTypeEnum.Input && !directive.On.Contains(TypeSystemDirectiveLocation.INPUT_OBJECT))
-            //todo (GqlType == GqlTypeEnum.Union && !directive.On.Contains(TypeSystemDirectiveLocation.UNION) ||
+                (GqlType == GqlTypeEnum.Input && !directive.On.Contains(TypeSystemDirectiveLocation.INPUT_OBJECT)) ||
+                (GqlType == GqlTypeEnum.Union && !directive.On.Contains(TypeSystemDirectiveLocation.UNION))
             )
             {
                 throw new EntityQuerySchemaException($"{TypeDotnet.Name} marked with {directive.GetType().Name} directive which is not valid on a {GqlType}");

--- a/src/EntityGraphQL/Schema/BaseSchemaTypeWithFields.cs
+++ b/src/EntityGraphQL/Schema/BaseSchemaTypeWithFields.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
 using EntityGraphQL.Compiler;
+using EntityGraphQL.Schema.Directives;
 
 namespace EntityGraphQL.Schema
 {
@@ -20,7 +21,8 @@ namespace EntityGraphQL.Schema
         public IList<ISchemaType> BaseTypes => baseTypes.AsReadOnly();
         public IList<ISchemaType> PossibleTypes => possibleTypes.AsReadOnly();
 
-        public abstract bool IsOneOf { get; }
+        protected List<ISchemaDirective> directives = new();
+        public IList<ISchemaDirective> Directives => directives.AsReadOnly();
         public bool IsInput { get { return GqlType == GqlTypeEnum.Input; } }
         public bool IsInterface { get { return GqlType == GqlTypeEnum.Interface; } }
         public bool IsEnum { get { return GqlType == GqlTypeEnum.Enum; } }
@@ -30,6 +32,9 @@ namespace EntityGraphQL.Schema
         public RequiredAuthorization? RequiredAuthorization { get; set; }
         private readonly Regex nameRegex = new("^[_a-zA-Z0-9]+$");
 
+        public event Action<IField> OnAddField = delegate { };
+        public event Action<object?> OnValidate = delegate { };
+
         protected BaseSchemaTypeWithFields(ISchemaProvider schema, string name, string? description, RequiredAuthorization? requiredAuthorization)
         {
             if (!nameRegex.IsMatch(name))
@@ -38,6 +43,35 @@ namespace EntityGraphQL.Schema
             Name = name;
             Description = description;
             RequiredAuthorization = requiredAuthorization;
+        }
+
+        public void ApplyAttributes(IEnumerable<Attribute> attributes)
+        {
+            if (attributes.Any())
+            {
+                foreach (var attribute in attributes)
+                {
+                    if (attribute is ExtensionAttribute extension)
+                    {
+                        extension.ApplyExtension(this);
+                    }
+                    else
+                    {
+                        //todo is this slow? can we get access to service provider?
+                        var extensionAttribute = typeof(IExtensionAttribute<>).MakeGenericType(attribute.GetType());
+                        var extensions = AppDomain.CurrentDomain.GetAssemblies()
+                                .SelectMany(s => s.GetTypes())
+                                .Where(p => extensionAttribute.IsAssignableFrom(p));
+
+                        foreach (var extensionType in extensions)
+                        {
+                            var ext = Activator.CreateInstance(extensionType);
+                            extensionAttribute.GetMethod("ApplyExtension", new[] { typeof(ISchemaType), attribute.GetType() })!.Invoke(ext, new object[] { this, attribute });
+                        }
+
+                    }
+                }
+            }
         }
 
         /// <summary>
@@ -104,9 +138,7 @@ namespace EntityGraphQL.Schema
             if (FieldsByName.ContainsKey(field.Name))
                 throw new EntityQuerySchemaException($"Field {field.Name} already exists on type {this.Name}. Use ReplaceField() if this is intended.");
 
-            if (IsOneOf && field.ReturnType.TypeNotNullable)
-                throw new EntityQuerySchemaException($"{TypeDotnet.Name} is a OneOf type but all its fields are not nullable. OneOf input types require all the field to be nullable.");
-
+            OnAddField(field);
 
             FieldsByName.Add(field.Name, (TFieldType)field);
             return field;
@@ -119,6 +151,30 @@ namespace EntityGraphQL.Schema
         public void RemoveField(string name)
         {
             FieldsByName.Remove(name);
+        }
+
+        public ISchemaType AddDirective(ISchemaDirective directive)
+        {
+            if (
+                (GqlType == GqlTypeEnum.Scalar && !directive.On.Contains(TypeSystemDirectiveLocation.SCALAR)) ||
+                (GqlType == GqlTypeEnum.Object && !directive.On.Contains(TypeSystemDirectiveLocation.OBJECT)) ||
+                (GqlType == GqlTypeEnum.Interface && !directive.On.Contains(TypeSystemDirectiveLocation.INTERFACE)) ||
+                (GqlType == GqlTypeEnum.Enum && !directive.On.Contains(TypeSystemDirectiveLocation.ENUM)) ||
+                (GqlType == GqlTypeEnum.Input && !directive.On.Contains(TypeSystemDirectiveLocation.INPUT_OBJECT))
+            //todo (GqlType == GqlTypeEnum.Union && !directive.On.Contains(TypeSystemDirectiveLocation.UNION) ||
+            )
+            {
+                throw new EntityQuerySchemaException($"{TypeDotnet.Name} marked with {directive.GetType().Name} directive which is not valid on a {GqlType}");
+            }
+
+            directives.Add(directive);
+
+            return this;
+        }
+
+        public void Validate(object? value)
+        {
+            OnValidate(value);
         }
 
         public abstract ISchemaType ImplementAllBaseTypes(bool addTypeIfNotInSchema = true, bool addAllFieldsOnAddedType = true);

--- a/src/EntityGraphQL/Schema/ControllerType.cs
+++ b/src/EntityGraphQL/Schema/ControllerType.cs
@@ -102,21 +102,7 @@ public abstract class ControllerType
         var returnType = new GqlTypeInfo(() => SchemaType.Schema.Type(typeName), actualReturnType, method.IsNullable());
         var field = MakeField(name, method, description, options, isAsync, requiredClaims, returnType);
 
-        var validators = method.GetCustomAttributes<ArgumentValidatorAttribute>();
-        if (validators != null)
-        {
-            foreach (var validator in validators)
-            {
-                field.AddValidator(validator.Validator.ValidateAsync);
-            }
-        }
-
-        var obsoleteAttribute = method.GetCustomAttribute<ObsoleteAttribute>();
-        if (obsoleteAttribute != null)
-        {
-            field.IsDeprecated = true;
-            field.DeprecationReason = obsoleteAttribute.Message;
-        }
+        field.ApplyAttributes(method.GetCustomAttributes());
 
         // add the subscription/mutation type if it doesn't already exist
         if (!SchemaType.Schema.HasType(SchemaType.TypeDotnet))

--- a/src/EntityGraphQL/Schema/Directives/DeprecatedDirective.cs
+++ b/src/EntityGraphQL/Schema/Directives/DeprecatedDirective.cs
@@ -1,0 +1,65 @@
+﻿using EntityGraphQL.Schema.Directives;
+using EntityGraphQL.Schema.Models;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace EntityGraphQL.Schema
+{
+    public static class DeprecatedDirectiveExtensions
+    {
+        /// <summary>
+        /// Marks this field as deprecated
+        /// </summary>
+        /// <param name="reason"></param>
+        public static void Deprecate(this IField field, string? reason)
+        {
+            field.AddDirective(new DeprecatedDirective(reason));
+        }
+    }
+}
+
+namespace EntityGraphQL.Schema.Directives
+{
+    public class ObsoleteAttributeRegistration : IExtensionAttribute<ObsoleteAttribute>
+    {
+        public void ApplyExtension(IField field, ObsoleteAttribute attribute)
+        {
+            field.Deprecate(attribute.Message);
+        }
+    }
+
+    public class DeprecatedDirective : ISchemaDirective
+    {
+        public DeprecatedDirective(string? reason = null)
+        {
+            Reason = reason;
+        }
+
+        public string? Reason { get; }
+
+        public IEnumerable<TypeSystemDirectiveLocation> On => new[] {
+            TypeSystemDirectiveLocation.FIELD_DEFINITION,
+            TypeSystemDirectiveLocation.ARGUMENT_DEFINITION,
+            TypeSystemDirectiveLocation.INPUT_FIELD_DEFINITION,
+            TypeSystemDirectiveLocation.ENUM_VALUE
+        };
+
+        public void ProcessField(Models.Field field)
+        {
+            field.IsDeprecated = true;
+            field.DeprecationReason = Reason;
+        }
+
+        public void ProcessEnumValue(EnumValue enumValue)
+        {
+            enumValue.IsDeprecated = true;
+            enumValue.DeprecationReason = Reason;
+        }
+
+        public string ToGraphQLSchemaString()
+        {
+            return $"@deprecated(reason: \"{Reason}\")";
+        }
+    }
+}

--- a/src/EntityGraphQL/Schema/Directives/ISchemaDirective.cs
+++ b/src/EntityGraphQL/Schema/Directives/ISchemaDirective.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace EntityGraphQL.Schema.Directives
+{
+    public interface ISchemaDirective
+    {
+        IEnumerable<TypeSystemDirectiveLocation> On { get; }
+
+        void ProcessField(Models.Field field) { }
+        void ProcessType(Models.TypeElement type) { }
+        void ProcessEnumValue(Models.EnumValue enumValue) { }
+
+        string ToGraphQLSchemaString();
+    }
+}

--- a/src/EntityGraphQL/Schema/Directives/OneOfDirective.cs
+++ b/src/EntityGraphQL/Schema/Directives/OneOfDirective.cs
@@ -1,0 +1,68 @@
+﻿using EntityGraphQL.Compiler;
+using EntityGraphQL.Schema.Directives;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace EntityGraphQL.Schema
+{
+    public static class OneOfDirectiveExtensions
+    {
+        public static void OneOf(this ISchemaType type)
+        {
+            type.AddDirective(new OneOfDirective());
+
+            type.OnAddField += (field) => {
+                if (field.ReturnType.TypeNotNullable)
+                {
+                    throw new EntityQuerySchemaException($"{type.TypeDotnet.Name} is a OneOf type but all its fields are not nullable. OneOf input types require all the field to be nullable.");
+                }
+            };
+
+            type.OnValidate += (value) => {
+                if (value != null)
+                {
+                    var singleField = value.GetType().GetProperties().Count(x => x.GetValue(value) != null);
+
+                    if (singleField != 1) // we got multiple set
+                        throw new EntityGraphQLValidationException($"Exactly one field must be specified for argument of type {type.Name}.");
+                }
+            };
+
+        }
+    }
+}
+
+namespace EntityGraphQL.Schema.Directives
+{
+
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = true, Inherited = true)]
+    public class GraphQLOneOfAttribute : ExtensionAttribute
+    {
+        public override void ApplyExtension(ISchemaType type)
+        {
+            type.OneOf();
+        }
+    }
+
+    public class OneOfDirective : ISchemaDirective
+    {
+        public OneOfDirective()
+        {
+        }
+
+        public IEnumerable<TypeSystemDirectiveLocation> On => new[] {
+            TypeSystemDirectiveLocation.INPUT_OBJECT
+        };
+
+        public void ProcessType(Models.TypeElement type)
+        {
+            type.OneField = true;
+        }
+
+        public string ToGraphQLSchemaString()
+        {
+            return $"@oneOf";
+        }
+    }
+}

--- a/src/EntityGraphQL/Schema/Directives/SchemaDirectiveExtensions.cs
+++ b/src/EntityGraphQL/Schema/Directives/SchemaDirectiveExtensions.cs
@@ -1,0 +1,38 @@
+﻿using EntityGraphQL.Schema.Directives;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace EntityGraphQL.Schema
+{
+    public static class SchemaDirectiveExtensions
+    {
+        public static void ProcessField(this IEnumerable<ISchemaDirective> directives, Models.Field field)
+        {
+            foreach (var directive in directives)
+            {
+                directive.ProcessField(field);
+            }
+        }
+
+        public static void ProcessType(this IEnumerable<ISchemaDirective> directives, Models.TypeElement type)
+        {
+            foreach (var directive in directives)
+            {
+                directive.ProcessType(type);
+            }
+        }
+
+        public static void ProcessEnumValue(this IEnumerable<ISchemaDirective> directives, Models.EnumValue enumValue)
+        {
+            foreach (var directive in directives)
+            {
+                directive.ProcessEnumValue(enumValue);
+            }
+        }
+
+
+    }
+}

--- a/src/EntityGraphQL/Schema/Directives/SpecifiedByDirective.cs
+++ b/src/EntityGraphQL/Schema/Directives/SpecifiedByDirective.cs
@@ -1,0 +1,58 @@
+﻿using EntityGraphQL.Compiler;
+using EntityGraphQL.Schema.Directives;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace EntityGraphQL.Schema
+{
+    public static class SpecifiedByExtensions
+    {
+        public static void SpecifiedBy(this ISchemaType type, string url)
+        {
+            if (!type.IsScalar)
+            {
+                throw new EntityQuerySchemaException($"@specifiedBy can only be used on scalars");
+            }
+
+            type.AddDirective(new SpecifiedByDirective(url));
+        }
+    }
+}
+
+namespace EntityGraphQL.Schema.Directives
+{
+
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = true, Inherited = true)]
+    public class SpecifiedByDirectiveAttribute : ExtensionAttribute
+    {
+        public override void ApplyExtension(ISchemaType type)
+        {
+            type.OneOf();
+        }
+    }
+
+    public class SpecifiedByDirective : ISchemaDirective
+    {
+        public SpecifiedByDirective(string url)
+        {
+            this.Url = url;
+        }
+
+        public IEnumerable<TypeSystemDirectiveLocation> On => new[] {
+            TypeSystemDirectiveLocation.SCALAR
+        };
+
+        public void ProcessType(Models.TypeElement type)
+        {
+            type.SpecifiedByURL = Url;
+        }
+
+        public string Url { get; }
+
+        public string ToGraphQLSchemaString()
+        {
+            return $"@specifiedBy(url: \"{Url}\")";
+        }
+    }
+}

--- a/src/EntityGraphQL/Schema/Directives/TypeSystemDirectiveLocation.cs
+++ b/src/EntityGraphQL/Schema/Directives/TypeSystemDirectiveLocation.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace EntityGraphQL.Schema.Directives
+{
+    public enum TypeSystemDirectiveLocation
+    {
+        SCHEMA,
+        SCALAR,
+        OBJECT,
+        FIELD_DEFINITION,
+        ARGUMENT_DEFINITION,
+        INTERFACE,
+        UNION,
+        ENUM,
+        ENUM_VALUE,
+        INPUT_OBJECT,
+        INPUT_FIELD_DEFINITION
+    }
+}

--- a/src/EntityGraphQL/Schema/ExtensionAttribute.cs
+++ b/src/EntityGraphQL/Schema/ExtensionAttribute.cs
@@ -1,0 +1,17 @@
+using System;
+
+namespace EntityGraphQL.Schema
+{
+    public abstract class ExtensionAttribute : Attribute
+    {
+        public virtual void ApplyExtension(IField field) { }
+
+        public virtual void ApplyExtension(ISchemaType type) { }
+    }
+
+    public interface IExtensionAttribute<TAttribute> where TAttribute : Attribute
+    {
+        public void ApplyExtension(IField field, TAttribute attribute) { }
+        public void ApplyExtension(ISchemaType type, TAttribute attribute) { }
+    }
+}

--- a/src/EntityGraphQL/Schema/Field.cs
+++ b/src/EntityGraphQL/Schema/Field.cs
@@ -6,6 +6,7 @@ using System.Reflection;
 using System.Threading.Tasks;
 using EntityGraphQL.Compiler;
 using EntityGraphQL.Compiler.Util;
+using EntityGraphQL.Schema.Directives;
 using EntityGraphQL.Schema.FieldExtensions;
 
 namespace EntityGraphQL.Schema
@@ -52,13 +53,6 @@ namespace EntityGraphQL.Schema
                 var memberExp = (MemberExpression)resolve.Body;
                 ReturnType.TypeNotNullable = GraphQLNotNullAttribute.IsMemberMarkedNotNull(memberExp.Member) || ReturnType.TypeNotNullable;
                 ReturnType.ElementTypeNullable = GraphQLElementTypeNullable.IsMemberElementMarkedNullable(memberExp.Member) || ReturnType.ElementTypeNullable;
-
-                var obsoleteAttribute = memberExp.Member.GetCustomAttribute<ObsoleteAttribute>();
-                if (obsoleteAttribute != null)
-                {
-                    IsDeprecated = true;
-                    DeprecationReason = obsoleteAttribute.Message;
-                }
             }
 
             if (withServices)
@@ -76,16 +70,6 @@ namespace EntityGraphQL.Schema
                 Arguments = ExpressionUtil.ObjectToDictionaryArgs(schema, argTypes);
                 ArgumentsType = argTypes.GetType();
             }
-        }
-
-        /// <summary>
-        /// Marks this field as deprecated
-        /// </summary>
-        /// <param name="reason"></param>
-        public void Deprecate(string reason)
-        {
-            IsDeprecated = true;
-            DeprecationReason = reason;
         }
 
         /// <summary>

--- a/src/EntityGraphQL/Schema/FieldExtensions/ConnectionPaging/UseConnectionPagingExtension.cs
+++ b/src/EntityGraphQL/Schema/FieldExtensions/ConnectionPaging/UseConnectionPagingExtension.cs
@@ -10,14 +10,14 @@ namespace EntityGraphQL.Schema.FieldExtensions
         /// <param name="defaultPageSize">If no values are passed for first or last arguments. This value will be applied to the first argument</param>
         /// <param name="maxPageSize">If either argument first or last is greater than this value an error is raised</param>
         /// <returns></returns>
-        public static Field UseConnectionPaging(this Field field, int? defaultPageSize = null, int? maxPageSize = null)
+        public static IField UseConnectionPaging(this IField field, int? defaultPageSize = null, int? maxPageSize = null)
         {
             field.AddExtension(new ConnectionPagingExtension(defaultPageSize, maxPageSize));
             return field;
         }
     }
 
-    public class UseConnectionPagingAttribute : FieldExtensionAttribute
+    public class UseConnectionPagingAttribute : ExtensionAttribute
     {
         public UseConnectionPagingAttribute()
         {
@@ -36,7 +36,7 @@ namespace EntityGraphQL.Schema.FieldExtensions
 
         public int? DefaultPageSize { get; set; }
         public int? MaxPageSize { get; set; }
-        public override void ApplyExtension(Field field)
+        public override void ApplyExtension(IField field)
         {
             field.UseConnectionPaging(DefaultPageSize, MaxPageSize);
         }

--- a/src/EntityGraphQL/Schema/FieldExtensions/FieldExtensionAttribute.cs
+++ b/src/EntityGraphQL/Schema/FieldExtensions/FieldExtensionAttribute.cs
@@ -1,9 +1,0 @@
-using System;
-
-namespace EntityGraphQL.Schema.FieldExtensions
-{
-    public abstract class FieldExtensionAttribute : Attribute
-    {
-        public abstract void ApplyExtension(Field field);
-    }
-}

--- a/src/EntityGraphQL/Schema/FieldExtensions/Filter/UseFilterExtension.cs
+++ b/src/EntityGraphQL/Schema/FieldExtensions/Filter/UseFilterExtension.cs
@@ -9,16 +9,16 @@ namespace EntityGraphQL.Schema.FieldExtensions
         /// </summary>
         /// <param name="field"></param>
         /// <returns></returns>
-        public static Field UseFilter(this Field field)
+        public static IField UseFilter(this IField field)
         {
             field.AddExtension(new FilterExpressionExtension());
             return field;
         }
     }
 
-    public class UseFilterAttribute : FieldExtensionAttribute
+    public class UseFilterAttribute : ExtensionAttribute
     {
-        public override void ApplyExtension(Field field)
+        public override void ApplyExtension(IField field)
         {
             field.UseFilter();
         }

--- a/src/EntityGraphQL/Schema/FieldExtensions/OffsetPaging/OffsetPaging.cs
+++ b/src/EntityGraphQL/Schema/FieldExtensions/OffsetPaging/OffsetPaging.cs
@@ -10,14 +10,14 @@ namespace EntityGraphQL.Schema.FieldExtensions
         /// <param name="defaultPageSize">If argument take is null this value will be used</param>
         /// <param name="maxPageSize">If argument take is greater than this value an error will be raised</param>
         /// <returns></returns>
-        public static Field UseOffsetPaging(this Field field, int? defaultPageSize = null, int? maxPageSize = null)
+        public static IField UseOffsetPaging(this IField field, int? defaultPageSize = null, int? maxPageSize = null)
         {
             field.AddExtension(new OffsetPagingExtension(defaultPageSize, maxPageSize));
             return field;
         }
     }
 
-    public class UseOffsetPagingAttribute : FieldExtensionAttribute
+    public class UseOffsetPagingAttribute : ExtensionAttribute
     {
         public int? DefaultPageSize { get; set; }
         public int? MaxPageSize { get; set; }
@@ -34,7 +34,7 @@ namespace EntityGraphQL.Schema.FieldExtensions
             MaxPageSize = maxPageSize;
         }
 
-        public override void ApplyExtension(Field field)
+        public override void ApplyExtension(IField field)
         {
             field.UseOffsetPaging(DefaultPageSize, MaxPageSize);
         }

--- a/src/EntityGraphQL/Schema/FieldExtensions/Sorting/UseSortExtension.cs
+++ b/src/EntityGraphQL/Schema/FieldExtensions/Sorting/UseSortExtension.cs
@@ -13,7 +13,7 @@ namespace EntityGraphQL.Schema.FieldExtensions
         /// <param name="fieldSelection">Select the fields you want available for sorting.
         /// T must be the context of the collection you are applying the sort to</param>
         /// <returns></returns>
-        public static Field UseSort<ElementType, ReturnType>(this Field field, Expression<Func<ElementType, ReturnType>> fieldSelection)
+        public static IField UseSort<ElementType, ReturnType>(this IField field, Expression<Func<ElementType, ReturnType>> fieldSelection)
         {
             field.AddExtension(new SortExtension(fieldSelection.ReturnType, null, null));
             return field;
@@ -28,7 +28,7 @@ namespace EntityGraphQL.Schema.FieldExtensions
         /// <param name="defaultSort">Sort to use if no sort argument supplied in query</param>
         /// <param name="direction">Direction of the default sort</param>
         /// <returns></returns>
-        public static Field UseSort<ElementType, ReturnType, TSort>(this Field field, Expression<Func<ElementType, ReturnType>> fieldSelection, Expression<Func<ElementType, TSort>> defaultSort, SortDirectionEnum direction)
+        public static IField UseSort<ElementType, ReturnType, TSort>(this IField field, Expression<Func<ElementType, ReturnType>> fieldSelection, Expression<Func<ElementType, TSort>> defaultSort, SortDirectionEnum direction)
         {
             field.AddExtension(new SortExtension(fieldSelection.ReturnType, defaultSort, direction));
             return field;
@@ -42,7 +42,7 @@ namespace EntityGraphQL.Schema.FieldExtensions
         /// <param name="defaultSort">Sort to use if no sort argument supplied in query</param>
         /// <param name="direction">Direction of the default sort</param>
         /// <returns></returns>
-        public static Field UseSort<ElementType, TSort>(this Field field, Expression<Func<ElementType, TSort>> defaultSort, SortDirectionEnum direction)
+        public static IField UseSort<ElementType, TSort>(this IField field, Expression<Func<ElementType, TSort>> defaultSort, SortDirectionEnum direction)
         {
             field.AddExtension(new SortExtension(null, defaultSort, direction));
             return field;
@@ -54,18 +54,18 @@ namespace EntityGraphQL.Schema.FieldExtensions
         /// </summary>
         /// <param name="field"></param>
         /// <returns></returns>
-        public static Field UseSort(this Field field)
+        public static IField UseSort(this IField field)
         {
             field.AddExtension(new SortExtension(null, null, null));
             return field;
         }
     }
 
-    public class UseSortAttribute : FieldExtensionAttribute
+    public class UseSortAttribute : ExtensionAttribute
     {
         public UseSortAttribute() { }
 
-        public override void ApplyExtension(Field field)
+        public override void ApplyExtension(IField field)
         {
             field.UseSort();
         }

--- a/src/EntityGraphQL/Schema/IField.cs
+++ b/src/EntityGraphQL/Schema/IField.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq.Expressions;
 using EntityGraphQL.Compiler;
 using EntityGraphQL.Compiler.Util;
+using EntityGraphQL.Schema.Directives;
 using EntityGraphQL.Schema.FieldExtensions;
 
 namespace EntityGraphQL.Schema
@@ -35,8 +36,8 @@ namespace EntityGraphQL.Schema
         List<IFieldExtension> Extensions { get; set; }
         RequiredAuthorization? RequiredAuthorization { get; }
 
-        bool IsDeprecated { get; set; }
-        string? DeprecationReason { get; set; }
+        IList<ISchemaDirective> Directives { get; }
+        IField AddDirective(ISchemaDirective directive);
 
         ArgType GetArgumentType(string argName);
         bool HasArgumentByName(string argName);

--- a/src/EntityGraphQL/Schema/ISchemaType.cs
+++ b/src/EntityGraphQL/Schema/ISchemaType.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using EntityGraphQL.Schema.Directives;
 
 namespace EntityGraphQL.Schema
 {
@@ -21,11 +22,7 @@ namespace EntityGraphQL.Schema
         /// <summary>
         /// True if GqlType is GqlTypeEnum.Input
         /// </summary>
-        bool IsInput { get; }
-        /// <summary>
-        /// True if type is a Input @oneOf union
-        /// </summary>
-        bool IsOneOf { get; }
+        bool IsInput { get; }        
         /// <summary>
         /// True if GqlType is GqlTypeEnum.Interface
         /// </summary>
@@ -46,6 +43,10 @@ namespace EntityGraphQL.Schema
         bool RequiresSelection { get; }
         IList<ISchemaType> BaseTypes { get; }
         IList<ISchemaType> PossibleTypes { get; }
+
+        IList<ISchemaDirective> Directives { get; }
+        ISchemaType AddDirective(ISchemaDirective directive);
+        void ApplyAttributes(IEnumerable<Attribute> attributes);
         RequiredAuthorization? RequiredAuthorization { get; set; }
         IField GetField(string identifier, QueryRequestContext? requestContext);
         IEnumerable<IField> GetFields();
@@ -77,5 +78,10 @@ namespace EntityGraphQL.Schema
         /// <param name="typeName"></param>
         /// <returns></returns>
         ISchemaType Implements(string typeName);
+
+        void Validate(object? value);
+
+        public event Action<IField> OnAddField;
+        public event Action<object?> OnValidate;
     }
 }

--- a/src/EntityGraphQL/Schema/MethodField.cs
+++ b/src/EntityGraphQL/Schema/MethodField.cs
@@ -73,12 +73,6 @@ namespace EntityGraphQL.Schema
                 schema.AddInputType(inputType, inputType.Name, null).AddAllFields();
         }
 
-        public void Deprecate(string reason)
-        {
-            IsDeprecated = true;
-            DeprecationReason = reason;
-        }
-
         public virtual async Task<object?> CallAsync(object? context, IReadOnlyDictionary<string, object>? gqlRequestArgs, GraphQLValidator validator, IServiceProvider? serviceProvider, ParameterExpression? variableParameter, object? docVariables)
         {
             if (context == null)

--- a/src/EntityGraphQL/Schema/Models/Introspection.cs
+++ b/src/EntityGraphQL/Schema/Models/Introspection.cs
@@ -50,6 +50,8 @@ namespace EntityGraphQL.Schema.Models
         public TypeElement[] PossibleTypes { get; set; } = new TypeElement[0];
         public TypeElement? OfType { get; set; }
         public bool OneField { get; set; }
+        // may be non-null for custom SCALAR, otherwise null.
+        public string? SpecifiedByURL { get; set; }
     }
 
     public partial class Field

--- a/src/EntityGraphQL/Schema/MutationSchemaType.cs
+++ b/src/EntityGraphQL/Schema/MutationSchemaType.cs
@@ -8,8 +8,6 @@ namespace EntityGraphQL.Schema;
 public class MutationSchemaType : BaseSchemaTypeWithFields<MutationField>
 {
     public override Type TypeDotnet => typeof(MutationType);
-    public override bool IsOneOf => false;
-
     public MutationSchemaType(ISchemaProvider schema, string name, string? description, RequiredAuthorization? requiredAuthorization)
         : base(schema, name, description, requiredAuthorization)
     {

--- a/src/EntityGraphQL/Schema/SchemaBuilder.cs
+++ b/src/EntityGraphQL/Schema/SchemaBuilder.cs
@@ -174,7 +174,7 @@ namespace EntityGraphQL.Schema
             }
 
             LambdaExpression le = Expression.Lambda(prop.MemberType == MemberTypes.Property ? Expression.Property(param, prop.Name) : Expression.Field(param, prop.Name), param);
-            var attributes = prop.GetCustomAttributes(typeof(GraphQLAuthorizeAttribute), true).Cast<GraphQLAuthorizeAttribute>();
+            
             var requiredClaims = schema.AuthorizationService.GetRequiredAuthFromMember(prop);
             // get the object type returned (ignoring list etc) so we know the context to find fields etc
             Type returnType;
@@ -215,14 +215,7 @@ namespace EntityGraphQL.Schema
                     }
                 }
 
-                var extensions = prop.GetCustomAttributes(typeof(FieldExtensionAttribute), false)?.Cast<FieldExtensionAttribute>().ToList();
-                if (extensions?.Count > 0)
-                {
-                    foreach (var extension in extensions)
-                    {
-                        extension.ApplyExtension(field);
-                    }
-                }
+                field.ApplyAttributes(prop.GetCustomAttributes());
 
                 yield return field;
             }
@@ -293,6 +286,10 @@ namespace EntityGraphQL.Schema
                     {
                         type.ImplementAllBaseTypes(true, true);
                     }
+
+                    var schemaType = schema.GetSchemaType(propType, null);
+                    schemaType.ApplyAttributes(propType.GetCustomAttributes());
+
                     return type;
                 }
             }

--- a/src/EntityGraphQL/Schema/SchemaIntrospection.cs
+++ b/src/EntityGraphQL/Schema/SchemaIntrospection.cs
@@ -48,6 +48,8 @@
             {
                 var typeElement = new TypeElement("SCALAR", customScalar.Name);
 
+                customScalar.Directives.ProcessType(typeElement);
+
                 types.Add(typeElement);
             }
 
@@ -130,10 +132,11 @@
 
                 var typeElement = new TypeElement("INPUT_OBJECT", schemaType.Name)
                 {
-                    OneField = schemaType.IsOneOf,
                     Description = schemaType.Description,
                     InputFields = inputValues.ToArray()
                 };
+
+                schemaType.Directives.ProcessType(typeElement);
 
                 types.Add(typeElement);
             }
@@ -163,12 +166,14 @@
                     if (field.Name.StartsWith("__"))
                         continue;
 
-                    enumTypes.Add(new EnumValue(field.Name)
+                    var e = new EnumValue(field.Name)
                     {
                         Description = field.Description,
-                        IsDeprecated = field.IsDeprecated,
-                        DeprecationReason = field.DeprecationReason
-                    });
+                    };
+
+                    field.Directives.ProcessEnumValue(e);
+
+                    enumTypes.Add(e);
                 }
 
                 typeElement.EnumValues = enumTypes.ToArray();
@@ -251,13 +256,15 @@
                 if (field.Name.StartsWith("__"))
                     continue;
 
-                fieldDescs.Add(new Models.Field(schema.SchemaFieldNamer(field.Name), BuildType(schema, field.ReturnType, field.ReturnType.TypeDotnet))
+                var f = new Models.Field(schema.SchemaFieldNamer(field.Name), BuildType(schema, field.ReturnType, field.ReturnType.TypeDotnet))
                 {
                     Args = BuildArgs(schema, field).ToArray(),
-                    DeprecationReason = field.DeprecationReason,
                     Description = field.Description,
-                    IsDeprecated = field.IsDeprecated,
-                });
+                };
+
+                field.Directives.ProcessField(f);
+
+                fieldDescs.Add(f);
             }
             return fieldDescs.ToArray();
         }
@@ -276,13 +283,15 @@
                     continue;
 
                 //== Fields ==//
-                rootFields.Add(new Models.Field(field.Name, BuildType(schema, field.ReturnType, field.ReturnType.TypeDotnet))
+                var f = new Models.Field(field.Name, BuildType(schema, field.ReturnType, field.ReturnType.TypeDotnet))
                 {
                     Args = BuildArgs(schema, field).ToArray(),
-                    IsDeprecated = field.IsDeprecated,
-                    DeprecationReason = field.DeprecationReason,
                     Description = field.Description
-                });
+                };
+
+                field.Directives.ProcessField(f);
+
+                rootFields.Add(f);
             }
             return rootFields.ToArray();
         }
@@ -297,13 +306,15 @@
                     continue;
 
                 var args = BuildArgs(schema, field).ToArray();
-                rootFields.Add(new Models.Field(field.Name, BuildType(schema, field.ReturnType, field.ReturnType.TypeDotnet))
+                var f = new Models.Field(field.Name, BuildType(schema, field.ReturnType, field.ReturnType.TypeDotnet))
                 {
                     Args = args,
-                    IsDeprecated = field.IsDeprecated,
-                    DeprecationReason = field.DeprecationReason,
                     Description = field.Description
-                });
+                };
+
+                field.Directives.ProcessField(f);
+
+                rootFields.Add(f);
             }
             return rootFields.ToArray();
         }

--- a/src/tests/EntityGraphQL.AspNet.Tests/AuthorizeDirective.cs
+++ b/src/tests/EntityGraphQL.AspNet.Tests/AuthorizeDirective.cs
@@ -1,0 +1,62 @@
+﻿using EntityGraphQL.AspNet;
+using EntityGraphQL.Schema.Directives;
+using EntityGraphQL.Schema.Models;
+using Microsoft.AspNetCore.Authorization;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace EntityGraphQL.Schema.Directives
+{
+    public class AuthorizeAttributeRegistration :
+        IExtensionAttribute<AuthorizeAttribute>,
+        IExtensionAttribute<GraphQLAuthorizePolicyAttribute>
+    {
+        public void ApplyExtension(IField field, AuthorizeAttribute attribute)
+        {
+            field.AddDirective(new AuthorizeDirective(attribute));
+        }
+
+        public void ApplyExtension(IField field, GraphQLAuthorizePolicyAttribute attribute)
+        {
+            field.AddDirective(new AuthorizeDirective(attribute));
+        }
+
+        public void ApplyExtension(ISchemaType type, AuthorizeAttribute attribute)
+        {
+            type.AddDirective(new AuthorizeDirective(attribute));
+        }
+
+        public void ApplyExtension(ISchemaType type, GraphQLAuthorizePolicyAttribute attribute)
+        {
+            type.AddDirective(new AuthorizeDirective(attribute));
+        }
+    }
+
+    public class AuthorizeDirective : ISchemaDirective
+    {
+        public AuthorizeDirective(AuthorizeAttribute authorize)
+        {
+            Roles = authorize.Roles;
+            Policies = new List<string>() { authorize.Policy! };
+        }
+
+        public AuthorizeDirective(GraphQLAuthorizePolicyAttribute authorize)
+        {
+            Policies = authorize.Policies;
+        }
+
+        public IEnumerable<TypeSystemDirectiveLocation> On => new[] {
+            TypeSystemDirectiveLocation.OBJECT,
+            TypeSystemDirectiveLocation.FIELD_DEFINITION
+        };
+
+        public string? Roles { get; }
+        public List<string> Policies { get; }
+
+        public string ToGraphQLSchemaString()
+        {
+            return $"@authorize(roles: \"{Roles}\", policies: \"{string.Join(", ", Policies)}\")";
+        }
+    }
+}

--- a/src/tests/EntityGraphQL.AspNet.Tests/PoliciesTests.cs
+++ b/src/tests/EntityGraphQL.AspNet.Tests/PoliciesTests.cs
@@ -17,6 +17,10 @@ namespace EntityGraphQL.AspNet.Tests
             var schema = SchemaBuilder.FromObject<PolicyDataContext>(new SchemaBuilderSchemaOptions { AuthorizationService = new PolicyOrRoleBasedAuthorization(services.GetService<IAuthorizationService>()!) });
             Assert.Single(schema.Type<Project>().RequiredAuthorization!.Policies);
             Assert.Equal("admin", schema.Type<Project>().RequiredAuthorization!.Policies.ElementAt(0).ElementAt(0));
+
+            var sdl = schema.ToGraphQLSchemaString();
+            Assert.Contains("type Project @authorize(roles: \"\", policies: \"admin\") {", sdl);
+            Assert.Contains("type: Int! @authorize(roles: \"\", policies: \"can-type\")", sdl);
         }
 
         [Fact]
@@ -30,7 +34,7 @@ namespace EntityGraphQL.AspNet.Tests
             schema.AddType<Project>("Project");
 
             Assert.Single(schema.Type<Project>().RequiredAuthorization!.Policies);
-            Assert.Equal("admin", schema.Type<Project>().RequiredAuthorization!.Policies.ElementAt(0).ElementAt(0));
+            Assert.Equal("admin", schema.Type<Project>().RequiredAuthorization!.Policies.ElementAt(0).ElementAt(0));            
         }
 
         [Fact]

--- a/src/tests/EntityGraphQL.Tests/ErrorTests.cs
+++ b/src/tests/EntityGraphQL.Tests/ErrorTests.cs
@@ -9,7 +9,7 @@ namespace EntityGraphQL.Tests
         public void MutationReportsError()
         {
             var schemaProvider = SchemaBuilder.FromObject<TestDataContext>();
-            schemaProvider.AddMutationsFrom<PeopleMutations>();
+            schemaProvider.AddMutationsFrom<PeopleMutations>(new SchemaBuilderMethodOptions() {  AutoCreateInputTypes = true });
             // Add a argument field with a require parameter
             var gql = new QueryRequest
             {

--- a/src/tests/EntityGraphQL.Tests/IntrospectionTests/IntrospectionTests.cs
+++ b/src/tests/EntityGraphQL.Tests/IntrospectionTests/IntrospectionTests.cs
@@ -198,6 +198,9 @@ fragment TypeRef on __Type {
             var fields = (IEnumerable<dynamic>)((dynamic)res.Data["__type"]).fields;
             Assert.True(Enumerable.Any(fields));
             Assert.DoesNotContain(fields, f => f.name == "owner");
+
+            var sdl = schema.ToGraphQLSchemaString();
+            Assert.Contains("owner: Person @deprecated(reason: \"This is deprecated\")", sdl);
         }
 
         [Fact]
@@ -229,6 +232,9 @@ fragment TypeRef on __Type {
             var fields = (IEnumerable<dynamic>)((dynamic)res.Data["__type"]).fields;
             Assert.True(Enumerable.Any(fields));
             Assert.DoesNotContain(fields, f => f.name == "projectsOld");
+
+            var sdl = schema.ToGraphQLSchemaString();
+            Assert.Contains("projectsOld: [ProjectOld!] @deprecated(reason: \"This is obsolete, use Projects instead\")", sdl);
         }
 
 

--- a/src/tests/EntityGraphQL.Tests/MutationTests/MutationTests.cs
+++ b/src/tests/EntityGraphQL.Tests/MutationTests/MutationTests.cs
@@ -33,7 +33,7 @@ namespace EntityGraphQL.Tests
         public void SupportsMutationOptional()
         {
             var schemaProvider = SchemaBuilder.FromObject<TestDataContext>();
-            schemaProvider.AddMutationsFrom<PeopleMutations>();
+            schemaProvider.AddMutationsFrom<PeopleMutations>(new SchemaBuilderMethodOptions() { AutoCreateInputTypes = true });
             // Add a argument field with a require parameter
             var gql = new QueryRequest
             {
@@ -61,7 +61,7 @@ namespace EntityGraphQL.Tests
         public void SupportsMutationArrayArg()
         {
             var schemaProvider = SchemaBuilder.FromObject<TestDataContext>();
-            schemaProvider.AddMutationsFrom<PeopleMutations>();
+            schemaProvider.AddMutationsFrom<PeopleMutations>(new SchemaBuilderMethodOptions() { AutoCreateInputTypes = true });
             // Add a argument field with a require parameter
             var gql = new QueryRequest
             {
@@ -95,7 +95,7 @@ namespace EntityGraphQL.Tests
             // ctx => ctx.People.First(p => p.Id == myNewPerson.Id)
             // that myNewPerson.Id does not get replace by something dumb like p.Id == p.Id
             var schemaProvider = SchemaBuilder.FromObject<TestDataContext>();
-            schemaProvider.AddMutationsFrom<PeopleMutations>();
+            schemaProvider.AddMutationsFrom<PeopleMutations>(new SchemaBuilderMethodOptions() { AutoCreateInputTypes = true });
             // Add a argument field with a require parameter
             var query = @"mutation AddPerson($names: [String]) {
   addPersonNamesExpression(names: $names) {
@@ -293,7 +293,7 @@ namespace EntityGraphQL.Tests
         public void SupportsSelectionFromConstant()
         {
             var schemaProvider = SchemaBuilder.FromObject<TestDataContext>();
-            schemaProvider.AddMutationsFrom<PeopleMutations>();
+            schemaProvider.AddMutationsFrom<PeopleMutations>(new SchemaBuilderMethodOptions() { AutoCreateInputTypes = true });
             // Add a argument field with a require parameter
             var gql = new QueryRequest
             {
@@ -328,7 +328,7 @@ namespace EntityGraphQL.Tests
                 type.AddField("age", "Person's age")
                     .ResolveWithService<AgeService>((p, service) => service.GetAge(p.Birthday));
             });
-            schemaProvider.AddMutationsFrom<PeopleMutations>();
+            schemaProvider.AddMutationsFrom<PeopleMutations>(new SchemaBuilderMethodOptions() { AutoCreateInputTypes = true });
             // Add a argument field with a require parameter
             var gql = new QueryRequest
             {
@@ -370,7 +370,7 @@ namespace EntityGraphQL.Tests
                 type.AddField("age", "Person's age")
                     .ResolveWithService<AgeService>((p, service) => service.GetAge(p.Birthday));
             });
-            schemaProvider.AddMutationsFrom<PeopleMutations>();
+            schemaProvider.AddMutationsFrom<PeopleMutations>(new SchemaBuilderMethodOptions() { AutoCreateInputTypes = true });
             // Add a argument field with a require parameter
             var gql = new QueryRequest
             {
@@ -406,7 +406,7 @@ namespace EntityGraphQL.Tests
         public void MutationReturnsCollectionConst()
         {
             var schemaProvider = SchemaBuilder.FromObject<TestDataContext>();
-            schemaProvider.AddMutationsFrom<PeopleMutations>();
+            schemaProvider.AddMutationsFrom<PeopleMutations>(new SchemaBuilderMethodOptions() { AutoCreateInputTypes = true });
             // Add a argument field with a require parameter
             var gql = new QueryRequest
             {
@@ -700,7 +700,7 @@ namespace EntityGraphQL.Tests
         public void TestComplexReturn()
         {
             var schemaProvider = SchemaBuilder.FromObject<TestDataContext>();
-            schemaProvider.AddMutationsFrom<PeopleMutations>();
+            schemaProvider.AddMutationsFrom<PeopleMutations>(new SchemaBuilderMethodOptions() { AutoCreateInputTypes = true });
             schemaProvider.AddInputType<DecimalInput>("DecimalInput", "DecimalInput").AddAllFields();
             var gql = new QueryRequest
             {

--- a/src/tests/EntityGraphQL.Tests/SchemaTests/SchemaProviderTests.cs
+++ b/src/tests/EntityGraphQL.Tests/SchemaTests/SchemaProviderTests.cs
@@ -2,6 +2,7 @@ using Xunit;
 using EntityGraphQL.Tests.ApiVersion1;
 using System.Linq;
 using System;
+using EntityGraphQL.Schema;
 
 namespace EntityGraphQL.Tests
 {
@@ -86,6 +87,46 @@ namespace EntityGraphQL.Tests
         {
             var schema = new TestObjectGraphSchema();
             Assert.True(schema.HasType(typeof(byte[])));
+        }
+
+        [Fact]
+        public void Scalar_SpecifiedBy()
+        {
+            var schema = new TestObjectGraphSchema();
+            schema.Type<int>().SpecifiedBy("https://www.example.com");
+            var sdl = schema.ToGraphQLSchemaString();
+
+            Assert.Contains("scalar Int @specifiedBy(url: \"https://www.example.com\")", sdl);
+
+            var gql = new QueryRequest
+            {
+                Query = @"
+                    query IntrospectionQuery {
+                        __type(name: ""Int"") {
+                            name
+                            specifiedByURL
+                        }
+                    }
+                "
+            };
+
+            var context = new TestDataContext();
+
+            var res = schema.ExecuteRequest(gql, context, null, null);
+            Assert.Null(res.Errors);
+
+            var schemaType = (dynamic)((dynamic)res.Data["__type"]);
+            Assert.Equal("https://www.example.com", schemaType.specifiedByURL);
+        }
+
+        [Fact]
+        public void Scalar_SpecifiedBy_ErrorsOnObjectType()
+        {
+            var schema = new TestObjectGraphSchema();
+
+            var ex = Assert.Throws<EntityQuerySchemaException>(() => { schema.Type<Person>().SpecifiedBy("https://www.example.com"); });
+
+            Assert.Equal("@specifiedBy can only be used on scalars", ex.Message);
         }
     }
 }

--- a/src/tests/EntityGraphQL.Tests/SerializationTests.cs
+++ b/src/tests/EntityGraphQL.Tests/SerializationTests.cs
@@ -105,7 +105,7 @@ namespace EntityGraphQL.AspNet.Tests
         public void JsonNewtonsoftJValue()
         {
             var schemaProvider = SchemaBuilder.FromObject<TestDataContext>();
-            schemaProvider.AddMutationsFrom<PeopleMutations>();
+            schemaProvider.AddMutationsFrom<PeopleMutations>(new SchemaBuilderMethodOptions() {  AutoCreateInputTypes = true });
             schemaProvider.AddCustomTypeConverter(new JObjectTypeConverter());
             schemaProvider.AddCustomTypeConverter(new JTokenTypeConverter());
             schemaProvider.AddCustomTypeConverter(new JValueTypeConverter());


### PR DESCRIPTION
Starting to refactor towards handling new schema directives (currently theres @deprecated and @oneOf).

Ultimately I was hoping to be able to include @auth and @required directives in my SDL (given a bunch of tools support it) but it's not an official standard.

~~A breaking change since I remove a couple of setters (although that could probably be reverted)~~

Currently trying to figure out if this a valuable refactor given that graphql doesn't currently support custom schema directives (lots of discussions on it from what I see but nothing final)

Thinking it might be nice to allow extensibility in the SchemaGenerator.


