### PR TITLE
Can't implement service via static method.

### DIFF
--- a/src/tests/EntityGraphQL.Tests/QueryTests/ServiceFieldTests.cs
+++ b/src/tests/EntityGraphQL.Tests/QueryTests/ServiceFieldTests.cs
@@ -1608,6 +1608,54 @@ namespace EntityGraphQL.Tests
         }
 
         [Fact]
+        public void TestServiceFieldWithStaticMethod() {
+            var schema = SchemaBuilder.FromObject<TestDataContext>();
+            schema.AddType<ProjectConfig>("ProjectConfig").AddAllFields();
+
+            schema.Type<Project>().AddField("config", "Get project configs if they exists")
+                .ResolveWithService<ConfigService>((p, srv) => GetProjectConfig(p, srv)) // srv.Get(p.Id)) works here
+                .IsNullable(false);
+
+            var serviceCollection = new ServiceCollection();
+            var srv = new ConfigService();
+            serviceCollection.AddSingleton(srv);
+
+            var gql = new QueryRequest {
+                Query = @"{
+                    projects {
+                        config { type __typename }
+                    }
+                }"
+            };
+
+            var context = new TestDataContext {
+                Projects = new List<Project>
+                {
+                    new Project
+                    {
+                        Id = 0,
+                        Tasks = new List<Task>
+                        {
+                            new Task
+                            {
+                                Id = 1,
+                            }
+                        }
+                    }
+                },
+            };
+
+            var res = schema.ExecuteRequest(gql, context, serviceCollection.BuildServiceProvider(), null);
+            Assert.Null(res.Errors);
+            var projects = (dynamic)res.Data["projects"];
+            Type projectType = Enumerable.First(projects).GetType();
+            Assert.Single(projectType.GetFields());
+            Assert.Equal("config", projectType.GetFields()[0].Name);
+        }
+
+        static ProjectConfig GetProjectConfig(Project project, ConfigService configService) => configService.Get(project.Id);
+
+        [Fact]
         public void TestScalarServiceFieldWithSameTypeReferencedExpression()
         {
             var schema = SchemaBuilder.FromObject<TestDataContext>();


### PR DESCRIPTION
When adding a field implemented through a service, if the implementation is invoked through a static method, the call fails. This PR has a unit test `TestServiceFieldWithStaticMethod`, which results in this error:

> Field 'projects' - variable 'srv' of type 'EntityGraphQL.Tests.ServiceFieldTests+ConfigService' referenced from scope '', but it is not defined

On a production project with a similar configuration, the error I get is effectively:

> ''GetItems_entity, service_' is not a member of type 'Entity' (Parameter 'propertyOrFieldName')'

The reason I was using a static method in the first place is to subvert the use of `Expression`. There is complex business logic that combines data from the entity and service and returns a custom non-entity type. The expression tree is far too complex for LINQ. All I want to do is have the method executed and the entire object returned. If the GraphQL client only requested select properties, they would be cherry picked at the end, with the generation of the other properties wasted work (which is acceptable in this use case).

Note that this issue is a regression. The use of a static method works in EntityGraphQL 2.x.