### PR TITLE
Required array parameter fails conversion

### DIFF
--- a/src/tests/EntityGraphQL.Tests/QueryTests/VariableTests.cs
+++ b/src/tests/EntityGraphQL.Tests/QueryTests/VariableTests.cs
@@ -118,7 +118,7 @@ namespace EntityGraphQL.Tests
         public void QueryVariableArrayGetsAList()
         {
             var schema = SchemaBuilder.FromObject<TestDataContext>();
-            schema.Query().AddField("test", new { ids = (Guid[])null }, (db, args) => db.People.Where(p => args.ids.Any(a => a == p.Guid)), "test field");
+            schema.Query().AddField("test", new { ids = ArgumentHelper.Required<Guid[]>() }, (db, args) => db.People.Where(p => ((Guid[])args.ids).Any(a => a == p.Guid)), "test field");
             var gql = new QueryRequest
             {
                 Query = @"query ($ids: [ID]) {


### PR DESCRIPTION
When passing a required variable of an array type to a query, the conversion operator used to access the wrapped value inside RequiredField throws an exception.

In the unit test in this PR, the failed conversion occurs in the cast `(Guid[])args.ids`. However, the error also occurs in the more subtle case of an implicit conversion, such as if `args.ids` is passed to a method that takes a parameter of type `Guid[]`.

A downstream problem is that the error handling is throwing an NullRefernceException, causing the original exception related to `IConvertable` to not be output.