### PR TITLE
fix #203 - breaking change to the add mutations methods to use an options object

### DIFF
--- a/src/EntityGraphQL/Schema/ISchemaProvider.cs
+++ b/src/EntityGraphQL/Schema/ISchemaProvider.cs
@@ -28,7 +28,7 @@ namespace EntityGraphQL.Schema
         ISchemaType AddUnion(Type type, string name, string? description);
         SchemaType<TBaseType> AddInputType<TBaseType>(string name, string? description);
         ISchemaType AddInputType(Type type, string name, string? description);
-        void AddMutationsFrom<TType>(bool autoAddInputTypes = false, bool addNonAttributedMethods = false) where TType : class;
+        void AddMutationsFrom<TType>(SchemaBuilderMutationOptions? options = null) where TType : class;
         ISchemaType AddScalarType(Type clrType, string gqlTypeName, string? description);
         SchemaType<TType> AddScalarType<TType>(string gqlTypeName, string? description);
         SchemaType<TBaseType> AddType<TBaseType>(string name, string? description);

--- a/src/EntityGraphQL/Schema/MutationField.cs
+++ b/src/EntityGraphQL/Schema/MutationField.cs
@@ -17,7 +17,7 @@ namespace EntityGraphQL.Schema
         private readonly MethodInfo method;
         private readonly bool isAsync;
 
-        public MutationField(ISchemaProvider schema, string methodName, GqlTypeInfo returnType, MethodInfo method, string description, RequiredAuthorization requiredAuth, bool isAsync, Func<string, string> fieldNamer, bool autoAddInputTypes)
+        public MutationField(ISchemaProvider schema, string methodName, GqlTypeInfo returnType, MethodInfo method, string description, RequiredAuthorization requiredAuth, bool isAsync, Func<string, string> fieldNamer, SchemaBuilderMutationOptions options)
             : base(schema, methodName, description, returnType)
         {
             Services = new List<Type>();
@@ -34,7 +34,7 @@ namespace EntityGraphQL.Schema
                     if (GraphQLIgnoreAttribute.ShouldIgnoreMemberFromInput(item))
                         continue;
                     Arguments.Add(fieldNamer(item.Name), ArgType.FromProperty(schema, item, null));
-                    AddInputTypesInArguments(schema, autoAddInputTypes, item.PropertyType);
+                    AddInputTypesInArguments(schema, options.AutoCreateInputTypes, item.PropertyType);
 
                 }
                 foreach (var item in ArgumentsType.GetFields(BindingFlags.Instance | BindingFlags.Public))
@@ -42,7 +42,7 @@ namespace EntityGraphQL.Schema
                     if (GraphQLIgnoreAttribute.ShouldIgnoreMemberFromInput(item))
                         continue;
                     Arguments.Add(fieldNamer(item.Name), ArgType.FromField(schema, item, null));
-                    AddInputTypesInArguments(schema, autoAddInputTypes, item.FieldType);
+                    AddInputTypesInArguments(schema, options.AutoCreateInputTypes, item.FieldType);
                 }
             }
             else
@@ -53,14 +53,14 @@ namespace EntityGraphQL.Schema
                         continue;
 
                     var inputType = item.ParameterType.GetEnumerableOrArrayType() ?? item.ParameterType;
-                    if (!schema.HasType(inputType) && autoAddInputTypes)
+                    if (!schema.HasType(inputType) && options.AutoCreateInputTypes)
                     {
-                        AddInputTypesInArguments(schema, autoAddInputTypes, inputType);
+                        AddInputTypesInArguments(schema, options.AutoCreateInputTypes, inputType);
                     }
                     if (item.ParameterType.IsPrimitive || (schema.HasType(inputType) && (schema.Type(inputType).IsInput || schema.Type(inputType).IsScalar || schema.Type(inputType).IsEnum)))
                     {
                         Arguments.Add(fieldNamer(item.Name!), ArgType.FromParameter(schema, item, null));
-                        AddInputTypesInArguments(schema, autoAddInputTypes, item.ParameterType);
+                        AddInputTypesInArguments(schema, options.AutoCreateInputTypes, item.ParameterType);
                     }
                 }
             }

--- a/src/EntityGraphQL/Schema/MutationType.cs
+++ b/src/EntityGraphQL/Schema/MutationType.cs
@@ -24,14 +24,15 @@ public class MutationType
     /// <summary>
     /// Add any public methods (static or not) marked with GraphQLMutationAttribute in the given object to the schema. Method names are added as using fieldNamer
     /// </summary>
-    /// <param name="autoAddInputTypes">If true, any class types seen in the mutation argument properties will be added to the schema</param>
+    /// <param name="options">Options for the schema builder</param>
     /// <typeparam name="TType"></typeparam>
-    public MutationType AddFrom<TType>(bool autoAddInputTypes = false, bool addNonAttributedMethods = false) where TType : class
+    public MutationType AddFrom<TType>(SchemaBuilderMutationOptions? options = null) where TType : class
     {
+        options ??= new SchemaBuilderMutationOptions();
         var types = typeof(TType).Assembly
-                            .GetTypes()
-                            .Where(x => x.IsClass && !x.IsAbstract)
-                            .Where(x => typeof(TType).IsAssignableFrom(x));
+                                .GetTypes()
+                                .Where(x => x.IsClass && !x.IsAbstract)
+                                .Where(x => typeof(TType).IsAssignableFrom(x));
 
         foreach (Type type in types)
         {
@@ -39,10 +40,10 @@ public class MutationType
             foreach (var method in type.GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static | BindingFlags.DeclaredOnly))
             {
                 var attribute = method.GetCustomAttribute(typeof(GraphQLMutationAttribute)) as GraphQLMutationAttribute;
-                if (attribute != null || addNonAttributedMethods)
+                if (attribute != null || options.AddNonAttributedMethods)
                 {
                     string name = SchemaType.Schema.SchemaFieldNamer(method.Name);
-                    AddMutationMethod(name, classLevelRequiredAuth, method, attribute?.Description ?? "", autoAddInputTypes);
+                    AddMutationMethod(name, classLevelRequiredAuth, method, attribute?.Description ?? "", options);
                 }
             }
         }
@@ -54,10 +55,10 @@ public class MutationType
     /// name using the SchemaFieldNamer. Use the [Description] attribute on the method to set the description.
     /// </summary>
     /// <param name="mutationDelegate">A method to execute the mutation logic</param>
-    /// <param name="autoAddInputTypes">If true, any class types seen in the mutation argument properties will be added to the schema</param>
-    public MutationField Add(Delegate mutationDelegate, bool autoAddInputTypes = false)
+    /// <param name="options">Options for the schema builder</param>
+    public MutationField Add(Delegate mutationDelegate, SchemaBuilderMutationOptions? options = null)
     {
-        return Add(SchemaType.Schema.SchemaFieldNamer(mutationDelegate.Method.Name), mutationDelegate, autoAddInputTypes);
+        return Add(SchemaType.Schema.SchemaFieldNamer(mutationDelegate.Method.Name), mutationDelegate, options);
     }
 
     /// <summary>
@@ -65,26 +66,28 @@ public class MutationType
     /// </summary>
     /// <param name="mutationName">Mutation field name</param>
     /// <param name="mutationDelegate">A method to execute the mutation logic</param>
-    /// <param name="autoAddInputTypes">If true, any class types seen in the mutation argument properties will be added to the schema</param>
-    public MutationField Add(string mutationName, Delegate mutationDelegate, bool autoAddInputTypes = false)
+    /// <param name="options">Options for the schema builder</param>
+    public MutationField Add(string mutationName, Delegate mutationDelegate, SchemaBuilderMutationOptions? options = null)
     {
         var description = (mutationDelegate.Method.GetCustomAttribute(typeof(DescriptionAttribute)) as DescriptionAttribute)?.Description ?? string.Empty;
-        return Add(mutationName, description, mutationDelegate, autoAddInputTypes);
+        return Add(mutationName, description, mutationDelegate, options);
     }
 
     /// <summary>
     /// Add a single mutation field to the schema. Mutation field name used as supplied.
     /// </summary>
     /// <param name="mutationName">Mutation field name</param>
+    /// <param name="description">Description of the mutation field</param>
     /// <param name="mutationDelegate">A method to execute the mutation logic</param>
-    /// <param name="autoAddInputTypes">If true, any class types seen in the mutation argument properties will be added to the schema</param>
-    public MutationField Add(string mutationName, string description, Delegate mutationDelegate, bool autoAddInputTypes = false)
+    /// <param name="options">Options for the schema builder</param>
+    public MutationField Add(string mutationName, string description, Delegate mutationDelegate, SchemaBuilderMutationOptions? options = null)
     {
-        return AddMutationMethod(mutationName, null, mutationDelegate.Method, description, autoAddInputTypes);
+        return AddMutationMethod(mutationName, null, mutationDelegate.Method, description, options);
     }
 
-    private MutationField AddMutationMethod(string name, RequiredAuthorization? classLevelRequiredAuth, MethodInfo method, string? description, bool autoAddInputTypes)
+    private MutationField AddMutationMethod(string name, RequiredAuthorization? classLevelRequiredAuth, MethodInfo method, string? description, SchemaBuilderMutationOptions? options)
     {
+        options ??= new SchemaBuilderMutationOptions();
         var isAsync = method.GetCustomAttribute(typeof(AsyncStateMachineAttribute)) != null;
         var takeGenericArgument = isAsync || method.ReturnType.IsGenericType && method.ReturnType.GetGenericTypeDefinition() == typeof(Task<>);
         var methodAuth = SchemaType.Schema.AuthorizationService.GetRequiredAuthFromMember(method);
@@ -92,9 +95,14 @@ public class MutationType
         if (classLevelRequiredAuth != null)
             requiredClaims = requiredClaims.Concat(classLevelRequiredAuth);
         var actualReturnType = GetTypeFromMutationReturn(takeGenericArgument ? method.ReturnType.GetGenericArguments()[0] : method.ReturnType);
-        var typeName = SchemaType.Schema.GetSchemaType(actualReturnType.GetNonNullableOrEnumerableType(), null).Name;
+        var nonListReturnType = actualReturnType.GetNonNullableOrEnumerableType();
+        if (!SchemaType.Schema.HasType(nonListReturnType) && options.AutoCreateNewComplexTypes)
+        {
+            SchemaBuilder.CacheType(nonListReturnType, SchemaType.Schema, options, false);
+        }
+        var typeName = SchemaType.Schema.GetSchemaType(nonListReturnType, null).Name;
         var returnType = new GqlTypeInfo(() => SchemaType.Schema.Type(typeName), actualReturnType, method.IsNullable());
-        var mutationField = new MutationField(SchemaType.Schema, name, returnType, method, description ?? string.Empty, requiredClaims, isAsync, SchemaType.Schema.SchemaFieldNamer, autoAddInputTypes);
+        var mutationField = new MutationField(SchemaType.Schema, name, returnType, method, description ?? string.Empty, requiredClaims, isAsync, SchemaType.Schema.SchemaFieldNamer, options);
 
         var validators = method.GetCustomAttributes<ArgumentValidatorAttribute>();
         if (validators != null)
@@ -121,7 +129,7 @@ public class MutationType
     /// </summary>
     /// <param name="type"></param>
     /// <returns></returns>
-    private Type GetTypeFromMutationReturn(Type type)
+    private static Type GetTypeFromMutationReturn(Type type)
     {
         if (type.BaseType == typeof(LambdaExpression))
         {

--- a/src/EntityGraphQL/Schema/SchemaBuilder.cs
+++ b/src/EntityGraphQL/Schema/SchemaBuilder.cs
@@ -228,7 +228,7 @@ namespace EntityGraphQL.Schema
             }
         }
 
-        private static void CacheType(Type propType, ISchemaProvider schema, SchemaBuilderOptions options, bool isInputType)
+        internal static void CacheType(Type propType, ISchemaProvider schema, SchemaBuilderOptions options, bool isInputType)
         {
             if (!schema.HasType(propType))
             {
@@ -244,13 +244,14 @@ namespace EntityGraphQL.Schema
 
                 if ((options.AutoCreateNewComplexTypes && typeInfo.IsClass) || ((typeInfo.IsInterface || typeInfo.IsAbstract) && options.AutoCreateInterfaceTypes))
                 {
-                    var fieldCount = typeInfo.GetProperties().Count() + typeInfo.GetFields().Count();
+                    var fieldCount = typeInfo.GetProperties().Length + typeInfo.GetFields().Length;
 
                     // add type before we recurse more that may also add the type
                     // dynamcially call generic method
                     // hate this, but want to build the types with the right Genenics so you can extend them later.
                     // this is not the fastest, but only done on schema creation
-                    var addMethod = (isInputType, typeInfo.IsInterface, typeInfo.IsAbstract, fieldCount) switch {
+                    var addMethod = (isInputType, typeInfo.IsInterface, typeInfo.IsAbstract, fieldCount) switch
+                    {
                         (true, _, _, _) => nameof(ISchemaProvider.AddInputType),
                         (_, true, _, > 0) => nameof(ISchemaProvider.AddInterface),
                         (_, _, true, > 0) => nameof(ISchemaProvider.AddInterface),
@@ -268,7 +269,7 @@ namespace EntityGraphQL.Schema
 
                     var fields = GetFieldsFromObject(propType, schema, options, isInputType);
                     typeAdded.AddFields(fields);
-                  
+
 
                     if (options.AutoCreateInterfaceTypes)
                     {

--- a/src/EntityGraphQL/Schema/SchemaBuilderOptions.cs
+++ b/src/EntityGraphQL/Schema/SchemaBuilderOptions.cs
@@ -46,6 +46,13 @@ namespace EntityGraphQL.Schema
         /// If true (default = false), any object type that is encountered during reflection of the object graph that has abstract or interface types (regardless of if they are referenced by other fields), those will be added to the schema as an Interface including it's fields
         /// </summary>
         public bool AutoCreateInterfaceTypes { get; set; } = false;
+
+    }
+
+    public class SchemaBuilderMutationOptions : SchemaBuilderOptions
+    {
+        public bool AutoCreateInputTypes { get; set; } = true;
+        public bool AddNonAttributedMethods { get; set; } = false;
     }
 
     /// <summary>

--- a/src/EntityGraphQL/Schema/SchemaProvider.cs
+++ b/src/EntityGraphQL/Schema/SchemaProvider.cs
@@ -428,11 +428,10 @@ namespace EntityGraphQL.Schema
         /// Add any methods marked with GraphQLMutationAttribute in the given object to the schema. Method names are added as using fieldNamer
         /// </summary>
         /// <typeparam name="TType"></typeparam>
-        /// <param name="autoAddInputTypes">If true, any class types seen in the mutation argument properties will be added to the schema</param>
-        /// <param name="addNonAttributedMethods">If true, add any method in the mutation class even if it isn't marked with the mutation attribute</param>
-        public void AddMutationsFrom<TType>(bool autoAddInputTypes = false, bool addNonAttributedMethods = false) where TType : class
+        /// <param name="options">Options for the schema builder</param>
+        public void AddMutationsFrom<TType>(SchemaBuilderMutationOptions? options = null) where TType : class
         {
-            mutationType.AddFrom<TType>(autoAddInputTypes, addNonAttributedMethods);
+            mutationType.AddFrom<TType>(options);
         }
 
         /// <summary>

--- a/src/tests/EntityGraphQL.Tests/MutationTests/MutationTests.cs
+++ b/src/tests/EntityGraphQL.Tests/MutationTests/MutationTests.cs
@@ -561,7 +561,6 @@ namespace EntityGraphQL.Tests
         {
             var schemaProvider = SchemaBuilder.FromObject<TestDataContext>();
             schemaProvider.AddMutationsFrom<PeopleMutations>();
-            schemaProvider.AddInputType<InputObject>("InputObject", "Input data").AddAllFields();
             // Add a argument field with a require parameter
             var gql = new QueryRequest
             {
@@ -582,7 +581,6 @@ namespace EntityGraphQL.Tests
         {
             var schemaProvider = SchemaBuilder.FromObject<TestDataContext>();
             schemaProvider.AddMutationsFrom<PeopleMutations>();
-            schemaProvider.AddInputType<InputObject>("InputObject", "Input data").AddAllFields();
             // Add a argument field with a require parameter
             var gql = new QueryRequest
             {
@@ -606,7 +604,6 @@ namespace EntityGraphQL.Tests
         {
             var schemaProvider = SchemaBuilder.FromObject<TestDataContext>();
             schemaProvider.AddMutationsFrom<PeopleMutations>();
-            schemaProvider.AddInputType<InputObjectId>("InputObjectId", "InputObjectId").AddAllFields();
             // Add a argument field with a require parameter
             var gql = new QueryRequest
             {
@@ -790,9 +787,6 @@ namespace EntityGraphQL.Tests
             Assert.Equal(true, results.Data["nullableGuidArgs"]);
         }
 
-
-
-
         [Fact]
         public void TestNullableGuidEmptyString()
         {
@@ -866,7 +860,7 @@ namespace EntityGraphQL.Tests
         public void ConstOnMutationArgOrInpoutTypeNotAdded()
         {
             var schema = SchemaBuilder.Create<TestDataContext>();
-            schema.Mutation().Add(MuationWithInputTypeConst, true);
+            schema.Mutation().Add(MuationWithInputTypeConst, new SchemaBuilderMutationOptions { AutoCreateInputTypes = true });
 
             Assert.DoesNotContain(schema.Mutation().SchemaType.GetFields().First(f => f.Name == "muationWithInputTypeConst").Arguments, f => f.Key == "isConst");
 
@@ -903,7 +897,7 @@ namespace EntityGraphQL.Tests
             var schemaProvider = SchemaBuilder.FromObject<TestDataContext>();
             schemaProvider.Mutation().AddFrom<IMutations>();
 
-            Assert.Equal(26, schemaProvider.Mutation().SchemaType.GetFields().Count());
+            Assert.Equal(27, schemaProvider.Mutation().SchemaType.GetFields().Count());
         }
 
         public class NonAttributeMarkedMethod
@@ -928,7 +922,7 @@ namespace EntityGraphQL.Tests
         public void TestAddFromMultipleClassesImplementingInterfaceWhenEnabled()
         {
             var schemaProvider = SchemaBuilder.FromObject<TestDataContext>();
-            schemaProvider.Mutation().AddFrom<NonAttributeMarkedMethod>(addNonAttributedMethods: true);
+            schemaProvider.Mutation().AddFrom<NonAttributeMarkedMethod>(new SchemaBuilderMutationOptions { AddNonAttributedMethods = true });
 
             Assert.NotEmpty(schemaProvider.Mutation().SchemaType.GetFields());
         }
@@ -954,7 +948,7 @@ namespace EntityGraphQL.Tests
         public void TestRightValueReturnedFromActivatorCreateMutationClass()
         {
             var schemaProvider = SchemaBuilder.FromObject<TestDataContext>();
-            schemaProvider.Mutation().AddFrom<MutationClassInstantiationTest>(addNonAttributedMethods: true);
+            schemaProvider.Mutation().AddFrom<MutationClassInstantiationTest>(new SchemaBuilderMutationOptions { AddNonAttributedMethods = true });
 
             var gql = new QueryRequest
             {

--- a/src/tests/EntityGraphQL.Tests/MutationTests/PeopleMutations.cs
+++ b/src/tests/EntityGraphQL.Tests/MutationTests/PeopleMutations.cs
@@ -57,6 +57,13 @@ namespace EntityGraphQL.Tests
 
         [GraphQLMutation]
 
+        public Person AddPersonSingleArgumentNestedType(NestedInputObject nameInput)
+        {
+            return new Person { Name = string.IsNullOrEmpty(nameInput.Name) ? "Default" : nameInput.Name, Id = 555, Projects = new List<Project>() };
+        }
+
+        [GraphQLMutation]
+
         public Expression<Func<TestDataContext, Person>> AddPersonNames(TestDataContext db, PeopleMutationsArgs args)
         {
             var id = 11;

--- a/src/tests/EntityGraphQL.Tests/ValidationTests.cs
+++ b/src/tests/EntityGraphQL.Tests/ValidationTests.cs
@@ -15,7 +15,7 @@ public class ValidationTests
     public void TestValidationAttributesOnMutationArgs()
     {
         var schema = SchemaBuilder.FromObject<ValidationTestsContext>();
-        schema.AddMutationsFrom<ValidationTestsMutations>(true);
+        schema.AddMutationsFrom<ValidationTestsMutations>(new SchemaBuilderMutationOptions { AutoCreateInputTypes = true });
         var gql = new QueryRequest
         {
             Query = @"mutation Mutate {
@@ -42,7 +42,7 @@ public class ValidationTests
     public void TestValidationAttributesOnNestedMutationArgs()
     {
         var schema = SchemaBuilder.FromObject<ValidationTestsContext>();
-        schema.AddMutationsFrom<ValidationTestsMutations>(true);
+        schema.AddMutationsFrom<ValidationTestsMutations>(new SchemaBuilderMutationOptions { AutoCreateInputTypes = true });
         var gql = new QueryRequest
         {
             Query = @"mutation Mutate {
@@ -170,7 +170,7 @@ public class ValidationTests
         Assert.Equal(3, results.Errors.Count);
         Assert.Equal("Field 'movies' - Genre is required", results.Errors[0].Message);
         Assert.Equal("Field 'movies' - Title must be less than 5 characters", results.Errors[1].Message);
-        Assert.Equal("Field 'movies' - Price must be between $1 and $100", results.Errors[2].Message);        
+        Assert.Equal("Field 'movies' - Price must be between $1 and $100", results.Errors[2].Message);
     }
 
     [Fact]


### PR DESCRIPTION
Follows the other schema builder methods using an options object.

Is a breaking change to the API.