### PR TITLE
add DateTimeOffset support

### DIFF
--- a/src/EntityGraphQL/Schema/SchemaProvider.cs
+++ b/src/EntityGraphQL/Schema/SchemaProvider.cs
@@ -64,6 +64,7 @@ namespace EntityGraphQL.Schema
 
             // default custom scalar for DateTime
             schemaTypes.Add("Date", new SchemaType<DateTime>(this, "Date", "Date with time scalar", null, GqlTypeEnum.Scalar));
+            schemaTypes.Add("DateTimeOffset", new SchemaType<DateTimeOffset>(this, "DateTimeOffset", "DateTimeOffset scalar", null, GqlTypeEnum.Scalar));
 
             customTypeMappings = new Dictionary<Type, GqlTypeInfo> {
                 {typeof(sbyte), new GqlTypeInfo(() => Type("Int"), typeof(sbyte))},

--- a/src/tests/EntityGraphQL.Tests/QueryTests/QueryTests.cs
+++ b/src/tests/EntityGraphQL.Tests/QueryTests/QueryTests.cs
@@ -324,6 +324,28 @@ namespace EntityGraphQL.Tests
             var results = schemaProvider.ExecuteRequest(gql, testSchema, null, null);
             Assert.Null(results.Errors);
         }
+        
+        [Fact]
+        public void DateScalarsTest()
+        {
+            var schemaProvider = SchemaBuilder.FromObject<TestDataContext>();
+            var gql = new QueryRequest
+            {
+                Query = @"{
+  projects {
+      created
+      updated
+  }
+}
+",
+            };
+
+            var testSchema = new TestDataContext().FillWithTestData();
+            var result = schemaProvider.ExecuteRequest(gql, testSchema, null, null);
+            Assert.Null(result.Errors);
+            Assert.NotNull(((dynamic)result.Data["projects"])[0].created);
+            Assert.NotNull(((dynamic)result.Data["projects"])[0].updated);
+        }
 
         [Fact]
         public void TestTopLevelScalar()

--- a/src/tests/EntityGraphQL.Tests/TestDataContext.cs
+++ b/src/tests/EntityGraphQL.Tests/TestDataContext.cs
@@ -99,6 +99,7 @@ namespace EntityGraphQL.Tests
         public Person Owner { get; set; }
         public string Description { get; set; }
         public bool IsActive { get; set; }
+        public DateTimeOffset? Created { get; set; }
         public DateTime? Updated { get; set; }
         public IEnumerable<Project> Children { get; set; }
     }
@@ -166,6 +167,8 @@ namespace EntityGraphQL.Tests
                         Name = "task 4"
                     }
                 },
+                Created = DateTimeOffset.Now.AddMonths(-3),
+                Updated = DateTime.Now.AddMonths(-2),
             };
             context.People = new List<Person>
             {


### PR DESCRIPTION
added DateTimeOffset as default scalar, there is no need to add scalar type manually.

exception when DateTimeOffset is used in object graph: "No schema type found for dotnet type DateTimeOffset. Make sure you add it or add a type mapping"

solution:
```c#
services.AddGraphQLSchema<DemoContext>(options =>
{
    options.PreBuildSchemaFromContext = (schema) =>
    {
        schema.AddScalarType<DateTimeOffset>("DateTimeOffset", "Type representing a DateTimeOffset");
    };
});
```