### PR TITLE
Cannot pass object with selected fields to resolution method

### DIFF
--- a/src/tests/EntityGraphQL.Tests/QueryTests/ServiceFieldTests.cs
+++ b/src/tests/EntityGraphQL.Tests/QueryTests/ServiceFieldTests.cs
@@ -704,7 +704,7 @@ namespace EntityGraphQL.Tests
             schema.AddType<ProjectConfig>("ProjectConfig").AddAllFields();
 
             schema.Type<Project>().AddField("config", "Get project config")
-                .ResolveWithService<ConfigService>((p, srv) => srv.Get(p.Id));
+                .ResolveWithService<ConfigService>((p, srv) => srv.Get(p));
             // because of the selections of the config.type (a service) when we do our second selection (first is EF compatible)
             // the type of t will not match, need to be replaced
             schema.Type<Project>().ReplaceField("tasks", p => p.Tasks.Where(t => t.IsActive), "Active tasks");
@@ -1841,6 +1841,8 @@ namespace EntityGraphQL.Tests
                     Type = "Something"
                 };
             }
+
+            public ProjectConfig Get(Project p) => Get(p.Id);
 
             public string Get(string str1, string str2)
             {


### PR DESCRIPTION
To select fields from an object, EntityGraphQL creates a proxy object for it. This proxy object is incompatible with the original type. The incompatibility causes a runtime error when the proxy object is passed to a method used to resolve a subsequent field. This PR tests this scenario.