### PR TITLE
Hold the type a field  belongs to

### DIFF
--- a/docs/docs/field-extensions/custom-extensions.md
+++ b/docs/docs/field-extensions/custom-extensions.md
@@ -63,7 +63,7 @@ public class FormatStringExtension : IFieldExtension
         return expression;
     }
 
-    public (Expression baseExpression, Dictionary<string, CompiledField> selectionExpressions, ParameterExpression selectContextParam) ProcessExpressionSelection(GraphQLFieldType fieldType, Expression baseExpression, Dictionary<string, CompiledField> selectionExpressions, ParameterExpression? selectContextParam, bool servicesPass, ParameterReplacer parameterReplacer)
+    public (Expression baseExpression, Dictionary<IFieldKey, CompiledField> selectionExpressions, ParameterExpression selectContextParam) ProcessExpressionSelection(GraphQLFieldType fieldType, Expression baseExpression, Dictionary<IFieldKey, CompiledField> selectionExpressions, ParameterExpression? selectContextParam, bool servicesPass, ParameterReplacer parameterReplacer)
     {
         // Called for object projection and collection fields. Giving you an opportunity to modify
         // the selection expression or the selection base expression.

--- a/src/EntityGraphQL/Compiler/GqlNodes/BaseGraphQLQueryField.cs
+++ b/src/EntityGraphQL/Compiler/GqlNodes/BaseGraphQLQueryField.cs
@@ -33,9 +33,9 @@ namespace EntityGraphQL.Compiler
 
         protected bool NeedsServiceWrap(bool withoutServiceFields) => !withoutServiceFields && Field?.Services.Any() == true;
 
-        protected virtual Dictionary<string, CompiledField> GetSelectionFields(CompileContext compileContext, IServiceProvider? serviceProvider, List<GraphQLFragmentStatement> fragments, ParameterExpression? docParam, object? docVariables, bool withoutServiceFields, Expression nextFieldContext, ParameterExpression schemaContext, bool contextChanged, ParameterReplacer replacer)
+        protected virtual Dictionary<IFieldKey, CompiledField> GetSelectionFields(CompileContext compileContext, IServiceProvider? serviceProvider, List<GraphQLFragmentStatement> fragments, ParameterExpression? docParam, object? docVariables, bool withoutServiceFields, Expression nextFieldContext, ParameterExpression schemaContext, bool contextChanged, ParameterReplacer replacer)
         {
-            var selectionFields = new Dictionary<string, CompiledField>(StringComparer.OrdinalIgnoreCase);
+            var selectionFields = new Dictionary<IFieldKey, CompiledField>();
 
             foreach (var field in QueryFields)
             {
@@ -53,11 +53,11 @@ namespace EntityGraphQL.Compiler
                         fieldExp = replacer.Replace(fieldExp, subField.RootParameter!, nextFieldContext);
                     }
 
-                    selectionFields[subField.Name] = new CompiledField(subField, fieldExp);
+                    selectionFields[subField] = new CompiledField(subField, fieldExp);
                 }
             }
 
-            return selectionFields.Count == 0 ? new Dictionary<string, CompiledField>() : selectionFields;
+            return selectionFields.Count == 0 ? new Dictionary<IFieldKey, CompiledField>() : selectionFields;
         }
     }
 }

--- a/src/EntityGraphQL/Compiler/GqlNodes/GraphQLInlineFragmentField.cs
+++ b/src/EntityGraphQL/Compiler/GqlNodes/GraphQLInlineFragmentField.cs
@@ -14,12 +14,6 @@ namespace EntityGraphQL.Compiler
         {
         }
 
-        public override void AddField(BaseGraphQLField field)
-        {
-            field.Name = $"{Name}.{field.Name}";
-            base.AddField(field);
-        }
-
         public override IEnumerable<BaseGraphQLField> Expand(CompileContext compileContext, List<GraphQLFragmentStatement> fragments, bool withoutServiceFields, Expression fieldContext, ParameterExpression? docParam, object? docVariables)
         {
             return this.QueryFields;

--- a/src/EntityGraphQL/Compiler/GqlNodes/GraphQLListSelectionField.cs
+++ b/src/EntityGraphQL/Compiler/GqlNodes/GraphQLListSelectionField.cs
@@ -102,7 +102,7 @@ namespace EntityGraphQL.Compiler
             return resultExpression;
         }
 
-        private Expression WrapWithNullCheck(CompileContext compileContext, ParameterExpression selectParam, Expression listContext, Dictionary<string, CompiledField> selectExpressions, IServiceProvider? serviceProvider, ParameterExpression schemaContext, ParameterReplacer replacer)
+        private Expression WrapWithNullCheck(CompileContext compileContext, ParameterExpression selectParam, Expression listContext, Dictionary<IFieldKey, CompiledField> selectExpressions, IServiceProvider? serviceProvider, ParameterExpression schemaContext, ParameterReplacer replacer)
         {
             // null check on listContext which may be a call to a service that we do not want to call twice
             var fieldParamValues = new List<object>(compileContext.ConstantParameters.Values);
@@ -114,7 +114,7 @@ namespace EntityGraphQL.Compiler
             {
                 updatedListContext = GraphQLHelper.InjectServices(serviceProvider, compileContext.Services, fieldParamValues, listContext, fieldParams, replacer);
 
-                foreach(var selectExpression in selectExpressions)
+                foreach (var selectExpression in selectExpressions)
                 {
                     selectExpression.Value.Expression = GraphQLHelper.InjectServices(serviceProvider, compileContext.Services, fieldParamValues, selectExpression.Value.Expression, fieldParams, replacer);
                 }

--- a/src/EntityGraphQL/Compiler/Util/CompileHelper.cs
+++ b/src/EntityGraphQL/Compiler/Util/CompileHelper.cs
@@ -29,9 +29,9 @@ namespace EntityGraphQL.Compiler
             return expression;
         }
 
-        public static Dictionary<string, Expression> ExpressionOnly(this Dictionary<string, CompiledField> source)
+        public static Dictionary<string, Expression> ExpressionOnly(this Dictionary<IFieldKey, CompiledField> source)
         {
-            return source.ToDictionary(i => i.Key, i => i.Value.Expression);
+            return source.ToDictionary(i => i.Key.Name, i => i.Value.Expression);
         }
     }
 }

--- a/src/EntityGraphQL/Compiler/Util/ExpressionUtil.cs
+++ b/src/EntityGraphQL/Compiler/Util/ExpressionUtil.cs
@@ -426,7 +426,7 @@ namespace EntityGraphQL.Compiler.Util
         /// <summary>
         /// Makes a selection from a IEnumerable context
         /// </summary>
-        public static Expression MakeSelectWithDynamicType(string fieldDescription, ParameterExpression currentContextParam, Expression baseExp, IDictionary<string, CompiledField> fieldExpressions)
+        public static Expression MakeSelectWithDynamicType(string fieldDescription, ParameterExpression currentContextParam, Expression baseExp, IDictionary<IFieldKey, CompiledField> fieldExpressions)
         {
             if (!fieldExpressions.Any())
                 return baseExp;
@@ -440,7 +440,7 @@ namespace EntityGraphQL.Compiler.Util
             // If 0 or 1 valid types then default to basic behaviour
             if (validTypes.Count() < 2)
             {
-                var memberExpressions = fieldExpressions.ToDictionary(i => i.Key, i => i.Value.Expression);
+                var memberExpressions = fieldExpressions.ToDictionary(i => i.Key.Name, i => i.Value.Expression);
                 var memberInit = CreateNewExpression(fieldDescription, memberExpressions, out Type dynamicType);
                 if (memberInit == null || dynamicType == null) // nothing to select
                     return baseExp;
@@ -468,7 +468,7 @@ namespace EntityGraphQL.Compiler.Util
 
                     var fieldsOnType = fieldExpressions.Values
                        .Where(i => RootType(i.Expression)!.IsAssignableFrom(type) || typeof(ISchemaType).IsAssignableFrom(RootType(i.Expression)))
-                       .ToDictionary(i => i.Field.Name.Replace($"{RootType(i.Expression)?.Name}.", ""), i => i.Expression);
+                       .ToDictionary(i => i.Field.Name, i => i.Expression);
 
                     var memberInit = CreateNewExpression(fieldDescription, fieldsOnType, out Type dynamicType, parentType: baseDynamicType);
 

--- a/src/EntityGraphQL/Schema/BaseField.cs
+++ b/src/EntityGraphQL/Schema/BaseField.cs
@@ -22,6 +22,7 @@ namespace EntityGraphQL.Schema
         public IDictionary<string, ArgType> Arguments { get; set; } = new Dictionary<string, ArgType>();
         public ParameterExpression? ArgumentParam { get; set; }
         public string Name { get; internal set; }
+        public ISchemaType FromType { get; }
         public GqlTypeInfo ReturnType { get; protected set; }
         public List<IFieldExtension> Extensions { get; set; }
         public RequiredAuthorization? RequiredAuthorization { get; protected set; }
@@ -52,9 +53,10 @@ namespace EntityGraphQL.Schema
 
         protected List<Action<ArgumentValidatorContext>> argumentValidators = new();
 
-        protected BaseField(ISchemaProvider schema, string name, string? description, GqlTypeInfo returnType)
+        protected BaseField(ISchemaProvider schema, ISchemaType fromType, string name, string? description, GqlTypeInfo returnType)
         {
             this.Schema = schema;
+            FromType = fromType;
             Description = description ?? string.Empty;
             Name = name;
             ReturnType = returnType;

--- a/src/EntityGraphQL/Schema/Field.cs
+++ b/src/EntityGraphQL/Schema/Field.cs
@@ -29,8 +29,8 @@ namespace EntityGraphQL.Schema
             }
         }
 
-        internal Field(ISchemaProvider schema, string name, LambdaExpression? resolve, string? description, GqlTypeInfo returnType, RequiredAuthorization? requiredAuth)
-        : base(schema, name, description, returnType)
+        internal Field(ISchemaProvider schema, ISchemaType fromType, string name, LambdaExpression? resolve, string? description, GqlTypeInfo returnType, RequiredAuthorization? requiredAuth)
+        : base(schema, fromType, name, description, returnType)
         {
             RequiredAuthorization = requiredAuth;
             Extensions = new List<IFieldExtension>();
@@ -68,8 +68,8 @@ namespace EntityGraphQL.Schema
             }
         }
 
-        public Field(ISchemaProvider schema, string name, LambdaExpression? resolve, string? description, object? argTypes, GqlTypeInfo returnType, RequiredAuthorization? claims)
-            : this(schema, name, resolve, description, returnType, claims)
+        public Field(ISchemaProvider schema, ISchemaType fromType, string name, LambdaExpression? resolve, string? description, object? argTypes, GqlTypeInfo returnType, RequiredAuthorization? claims)
+            : this(schema, fromType, name, resolve, description, returnType, claims)
         {
             if (argTypes != null)
             {

--- a/src/EntityGraphQL/Schema/FieldExtensions/BaseFieldExtension.cs
+++ b/src/EntityGraphQL/Schema/FieldExtensions/BaseFieldExtension.cs
@@ -42,7 +42,7 @@ namespace EntityGraphQL.Schema.FieldExtensions
         /// <param name="baseExpression">Scalar: the expression. ListSelection: The expression used to add .Select() to. ObjectProjection: the base expression which fields are selected from</param>
         /// <param name="selectionExpressions">Scalar: null. ListSelection: The selection fields used in .Select(). ObjectProjection: The fields used in the new { field1 = ..., field2 = ... }</param>
         /// <returns></returns>
-        public virtual (Expression baseExpression, Dictionary<string, CompiledField> selectionExpressions, ParameterExpression? selectContextParam) ProcessExpressionSelection(Expression baseExpression, Dictionary<string, CompiledField> selectionExpressions, ParameterExpression? selectContextParam, bool servicesPass, ParameterReplacer parameterReplacer)
+        public virtual (Expression baseExpression, Dictionary<IFieldKey, CompiledField> selectionExpressions, ParameterExpression? selectContextParam) ProcessExpressionSelection(Expression baseExpression, Dictionary<IFieldKey, CompiledField> selectionExpressions, ParameterExpression? selectContextParam, bool servicesPass, ParameterReplacer parameterReplacer)
         {
             return (baseExpression, selectionExpressions, selectContextParam);
         }

--- a/src/EntityGraphQL/Schema/FieldExtensions/IFieldExtension.cs
+++ b/src/EntityGraphQL/Schema/FieldExtensions/IFieldExtension.cs
@@ -50,7 +50,7 @@ namespace EntityGraphQL.Schema.FieldExtensions
         /// <param name="baseExpression">ListSelection: The expression used to add .Select() to. ObjectProjection: the base expression which fields are selected from</param>
         /// <param name="selectionExpressions">ListSelection: The selection fields used in .Select(). ObjectProjection: The fields used in the new { field1 = ..., field2 = ... }</param>
         /// <returns></returns>
-        (Expression baseExpression, Dictionary<string, CompiledField> selectionExpressions, ParameterExpression? selectContextParam) ProcessExpressionSelection(Expression baseExpression, Dictionary<string, CompiledField> selectionExpressions, ParameterExpression? selectContextParam, bool servicesPass, ParameterReplacer parameterReplacer);
+        (Expression baseExpression, Dictionary<IFieldKey, CompiledField> selectionExpressions, ParameterExpression? selectContextParam) ProcessExpressionSelection(Expression baseExpression, Dictionary<IFieldKey, CompiledField> selectionExpressions, ParameterExpression? selectContextParam, bool servicesPass, ParameterReplacer parameterReplacer);
         /// <summary>
         /// Called when the field is being finalized for execution
         /// 

--- a/src/EntityGraphQL/Schema/FieldToResolve.cs
+++ b/src/EntityGraphQL/Schema/FieldToResolve.cs
@@ -4,7 +4,7 @@ using System.Linq.Expressions;
 namespace EntityGraphQL.Schema;
 public class FieldToResolveWithArgs<TContext, TParams> : Field
 {
-    public FieldToResolveWithArgs(ISchemaProvider schema, string name, string? description, TParams argTypes) : base(schema, name, null, description, argTypes, SchemaBuilder.MakeGraphQlType(schema, typeof(object), null), null)
+    public FieldToResolveWithArgs(ISchemaProvider schema, ISchemaType fromType, string name, string? description, TParams argTypes) : base(schema, fromType, name, null, description, argTypes, SchemaBuilder.MakeGraphQlType(schema, typeof(object), null), null)
     {
     }
 
@@ -47,7 +47,7 @@ public class FieldToResolveWithArgs<TContext, TParams> : Field
 
 public class FieldToResolve<TContext> : Field
 {
-    public FieldToResolve(ISchemaProvider schema, string name, string? description, object? argTypes) : base(schema, name, null, description, argTypes, SchemaBuilder.MakeGraphQlType(schema, typeof(object), null), null)
+    public FieldToResolve(ISchemaProvider schema, ISchemaType fromType, string name, string? description, object? argTypes) : base(schema, fromType, name, null, description, argTypes, SchemaBuilder.MakeGraphQlType(schema, typeof(object), null), null)
     {
     }
 

--- a/src/EntityGraphQL/Schema/IField.cs
+++ b/src/EntityGraphQL/Schema/IField.cs
@@ -26,6 +26,10 @@ namespace EntityGraphQL.Schema
         ParameterExpression? ArgumentParam { get; }
         Type? ArgumentsType { get; set; }
         string Name { get; }
+        /// <summary>
+        /// GraphQL type this fiel belongs to
+        /// </summary>
+        ISchemaType FromType { get; }
         GqlTypeInfo ReturnType { get; }
         List<IFieldExtension> Extensions { get; set; }
         RequiredAuthorization? RequiredAuthorization { get; }

--- a/src/EntityGraphQL/Schema/MutationField.cs
+++ b/src/EntityGraphQL/Schema/MutationField.cs
@@ -17,8 +17,8 @@ namespace EntityGraphQL.Schema
         private readonly MethodInfo method;
         private readonly bool isAsync;
 
-        public MutationField(ISchemaProvider schema, string methodName, GqlTypeInfo returnType, MethodInfo method, string description, RequiredAuthorization requiredAuth, bool isAsync, Func<string, string> fieldNamer, SchemaBuilderMutationOptions options)
-            : base(schema, methodName, description, returnType)
+        public MutationField(ISchemaProvider schema, ISchemaType fromType, string methodName, GqlTypeInfo returnType, MethodInfo method, string description, RequiredAuthorization requiredAuth, bool isAsync, Func<string, string> fieldNamer, SchemaBuilderMutationOptions options)
+            : base(schema, fromType, methodName, description, returnType)
         {
             Services = new List<Type>();
             this.method = method;

--- a/src/EntityGraphQL/Schema/MutationType.cs
+++ b/src/EntityGraphQL/Schema/MutationType.cs
@@ -101,7 +101,7 @@ public class MutationType
         }
         var typeName = SchemaType.Schema.GetSchemaType(nonListReturnType, null).Name;
         var returnType = new GqlTypeInfo(() => SchemaType.Schema.Type(typeName), actualReturnType, method.IsNullable());
-        var mutationField = new MutationField(SchemaType.Schema, name, returnType, method, description ?? string.Empty, requiredClaims, isAsync, SchemaType.Schema.SchemaFieldNamer, options);
+        var mutationField = new MutationField(SchemaType.Schema, this.SchemaType, name, returnType, method, description ?? string.Empty, requiredClaims, isAsync, SchemaType.Schema.SchemaFieldNamer, options);
 
         var validators = method.GetCustomAttributes<ArgumentValidatorAttribute>();
         if (validators != null)

--- a/src/EntityGraphQL/Schema/SchemaType.cs
+++ b/src/EntityGraphQL/Schema/SchemaType.cs
@@ -66,7 +66,7 @@ namespace EntityGraphQL.Schema
 
                     var enumName = Enum.Parse(TypeDotnet, field.Name).ToString()!;
                     var description = (field.GetCustomAttribute(typeof(DescriptionAttribute)) as DescriptionAttribute)?.Description;
-                    var schemaField = new Field(Schema, enumName, null, description, new GqlTypeInfo(() => Schema.GetSchemaType(TypeDotnet, null), TypeDotnet, field.IsNullable()), Schema.AuthorizationService.GetRequiredAuthFromMember(field));
+                    var schemaField = new Field(Schema, this, enumName, null, description, new GqlTypeInfo(() => Schema.GetSchemaType(TypeDotnet, null), TypeDotnet, field.IsNullable()), Schema.AuthorizationService.GetRequiredAuthFromMember(field));
                     var obsoleteAttribute = field.GetCustomAttribute<ObsoleteAttribute>();
                     if (obsoleteAttribute != null)
                     {
@@ -81,7 +81,7 @@ namespace EntityGraphQL.Schema
             {
                 if (options == null)
                     options = new SchemaBuilderOptions();
-                var fields = SchemaBuilder.GetFieldsFromObject(TypeDotnet, Schema, options, GqlType == GqlTypeEnum.Input);
+                var fields = SchemaBuilder.GetFieldsFromObject(TypeDotnet, this, Schema, options, GqlType == GqlTypeEnum.Input);
                 AddFields(fields);
             }
             return this;
@@ -133,7 +133,7 @@ namespace EntityGraphQL.Schema
         {
             var requiredAuth = Schema.AuthorizationService.GetRequiredAuthFromExpression(fieldSelection);
 
-            var field = new Field(Schema, name, fieldSelection, description, SchemaBuilder.MakeGraphQlType(Schema, typeof(TReturn), null), requiredAuth);
+            var field = new Field(Schema, this, name, fieldSelection, description, SchemaBuilder.MakeGraphQlType(Schema, typeof(TReturn), null), requiredAuth);
             this.AddField(field);
             return field;
         }
@@ -154,7 +154,7 @@ namespace EntityGraphQL.Schema
         {
             var requiredAuth = Schema.AuthorizationService.GetRequiredAuthFromExpression(fieldSelection);
 
-            var field = new Field(Schema, name, fieldSelection, description, argTypes, SchemaBuilder.MakeGraphQlType(Schema, typeof(TReturn), null), requiredAuth);
+            var field = new Field(Schema, this, name, fieldSelection, description, argTypes, SchemaBuilder.MakeGraphQlType(Schema, typeof(TReturn), null), requiredAuth);
             this.AddField(field);
             return field;
         }
@@ -168,7 +168,7 @@ namespace EntityGraphQL.Schema
         /// <returns>The field object to perform further configuration</returns>
         public FieldToResolve<TBaseType> AddField(string name, string? description)
         {
-            var field = new FieldToResolve<TBaseType>(Schema, name, description, null);
+            var field = new FieldToResolve<TBaseType>(Schema, this, name, description, null);
             AddField(field);
             return field;
         }
@@ -186,7 +186,7 @@ namespace EntityGraphQL.Schema
         /// <returns>The field object to perform further configuration</returns>
         public FieldToResolveWithArgs<TBaseType, TParams> AddField<TParams>(string name, TParams argTypes, string? description)
         {
-            var field = new FieldToResolveWithArgs<TBaseType, TParams>(Schema, name, description, argTypes);
+            var field = new FieldToResolveWithArgs<TBaseType, TParams>(Schema, this, name, description, argTypes);
             AddField(field);
             return field;
         }
@@ -205,7 +205,7 @@ namespace EntityGraphQL.Schema
             var requiredAuth = Schema.AuthorizationService.GetRequiredAuthFromExpression(fieldSelection);
 
             RemoveField(name);
-            return AddField(new Field(Schema, name, fieldSelection, description, SchemaBuilder.MakeGraphQlType(Schema, typeof(TReturn), null), requiredAuth));
+            return AddField(new Field(Schema, this, name, fieldSelection, description, SchemaBuilder.MakeGraphQlType(Schema, typeof(TReturn), null), requiredAuth));
         }
 
         /// <summary>
@@ -223,7 +223,7 @@ namespace EntityGraphQL.Schema
             var requiredAuth = Schema.AuthorizationService.GetRequiredAuthFromExpression(fieldSelection);
 
             RemoveField(name);
-            return AddField(new Field(Schema, name, fieldSelection, description, argTypes, SchemaBuilder.MakeGraphQlType(Schema, typeof(TReturn), null), requiredAuth));
+            return AddField(new Field(Schema, this, name, fieldSelection, description, argTypes, SchemaBuilder.MakeGraphQlType(Schema, typeof(TReturn), null), requiredAuth));
         }
 
         /// <summary>
@@ -234,7 +234,7 @@ namespace EntityGraphQL.Schema
         /// <returns>The field object to perform further configuration</returns>
         public FieldToResolve<TBaseType> ReplaceField(string name, string? description)
         {
-            var field = new FieldToResolve<TBaseType>(Schema, name, description, null);
+            var field = new FieldToResolve<TBaseType>(Schema, this, name, description, null);
             FieldsByName[field.Name] = field;
             return field;
         }
@@ -249,7 +249,7 @@ namespace EntityGraphQL.Schema
         /// <returns>The field object to perform further configuration</returns>
         public FieldToResolveWithArgs<TBaseType, TParams> ReplaceField<TParams>(string name, TParams argTypes, string? description)
         {
-            var field = new FieldToResolveWithArgs<TBaseType, TParams>(Schema, name, description, argTypes);
+            var field = new FieldToResolveWithArgs<TBaseType, TParams>(Schema, this, name, description, argTypes);
             FieldsByName[field.Name] = field;
             return field;
         }
@@ -390,7 +390,7 @@ namespace EntityGraphQL.Schema
                 .SelectMany(s => s.GetTypes())
                 .Where(p => TypeDotnet.IsAssignableFrom(p) && !p.IsInterface && !p.IsAbstract);
 
-            foreach(var type in types)
+            foreach (var type in types)
             {
                 AddPossibleType(type, addTypeIfNotInSchema, addAllFieldsOnAddedType);
             }
@@ -425,7 +425,7 @@ namespace EntityGraphQL.Schema
             if (schemaType == null)
                 throw new EntityGraphQLCompilerException($"No schema type found for dotnet type {type.Name}. Make sure you add the type to the schema. Or use parameter addTypeIfNotInSchema = true");
 
-            if(schemaType.GqlType != GqlTypeEnum.Object)
+            if (schemaType.GqlType != GqlTypeEnum.Object)
                 throw new EntityGraphQLCompilerException($"The member types of a Union type must all be Object base types");
 
             possibleTypes.Add(schemaType);

--- a/src/tests/EntityGraphQL.Tests/QueryTests/UnionTests.cs
+++ b/src/tests/EntityGraphQL.Tests/QueryTests/UnionTests.cs
@@ -1,6 +1,5 @@
 ﻿using Xunit;
 using EntityGraphQL.Compiler;
-using EntityGraphQL.Tests.ApiVersion1;
 using EntityGraphQL.Schema;
 
 namespace EntityGraphQL.Tests
@@ -41,7 +40,7 @@ query {
             context.Animals.Add(new Cat() { Name = "george", Lives = 9 });
 
             var qr = gql.ExecuteQuery(context, null, null);
-            dynamic animals = (dynamic)qr.Data["animals"];
+            dynamic animals = qr.Data["animals"];
             // we only have the fields requested
             Assert.Equal(2, animals.Count);
 


### PR DESCRIPTION
So we can better tell same name fields from different types apart for union types

@bzbetty thoughts on this instead of replacing the name to insert the type in one spot and removing it later?

Seems knowing the type the field came from would be useful elsewhere too.