### PR TITLE
Mutations with separate parameters fail if called without variables

### DIFF
--- a/src/tests/EntityGraphQL.Tests/MutationTests/MutationTests.cs
+++ b/src/tests/EntityGraphQL.Tests/MutationTests/MutationTests.cs
@@ -585,6 +585,7 @@ namespace EntityGraphQL.Tests
             {
                 Query = @"mutation {
           taskWithList(inputs: [{name: ""Bill""}, {name: ""Bob""}])
+          taskWithListSeparateArg(inputs: [{name: ""Bill""}, {name: ""Bob""}])
         }
         ",
             };
@@ -593,6 +594,7 @@ namespace EntityGraphQL.Tests
             var results = schemaProvider.ExecuteRequest(gql, testSchema, null, null);
             Assert.Null(results.Errors);
             Assert.Equal(true, results.Data["taskWithList"]);
+            Assert.Equal(true, results.Data["taskWithListSeparateArg"]);
         }
 
         [Fact]

--- a/src/tests/EntityGraphQL.Tests/MutationTests/PeopleMutations.cs
+++ b/src/tests/EntityGraphQL.Tests/MutationTests/PeopleMutations.cs
@@ -187,6 +187,9 @@ namespace EntityGraphQL.Tests
             return true;
         }
         [GraphQLMutation]
+        public bool TaskWithListSeparateArg(List<InputObject> inputs) => true;
+
+        [GraphQLMutation]
         public bool TaskWithListInt(ListIntArgs args)
         {
             return true;


### PR DESCRIPTION
This PR adds a test that mutation that takes its arguments separately (vs via a `MutationArguments` object) works when the GraphQL query passes the parameters directly, rather than via a GraphQL variable.