### PR TITLE
Document HTTP request using async

### DIFF
--- a/docs/docs/authorization.md
+++ b/docs/docs/authorization.md
@@ -15,7 +15,7 @@ _Note if you are using the `AddGraphQLSchema()` extension in `EntityGraphQL.AspN
 ```cs
 // Assuming you're in a ASP.NET controller
 // this.User is the current ClaimsPrincipal
-var results = schemaProvider.ExecuteRequest(query, dbContext, this.HttpContext.RequestServices, this.User);
+var results = await schemaProvider.ExecuteRequestAsync(query, dbContext, this.HttpContext.RequestServices, this.User);
 ```
 
 ## Adding Authorization on Roles or Policies

--- a/docs/docs/getting-started.md
+++ b/docs/docs/getting-started.md
@@ -255,18 +255,11 @@ public class QueryController : Controller
     }
 
     [HttpPost]
-    public object Post([FromBody]QueryRequest query)
+    public async Task<object> Post([FromBody]QueryRequest query)
     {
-        try
-        {
-            var results = _schemaProvider.ExecuteRequest(query, _dbContext, HttpContext.RequestServices, null);
-            // gql compile errors show up in results.Errors
-            return results;
-        }
-        catch (Exception)
-        {
-            return HttpStatusCode.InternalServerError;
-        }
+        var results = await _schemaProvider.ExecuteRequestAsync(query, _dbContext, HttpContext.RequestServices, null);
+        // gql compile errors show up in results.Errors
+        return results;
     }
 }
 ```

--- a/src/tests/EntityGraphQL.Tests/QueryTests/QueryTests.cs
+++ b/src/tests/EntityGraphQL.Tests/QueryTests/QueryTests.cs
@@ -31,6 +31,17 @@ namespace EntityGraphQL.Tests
         }
 
         [Fact]
+        public void CanQueryAsyncField() {
+            var objectSchemaProvider = SchemaBuilder.FromObject<TestDataContext>();
+            var tree = new GraphQLCompiler(objectSchemaProvider).Compile(@"
+{
+	firstUserId
+}");
+            var result = tree.ExecuteQuery(new TestDataContext().FillWithTestData(), null, null);
+            Assert.Equal(100, (int)result.Data["firstUserId"]);
+        }
+
+        [Fact]
         public void CanQueryExtendedFields()
         {
             var objectSchemaProvider = SchemaBuilder.FromObject<TestDataContext>();

--- a/src/tests/EntityGraphQL.Tests/TestDataContext.cs
+++ b/src/tests/EntityGraphQL.Tests/TestDataContext.cs
@@ -26,6 +26,7 @@ namespace EntityGraphQL.Tests
         public List<Location> Locations { get; set; } = new List<Location>();
         public virtual List<Person> People { get; set; } = new List<Person>();
         public List<User> Users { get; set; } = new List<User>();
+        public System.Threading.Tasks.Task<int?> FirstUserId => System.Threading.Tasks.Task.FromResult(Users.FirstOrDefault()?.Id);
     }
 
     public class TestDataContext2


### PR DESCRIPTION
Changes the docs to use `ExecuteRequestAsync` instead of `ExecuteRequest`. This not only provides a performance improvement, it also works around an apparent bug. In a production app, we were experiencing extremely high CPU when using the synchronous version of `ExecuteRequest`, rendering the web server unusable. The problem didn't always occur; it seemed to be related to the frequency of GraphQL queries, with successive calls getting progressively slower while always consuming an entire core. Switching to async solved the problem. Switching to async resolved the problem.

The high CPU issue doesn't occur when just calling `ExecuteRequest` directly. I tried adding high frequency calls to a unit test in QueryTests.cs, and they worked just fine. The problem appears to be related to interoperation with ASP.NET Core or Entity Framework Core.