### PR TITLE
Mutation autoAddInputTypes ignored without FromObject

### DIFF
--- a/src/tests/EntityGraphQL.Tests/MutationTests/MutationMethodParameterTests.cs
+++ b/src/tests/EntityGraphQL.Tests/MutationTests/MutationMethodParameterTests.cs
@@ -118,7 +118,44 @@ namespace EntityGraphQL.Tests
         }
 
         [Fact]
-        public void TestSeparateArguments_AutoAddInputTypes()
+        public void TestSingleArgument_AutoAddInputTypes_NestedType() {
+            var schemaProvider = SchemaBuilder.FromObject<TestDataContext>();
+            schemaProvider.AddMutationsFrom<PeopleMutations>(true, true);
+            // Add a argument field with a required parameter that is defined in a nested class
+            var gql = new QueryRequest {
+                Query = @"mutation AddPersonSingleArgumentNestedType($nameInput: InputObject) {
+                  addPersonSingleArgumentNestedType(nameInput: $nameInput) { id name }
+                }",
+                Variables = new QueryVariables {
+                    { "nameInput", new InputObject() { Name = "Frank" } },
+                }
+            };
+            var res = schemaProvider.ExecuteRequest(gql, new TestDataContext(), null, null);
+            Assert.Null(res.Errors);
+        }
+
+        [Fact]
+        public void TestSeparateArguments_AutoAddInputTypes() {
+            var schemaProvider = SchemaBuilder.FromObject<TestDataContext>();
+            schemaProvider.AddMutationsFrom<PeopleMutations>(true);
+            // Add a argument field with a require parameter
+            var gql = new QueryRequest {
+                Query = @"mutation AddPersonSeparateArguments($name: String!, $names: [String!], $nameInput: InputObject, $gender: Gender) {
+                  addPersonSeparateArguments(name: $name, names: $names, nameInput: $nameInput, gender: $gender) { id name }
+                }",
+                Variables = new QueryVariables {
+                    { "name", "Frank" },
+                    { "names", new [] { "Frank" } },
+                    { "nameInput", null },
+                    { "gender", Gender.Female }
+                }
+            };
+            var res = schemaProvider.ExecuteRequest(gql, new TestDataContext(), null, null);
+            Assert.Null(res.Errors);
+        }
+
+        [Fact]
+        public void TestSeparateArguments_DefaultSchemaBuilder_AutoAddInputTypes()
         {
             var schemaProvider = new SchemaProvider<TestDataContext>();
             schemaProvider.AddType<Person>(nameof(Person), null);

--- a/src/tests/EntityGraphQL.Tests/MutationTests/MutationMethodParameterTests.cs
+++ b/src/tests/EntityGraphQL.Tests/MutationTests/MutationMethodParameterTests.cs
@@ -120,8 +120,9 @@ namespace EntityGraphQL.Tests
         [Fact]
         public void TestSeparateArguments_AutoAddInputTypes()
         {
-            var schemaProvider = SchemaBuilder.FromObject<TestDataContext>();
-            schemaProvider.AddMutationsFrom<PeopleMutations>(true);
+            var schemaProvider = new SchemaProvider<TestDataContext>();
+            schemaProvider.AddType<Person>(nameof(Person), null);
+            schemaProvider.AddMutationsFrom<PeopleMutations>(autoAddInputTypes: true);
             // Add a argument field with a require parameter
             var gql = new QueryRequest
             {

--- a/src/tests/EntityGraphQL.Tests/MutationTests/PeopleMutations.cs
+++ b/src/tests/EntityGraphQL.Tests/MutationTests/PeopleMutations.cs
@@ -41,6 +41,18 @@ namespace EntityGraphQL.Tests
 
         [GraphQLMutation]
 
+        public Person AddPersonSingleArgumentNestedType(NestedInputObject nameInput) {
+            return new Person { Name = string.IsNullOrEmpty(nameInput.Name) ? "Default" : nameInput.Name, Id = 555, Projects = new List<Project>() };
+        }
+
+        public class NestedInputObject {
+            public string Name { get; set; }
+            public string LastName { get; set; }
+            public DateTime? Birthday { get; set; }
+        }
+
+        [GraphQLMutation]
+
         public Person AddInputWithChildWithId(ListOfObjectsWithIds nameInput)
         {
             return null;

--- a/src/tests/EntityGraphQL.Tests/TestDataContext.cs
+++ b/src/tests/EntityGraphQL.Tests/TestDataContext.cs
@@ -28,6 +28,13 @@ namespace EntityGraphQL.Tests
         public List<User> Users { get; set; } = new List<User>();
     }
 
+    public class TestDataContext2
+    {
+        public List<Task> Tasks { get; set; } = new();
+        public List<Person> People { get; set; } = new();
+        public List<User> Users { get; set; } = new();
+    }
+
     public class ProjectOld
     {
     }


### PR DESCRIPTION
The `autoAddInputTypes` parameter for `AddMutationsFrom` doesn't seem to have any effect if the schemaProvider wasn't created with `SchemaBuilder.FromObject`.

The unit test result shows `Person.id` missing, ~but I suspect there are more problems beyond that. I came across this by noticing in my own code that the arguments to my mutation were missing, as if autoAddInputTypes had not been set to true.~

~A related problem is that EntityGraphQL silently removed the arguments from the mutation, rather than reported an error.~