### PR TITLE
bug: mutations with inline args don't support variables with different name to argument name

### DIFF
--- a/src/EntityGraphQL/Schema/MutationField.cs
+++ b/src/EntityGraphQL/Schema/MutationField.cs
@@ -98,9 +98,20 @@ namespace EntityGraphQL.Schema
                     allArgs.Add(argInstance!);
                 }
                 else if (docVariables != null && gqlRequestArgs != null && gqlRequestArgs.ContainsKey(p.Name!))
-                {
+                { 
+                    object? value = null;
+
+                    if (gqlRequestArgs[p.Name!] is Expression argExpression)
+                    {
+                        value = Expression.Lambda(argExpression as Expression, variableParameter).Compile().DynamicInvoke(new[] { docVariables });
+                    }
+
                     var argField = Arguments[p.Name!];
-                    var value = ArgumentUtil.BuildArgumentFromMember(Schema, gqlRequestArgs ?? new Dictionary<string, object>(), argField.Name, argField.RawType, argField.DefaultValue, validationErrors);
+                    if (value == null)
+                    {
+                        value = ArgumentUtil.BuildArgumentFromMember(Schema, gqlRequestArgs ?? new Dictionary<string, object>(), argField.Name, argField.RawType, argField.DefaultValue, validationErrors);
+                    }
+
                     if (value == null || value is Expression)
                     {
                         var field = docVariables.GetType().GetField(p.Name!);

--- a/src/tests/EntityGraphQL.Tests/MutationTests/MutationMethodParameterTests.cs
+++ b/src/tests/EntityGraphQL.Tests/MutationTests/MutationMethodParameterTests.cs
@@ -99,6 +99,27 @@ namespace EntityGraphQL.Tests
         }
 
         [Fact]
+        public void TestSingleArgument_DifferentVariableName()
+        {
+            var schemaProvider = SchemaBuilder.FromObject<TestDataContext>();
+            schemaProvider.AddInputType<InputObject>("InputObject", "");
+            schemaProvider.AddMutationsFrom<PeopleMutations>(new SchemaBuilderMutationOptions { AutoCreateInputTypes = false });
+            // Add a argument field with a require parameter
+            var gql = new QueryRequest
+            {
+                Query = @"mutation AddPersonSingleArgument($differentName: InputObject) {
+                  addPersonSingleArgument(nameInput: $differentName) { id name }
+                }",
+                Variables = new QueryVariables {
+                    { "differentName", new InputObject() { Name = "Frank" } },
+                }
+            };
+            var res = schemaProvider.ExecuteRequest(gql, new TestDataContext(), null, null);
+            Assert.Null(res.Errors);
+            Assert.Equal("Frank", ((dynamic)res.Data["addPersonSingleArgument"]).name);
+        }
+
+        [Fact]
         public void TestSingleArgument_AutoAddInputTypes()
         {
             var schemaProvider = SchemaBuilder.FromObject<TestDataContext>();


### PR DESCRIPTION
```
  var gql = new QueryRequest
            {
                Query = @"mutation AddPersonSingleArgument($differentName: InputObject) {
                  addPersonSingleArgument(nameInput: $differentName) { id name }
                }",
                Variables = new QueryVariables {
                    { "differentName", new InputObject() { Name = "Frank" } },
                }
            };
```

was failing to find differentName as the argument for nameInput
