### PR TITLE
Async mutations without async keyword resolve to wrong type

### DIFF
--- a/src/tests/EntityGraphQL.Tests/MutationTests/MutationTests.cs
+++ b/src/tests/EntityGraphQL.Tests/MutationTests/MutationTests.cs
@@ -456,6 +456,24 @@ namespace EntityGraphQL.Tests
         }
 
         [Fact]
+        public void TestAsyncMutationWithoutAsyncKeyword() {
+            var schemaProvider = SchemaBuilder.FromObject<TestDataContext>();
+            schemaProvider.AddMutationsFrom<PeopleMutations>();
+            var gql = new QueryRequest {
+                Query = @"mutation AddPerson {
+          doGreatThingWithoutAsyncKeyword
+        }
+        ",
+            };
+
+            var testSchema = new TestDataContext();
+            var results = schemaProvider.ExecuteRequest(gql, testSchema, null, null);
+            Assert.Null(results.Errors);
+            dynamic result = results.Data["doGreatThingWithoutAsyncKeyword"];
+            Assert.True((bool)result);
+        }
+
+        [Fact]
         public void TestUnnamedMutationOp()
         {
             var schemaProvider = SchemaBuilder.FromObject<TestDataContext>();

--- a/src/tests/EntityGraphQL.Tests/MutationTests/PeopleMutations.cs
+++ b/src/tests/EntityGraphQL.Tests/MutationTests/PeopleMutations.cs
@@ -154,6 +154,8 @@ namespace EntityGraphQL.Tests
             });
         }
         [GraphQLMutation]
+        public Task<bool> DoGreatThingWithoutAsyncKeyword() => DoGreatThing();
+        [GraphQLMutation]
         public static async Task<bool> DoGreatThingStaticly()
         {
             return await Task<bool>.Run(() =>


### PR DESCRIPTION
A mutation that returns `Task<T>` but doesn't use the keyword causes a runtime exception like:
> Microsoft.CSharp.RuntimeBinder.RuntimeBinderException : Cannot convert type 'System.Threading.Tasks.Task<bool>' to 'bool'

This PR contains a test. Related issue: #197.