### PR TITLE
Fixes nullable lists

### DIFF
--- a/src/EntityGraphQL/Extensions/Nullability/NullabilityInfo.cs
+++ b/src/EntityGraphQL/Extensions/Nullability/NullabilityInfo.cs
@@ -1,0 +1,71 @@
+﻿#nullable enable
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.ObjectModel;
+
+
+using NullabilityInfoContext = Nullability.NullabilityInfoContextEx;
+using NullabilityInfo = Nullability.NullabilityInfoEx;
+using NullabilityState = Nullability.NullabilityStateEx;
+using System;
+
+namespace Nullability
+{
+    /// <summary>
+    /// A class that represents nullability info
+    /// </summary>
+    public sealed class NullabilityInfoEx
+    {
+        internal NullabilityInfoEx(Type type, NullabilityState readState, NullabilityState writeState,
+            NullabilityInfo? elementType, NullabilityInfo[] typeArguments)
+        {
+            Type = type;
+            ReadState = readState;
+            WriteState = writeState;
+            ElementType = elementType;
+            GenericTypeArguments = typeArguments;
+        }
+
+        /// <summary>
+        /// The <see cref="System.Type" /> of the member or generic parameter
+        /// to which this NullabilityInfo belongs
+        /// </summary>
+        public Type Type { get; }
+        /// <summary>
+        /// The nullability read state of the member
+        /// </summary>
+        public NullabilityState ReadState { get; internal set; }
+        /// <summary>
+        /// The nullability write state of the member
+        /// </summary>
+        public NullabilityState WriteState { get; internal set; }
+        /// <summary>
+        /// If the member type is an array, gives the <see cref="NullabilityInfo" /> of the elements of the array, null otherwise
+        /// </summary>
+        public NullabilityInfo? ElementType { get; }
+        /// <summary>
+        /// If the member type is a generic type, gives the array of <see cref="NullabilityInfo" /> for each type parameter
+        /// </summary>
+        public NullabilityInfo[] GenericTypeArguments { get; }
+    }
+
+    /// <summary>
+    /// An enum that represents nullability state
+    /// </summary>
+    public enum NullabilityStateEx
+    {
+        /// <summary>
+        /// Nullability context not enabled (oblivious)
+        /// </summary>
+        Unknown,
+        /// <summary>
+        /// Non nullable value or reference type
+        /// </summary>
+        NotNull,
+        /// <summary>
+        /// Nullable value or reference type
+        /// </summary>
+        Nullable
+    }
+}

--- a/src/EntityGraphQL/Extensions/Nullability/NullabilityInfoContext.cs
+++ b/src/EntityGraphQL/Extensions/Nullability/NullabilityInfoContext.cs
@@ -1,0 +1,666 @@
+﻿#nullable enable
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Diagnostics;
+
+
+using NullabilityInfoContext = Nullability.NullabilityInfoContextEx;
+using NullabilityInfo = Nullability.NullabilityInfoEx;
+using NullabilityState = Nullability.NullabilityStateEx;
+using System;
+using System.Reflection;
+using System.Linq;
+
+namespace Nullability
+{
+    /// <summary>
+    /// Provides APIs for populating nullability information/context from reflection members:
+    /// <see cref="ParameterInfo"/>, <see cref="FieldInfo"/>, <see cref="PropertyInfo"/> and <see cref="EventInfo"/>.
+    /// </summary>
+    public sealed class NullabilityInfoContextEx
+    {
+        private const string CompilerServicesNameSpace = "System.Runtime.CompilerServices";
+        private readonly Dictionary<Module, NotAnnotatedStatus> _publicOnlyModules = new();
+        private readonly Dictionary<MemberInfo, NullabilityState> _context = new();
+
+        internal static bool IsSupported { get; } =
+            AppContext.TryGetSwitch("System.Reflection.NullabilityInfoContext.IsSupported", out bool isSupported) ? isSupported : true;
+
+        [Flags]
+        private enum NotAnnotatedStatus
+        {
+            None = 0x0,    // no restriction, all members annotated
+            Private = 0x1, // private members not annotated
+            Internal = 0x2 // internal members not annotated
+        }
+
+        private NullabilityState? GetNullableContext(MemberInfo? memberInfo)
+        {
+            while (memberInfo != null)
+            {
+                if (_context.TryGetValue(memberInfo, out NullabilityState state))
+                {
+                    return state;
+                }
+
+                foreach (CustomAttributeData attribute in memberInfo.GetCustomAttributesData())
+                {
+                    if (attribute.AttributeType.Name == "NullableContextAttribute" &&
+                        attribute.AttributeType.Namespace == CompilerServicesNameSpace &&
+                        attribute.ConstructorArguments.Count == 1)
+                    {
+                        state = TranslateByte(attribute.ConstructorArguments[0].Value);
+                        _context.Add(memberInfo, state);
+                        return state;
+                    }
+                }
+
+                memberInfo = memberInfo.DeclaringType;
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Populates <see cref="NullabilityInfo" /> for the given <see cref="ParameterInfo" />.
+        /// If the nullablePublicOnly feature is set for an assembly, like it does in .NET SDK, the private and/or internal member's
+        /// nullability attributes are omitted, in this case the API will return NullabilityState.Unknown state.
+        /// </summary>
+        /// <param name="parameterInfo">The parameter which nullability info gets populated</param>
+        /// <exception cref="ArgumentNullException">If the parameterInfo parameter is null</exception>
+        /// <returns><see cref="NullabilityInfo" /></returns>
+        public NullabilityInfo Create(ParameterInfo parameterInfo)
+        {
+
+
+            EnsureIsSupported();
+
+            IList<CustomAttributeData> attributes = parameterInfo.GetCustomAttributesData();
+            NullableAttributeStateParser parser = parameterInfo.Member is MethodBase method && IsPrivateOrInternalMethodAndAnnotationDisabled(method)
+                ? NullableAttributeStateParser.Unknown
+                : CreateParser(attributes);
+            NullabilityInfo nullability = GetNullabilityInfo(parameterInfo.Member, parameterInfo.ParameterType, parser);
+
+            if (nullability.ReadState != NullabilityState.Unknown)
+            {
+                CheckParameterMetadataType(parameterInfo, nullability);
+            }
+
+            CheckNullabilityAttributes(nullability, attributes);
+            return nullability;
+        }
+
+        private void CheckParameterMetadataType(ParameterInfo parameter, NullabilityInfo nullability)
+        {
+            if (parameter.Member is MethodInfo method)
+            {
+                MethodInfo metaMethod = GetMethodMetadataDefinition(method);
+                ParameterInfo? metaParameter = null;
+                if (string.IsNullOrEmpty(parameter.Name))
+                {
+                    metaParameter = metaMethod.ReturnParameter;
+                }
+                else
+                {
+                    ParameterInfo[] parameters = metaMethod.GetParameters();
+                    for (int i = 0; i < parameters.Length; i++)
+                    {
+                        if (parameter.Position == i &&
+                            parameter.Name == parameters[i].Name)
+                        {
+                            metaParameter = parameters[i];
+                            break;
+                        }
+                    }
+                }
+
+                if (metaParameter != null)
+                {
+                    CheckGenericParameters(nullability, metaMethod, metaParameter.ParameterType, parameter.Member.ReflectedType);
+                }
+            }
+        }
+
+        private static MethodInfo GetMethodMetadataDefinition(MethodInfo method)
+        {
+            if (method.IsGenericMethod && !method.IsGenericMethodDefinition)
+            {
+                method = method.GetGenericMethodDefinition();
+            }
+
+            return (MethodInfo)GetMemberMetadataDefinition(method);
+        }
+
+        private static void CheckNullabilityAttributes(NullabilityInfo nullability, IList<CustomAttributeData> attributes)
+        {
+            var codeAnalysisReadState = NullabilityState.Unknown;
+            var codeAnalysisWriteState = NullabilityState.Unknown;
+
+            foreach (CustomAttributeData attribute in attributes)
+            {
+                if (attribute.AttributeType.Namespace == "System.Diagnostics.CodeAnalysis")
+                {
+                    if (attribute.AttributeType.Name == "NotNullAttribute")
+                    {
+                        codeAnalysisReadState = NullabilityState.NotNull;
+                    }
+                    else if ((attribute.AttributeType.Name == "MaybeNullAttribute" ||
+                            attribute.AttributeType.Name == "MaybeNullWhenAttribute") &&
+                            codeAnalysisReadState == NullabilityState.Unknown &&
+                            !IsValueTypeOrValueTypeByRef(nullability.Type))
+                    {
+                        codeAnalysisReadState = NullabilityState.Nullable;
+                    }
+                    else if (attribute.AttributeType.Name == "DisallowNullAttribute")
+                    {
+                        codeAnalysisWriteState = NullabilityState.NotNull;
+                    }
+                    else if (attribute.AttributeType.Name == "AllowNullAttribute" &&
+                        codeAnalysisWriteState == NullabilityState.Unknown &&
+                        !IsValueTypeOrValueTypeByRef(nullability.Type))
+                    {
+                        codeAnalysisWriteState = NullabilityState.Nullable;
+                    }
+                }
+            }
+
+            if (codeAnalysisReadState != NullabilityState.Unknown)
+            {
+                nullability.ReadState = codeAnalysisReadState;
+            }
+            if (codeAnalysisWriteState != NullabilityState.Unknown)
+            {
+                nullability.WriteState = codeAnalysisWriteState;
+            }
+        }
+
+        /// <summary>
+        /// Populates <see cref="NullabilityInfo" /> for the given <see cref="PropertyInfo" />.
+        /// If the nullablePublicOnly feature is set for an assembly, like it does in .NET SDK, the private and/or internal member's
+        /// nullability attributes are omitted, in this case the API will return NullabilityState.Unknown state.
+        /// </summary>
+        /// <param name="propertyInfo">The parameter which nullability info gets populated</param>
+        /// <exception cref="ArgumentNullException">If the propertyInfo parameter is null</exception>
+        /// <returns><see cref="NullabilityInfo" /></returns>
+        public NullabilityInfo Create(PropertyInfo propertyInfo)
+        {
+
+
+            EnsureIsSupported();
+
+            MethodInfo? getter = propertyInfo.GetGetMethod(true);
+            MethodInfo? setter = propertyInfo.GetSetMethod(true);
+            bool annotationsDisabled = (getter == null || IsPrivateOrInternalMethodAndAnnotationDisabled(getter))
+                && (setter == null || IsPrivateOrInternalMethodAndAnnotationDisabled(setter));
+            NullableAttributeStateParser parser = annotationsDisabled ? NullableAttributeStateParser.Unknown : CreateParser(propertyInfo.GetCustomAttributesData());
+            NullabilityInfo nullability = GetNullabilityInfo(propertyInfo, propertyInfo.PropertyType, parser);
+
+            if (getter != null)
+            {
+                CheckNullabilityAttributes(nullability, getter.ReturnParameter.GetCustomAttributesData());
+            }
+            else
+            {
+                nullability.ReadState = NullabilityState.Unknown;
+            }
+
+            if (setter != null)
+            {
+                CheckNullabilityAttributes(nullability, setter.GetParameters().Last().GetCustomAttributesData());
+            }
+            else
+            {
+                nullability.WriteState = NullabilityState.Unknown;
+            }
+
+            return nullability;
+        }
+
+        private bool IsPrivateOrInternalMethodAndAnnotationDisabled(MethodBase method)
+        {
+            if ((method.IsPrivate || method.IsFamilyAndAssembly || method.IsAssembly) &&
+               IsPublicOnly(method.IsPrivate, method.IsFamilyAndAssembly, method.IsAssembly, method.Module))
+            {
+                return true;
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Populates <see cref="NullabilityInfo" /> for the given <see cref="EventInfo" />.
+        /// If the nullablePublicOnly feature is set for an assembly, like it does in .NET SDK, the private and/or internal member's
+        /// nullability attributes are omitted, in this case the API will return NullabilityState.Unknown state.
+        /// </summary>
+        /// <param name="eventInfo">The parameter which nullability info gets populated</param>
+        /// <exception cref="ArgumentNullException">If the eventInfo parameter is null</exception>
+        /// <returns><see cref="NullabilityInfo" /></returns>
+        public NullabilityInfo Create(EventInfo eventInfo)
+        {
+
+
+            EnsureIsSupported();
+
+            return GetNullabilityInfo(eventInfo, eventInfo.EventHandlerType!, CreateParser(eventInfo.GetCustomAttributesData()));
+        }
+
+        /// <summary>
+        /// Populates <see cref="NullabilityInfo" /> for the given <see cref="FieldInfo" />
+        /// If the nullablePublicOnly feature is set for an assembly, like it does in .NET SDK, the private and/or internal member's
+        /// nullability attributes are omitted, in this case the API will return NullabilityState.Unknown state.
+        /// </summary>
+        /// <param name="fieldInfo">The parameter which nullability info gets populated</param>
+        /// <exception cref="ArgumentNullException">If the fieldInfo parameter is null</exception>
+        /// <returns><see cref="NullabilityInfo" /></returns>
+        public NullabilityInfo Create(FieldInfo fieldInfo)
+        {
+
+
+            EnsureIsSupported();
+
+            IList<CustomAttributeData> attributes = fieldInfo.GetCustomAttributesData();
+            NullableAttributeStateParser parser = IsPrivateOrInternalFieldAndAnnotationDisabled(fieldInfo) ? NullableAttributeStateParser.Unknown : CreateParser(attributes);
+            NullabilityInfo nullability = GetNullabilityInfo(fieldInfo, fieldInfo.FieldType, parser);
+            CheckNullabilityAttributes(nullability, attributes);
+            return nullability;
+        }
+
+        private static void EnsureIsSupported()
+        {
+            if (!IsSupported)
+            {
+                throw new InvalidOperationException("NullabilityInfoContext is not supported");
+            }
+        }
+
+        private bool IsPrivateOrInternalFieldAndAnnotationDisabled(FieldInfo fieldInfo)
+        {
+            if ((fieldInfo.IsPrivate || fieldInfo.IsFamilyAndAssembly || fieldInfo.IsAssembly) &&
+                IsPublicOnly(fieldInfo.IsPrivate, fieldInfo.IsFamilyAndAssembly, fieldInfo.IsAssembly, fieldInfo.Module))
+            {
+                return true;
+            }
+
+            return false;
+        }
+
+        private bool IsPublicOnly(bool isPrivate, bool isFamilyAndAssembly, bool isAssembly, Module module)
+        {
+            if (!_publicOnlyModules.TryGetValue(module, out NotAnnotatedStatus value))
+            {
+                value = PopulateAnnotationInfo(module.GetCustomAttributesData());
+                _publicOnlyModules.Add(module, value);
+            }
+
+            if (value == NotAnnotatedStatus.None)
+            {
+                return false;
+            }
+
+            if ((isPrivate || isFamilyAndAssembly) && value.HasFlag(NotAnnotatedStatus.Private) ||
+                 isAssembly && value.HasFlag(NotAnnotatedStatus.Internal))
+            {
+                return true;
+            }
+
+            return false;
+        }
+
+        private static NotAnnotatedStatus PopulateAnnotationInfo(IList<CustomAttributeData> customAttributes)
+        {
+            foreach (CustomAttributeData attribute in customAttributes)
+            {
+                if (attribute.AttributeType.Name == "NullablePublicOnlyAttribute" &&
+                    attribute.AttributeType.Namespace == CompilerServicesNameSpace &&
+                    attribute.ConstructorArguments.Count == 1)
+                {
+                    if (attribute.ConstructorArguments[0].Value is bool boolValue && boolValue)
+                    {
+                        return NotAnnotatedStatus.Internal | NotAnnotatedStatus.Private;
+                    }
+                    else
+                    {
+                        return NotAnnotatedStatus.Private;
+                    }
+                }
+            }
+
+            return NotAnnotatedStatus.None;
+        }
+
+        private NullabilityInfo GetNullabilityInfo(MemberInfo memberInfo, Type type, NullableAttributeStateParser parser)
+        {
+            int index = 0;
+            NullabilityInfo nullability = GetNullabilityInfo(memberInfo, type, parser, ref index);
+
+            if (nullability.ReadState != NullabilityState.Unknown)
+            {
+                TryLoadGenericMetaTypeNullability(memberInfo, nullability);
+            }
+
+            return nullability;
+        }
+
+        private NullabilityInfo GetNullabilityInfo(MemberInfo memberInfo, Type type, NullableAttributeStateParser parser, ref int index)
+        {
+            NullabilityState state = NullabilityState.Unknown;
+            NullabilityInfo? elementState = null;
+            NullabilityInfo[] genericArgumentsState = Array.Empty<NullabilityInfo>();
+            Type underlyingType = type;
+
+            if (underlyingType.IsByRef || underlyingType.IsPointer)
+            {
+                underlyingType = underlyingType.GetElementType()!;
+            }
+
+            if (underlyingType.IsValueType)
+            {
+                if (Nullable.GetUnderlyingType(underlyingType) is { } nullableUnderlyingType)
+                {
+                    underlyingType = nullableUnderlyingType;
+                    state = NullabilityState.Nullable;
+                }
+                else
+                {
+                    state = NullabilityState.NotNull;
+                }
+
+                if (underlyingType.IsGenericType)
+                {
+                    ++index;
+                }
+            }
+            else
+            {
+                if (!parser.ParseNullableState(index++, ref state)
+                    && GetNullableContext(memberInfo) is { } contextState)
+                {
+                    state = contextState;
+                }
+
+                if (underlyingType.IsArray)
+                {
+                    elementState = GetNullabilityInfo(memberInfo, underlyingType.GetElementType()!, parser, ref index);
+                }
+            }
+
+            if (underlyingType.IsGenericType)
+            {
+                Type[] genericArguments = underlyingType.GetGenericArguments();
+                genericArgumentsState = new NullabilityInfo[genericArguments.Length];
+
+                for (int i = 0; i < genericArguments.Length; i++)
+                {
+                    genericArgumentsState[i] = GetNullabilityInfo(memberInfo, genericArguments[i], parser, ref index);
+                }
+            }
+
+            return new NullabilityInfo(type, state, state, elementState, genericArgumentsState);
+        }
+
+        private static NullableAttributeStateParser CreateParser(IList<CustomAttributeData> customAttributes)
+        {
+            foreach (CustomAttributeData attribute in customAttributes)
+            {
+                if (attribute.AttributeType.Name == "NullableAttribute" &&
+                    attribute.AttributeType.Namespace == CompilerServicesNameSpace &&
+                    attribute.ConstructorArguments.Count == 1)
+                {
+                    return new NullableAttributeStateParser(attribute.ConstructorArguments[0].Value);
+                }
+            }
+
+            return new NullableAttributeStateParser(null);
+        }
+
+        private void TryLoadGenericMetaTypeNullability(MemberInfo memberInfo, NullabilityInfo nullability)
+        {
+            MemberInfo? metaMember = GetMemberMetadataDefinition(memberInfo);
+            Type? metaType = null;
+            if (metaMember is FieldInfo field)
+            {
+                metaType = field.FieldType;
+            }
+            else if (metaMember is PropertyInfo property)
+            {
+                metaType = GetPropertyMetaType(property);
+            }
+
+            if (metaType != null)
+            {
+                CheckGenericParameters(nullability, metaMember!, metaType, memberInfo.ReflectedType);
+            }
+        }
+
+        private static MemberInfo GetMemberMetadataDefinition(MemberInfo member)
+        {
+            Type? type = member.DeclaringType;
+            if ((type != null) && type.IsGenericType && !type.IsGenericTypeDefinition)
+            {
+                return NullabilityInfoExtensions.GetMemberWithSameMetadataDefinitionAs(type.GetGenericTypeDefinition(), member);
+            }
+
+            return member;
+        }
+
+        private static Type GetPropertyMetaType(PropertyInfo property)
+        {
+            if (property.GetGetMethod(true) is MethodInfo method)
+            {
+                return method.ReturnType;
+            }
+
+            return property.GetSetMethod(true)!.GetParameters()[0].ParameterType;
+        }
+
+        private void CheckGenericParameters(NullabilityInfo nullability, MemberInfo metaMember, Type metaType, Type? reflectedType)
+        {
+            if (metaType.IsGenericParameter)
+            {
+                if (nullability.ReadState == NullabilityState.NotNull)
+                {
+                    TryUpdateGenericParameterNullability(nullability, metaType, reflectedType);
+                }
+            }
+            else if (metaType.ContainsGenericParameters)
+            {
+                if (nullability.GenericTypeArguments.Length > 0)
+                {
+                    Type[] genericArguments = metaType.GetGenericArguments();
+
+                    for (int i = 0; i < genericArguments.Length; i++)
+                    {
+                        CheckGenericParameters(nullability.GenericTypeArguments[i], metaMember, genericArguments[i], reflectedType);
+                    }
+                }
+                else if (nullability.ElementType is { } elementNullability && metaType.IsArray)
+                {
+                    CheckGenericParameters(elementNullability, metaMember, metaType.GetElementType()!, reflectedType);
+                }
+                // We could also follow this branch for metaType.IsPointer, but since pointers must be unmanaged this
+                // will be a no-op regardless
+                else if (metaType.IsByRef)
+                {
+                    CheckGenericParameters(nullability, metaMember, metaType.GetElementType()!, reflectedType);
+                }
+            }
+        }
+
+        private bool TryUpdateGenericParameterNullability(NullabilityInfo nullability, Type genericParameter, Type? reflectedType)
+        {
+            Debug.Assert(genericParameter.IsGenericParameter);
+
+            if (reflectedType is not null
+                && !genericParameter.IsGenericMethodParameter()
+                && TryUpdateGenericTypeParameterNullabilityFromReflectedType(nullability, genericParameter, reflectedType, reflectedType))
+            {
+                return true;
+            }
+
+            if (IsValueTypeOrValueTypeByRef(nullability.Type))
+            {
+                return true;
+            }
+
+            var state = NullabilityState.Unknown;
+            if (CreateParser(genericParameter.GetCustomAttributesData()).ParseNullableState(0, ref state))
+            {
+                nullability.ReadState = state;
+                nullability.WriteState = state;
+                return true;
+            }
+
+            if (GetNullableContext(genericParameter) is { } contextState)
+            {
+                nullability.ReadState = contextState;
+                nullability.WriteState = contextState;
+                return true;
+            }
+
+            return false;
+        }
+
+        private bool TryUpdateGenericTypeParameterNullabilityFromReflectedType(NullabilityInfo nullability, Type genericParameter, Type context, Type reflectedType)
+        {
+            Debug.Assert(genericParameter.IsGenericParameter && !genericParameter.IsGenericMethodParameter());
+
+            Type contextTypeDefinition = context.IsGenericType && !context.IsGenericTypeDefinition ? context.GetGenericTypeDefinition() : context;
+            if (genericParameter.DeclaringType == contextTypeDefinition)
+            {
+                return false;
+            }
+
+            Type? baseType = contextTypeDefinition.BaseType;
+            if (baseType is null)
+            {
+                return false;
+            }
+
+            if (!baseType.IsGenericType
+                || (baseType.IsGenericTypeDefinition ? baseType : baseType.GetGenericTypeDefinition()) != genericParameter.DeclaringType)
+            {
+                return TryUpdateGenericTypeParameterNullabilityFromReflectedType(nullability, genericParameter, baseType, reflectedType);
+            }
+
+            Type[] genericArguments = baseType.GetGenericArguments();
+            Type genericArgument = genericArguments[genericParameter.GenericParameterPosition];
+            if (genericArgument.IsGenericParameter)
+            {
+                return TryUpdateGenericParameterNullability(nullability, genericArgument, reflectedType);
+            }
+
+            NullableAttributeStateParser parser = CreateParser(contextTypeDefinition.GetCustomAttributesData());
+            int nullabilityStateIndex = 1; // start at 1 since index 0 is the type itself
+            for (int i = 0; i < genericParameter.GenericParameterPosition; i++)
+            {
+                nullabilityStateIndex += CountNullabilityStates(genericArguments[i]);
+            }
+            return TryPopulateNullabilityInfo(nullability, parser, ref nullabilityStateIndex);
+
+            static int CountNullabilityStates(Type type)
+            {
+                Type underlyingType = Nullable.GetUnderlyingType(type) ?? type;
+                if (underlyingType.IsGenericType)
+                {
+                    int count = 1;
+                    foreach (Type genericArgument in underlyingType.GetGenericArguments())
+                    {
+                        count += CountNullabilityStates(genericArgument);
+                    }
+                    return count;
+                }
+
+                if (underlyingType.HasElementType)
+                {
+                    return (underlyingType.IsArray ? 1 : 0) + CountNullabilityStates(underlyingType.GetElementType()!);
+                }
+
+                return type.IsValueType ? 0 : 1;
+            }
+        }
+
+        private bool TryPopulateNullabilityInfo(NullabilityInfo nullability, NullableAttributeStateParser parser, ref int index)
+        {
+            bool isValueType = IsValueTypeOrValueTypeByRef(nullability.Type);
+            if (!isValueType)
+            {
+                var state = NullabilityState.Unknown;
+                if (!parser.ParseNullableState(index, ref state))
+                {
+                    return false;
+                }
+
+                nullability.ReadState = state;
+                nullability.WriteState = state;
+            }
+
+            if (!isValueType || (Nullable.GetUnderlyingType(nullability.Type) ?? nullability.Type).IsGenericType)
+            {
+                index++;
+            }
+
+            if (nullability.GenericTypeArguments.Length > 0)
+            {
+                foreach (NullabilityInfo genericTypeArgumentNullability in nullability.GenericTypeArguments)
+                {
+                    TryPopulateNullabilityInfo(genericTypeArgumentNullability, parser, ref index);
+                }
+            }
+            else if (nullability.ElementType is { } elementTypeNullability)
+            {
+                TryPopulateNullabilityInfo(elementTypeNullability, parser, ref index);
+            }
+
+            return true;
+        }
+
+        private static NullabilityState TranslateByte(object? value)
+        {
+            return value is byte b ? TranslateByte(b) : NullabilityState.Unknown;
+        }
+
+        private static NullabilityState TranslateByte(byte b) =>
+            b switch
+            {
+                1 => NullabilityState.NotNull,
+                2 => NullabilityState.Nullable,
+                _ => NullabilityState.Unknown
+            };
+
+        private static bool IsValueTypeOrValueTypeByRef(Type type) =>
+            type.IsValueType || ((type.IsByRef || type.IsPointer) && type.GetElementType()!.IsValueType);
+
+        private readonly struct NullableAttributeStateParser
+        {
+            private static readonly object UnknownByte = (byte)0;
+
+            private readonly object? _nullableAttributeArgument;
+
+            public NullableAttributeStateParser(object? nullableAttributeArgument)
+            {
+                this._nullableAttributeArgument = nullableAttributeArgument;
+            }
+
+            public static NullableAttributeStateParser Unknown => new(UnknownByte);
+
+            public bool ParseNullableState(int index, ref NullabilityState state)
+            {
+                switch (this._nullableAttributeArgument)
+                {
+                    case byte b:
+                        state = TranslateByte(b);
+                        return true;
+                    case ReadOnlyCollection<CustomAttributeTypedArgument> args
+                        when index < args.Count && args[index].Value is byte elementB:
+                        state = TranslateByte(elementB);
+                        return true;
+                    default:
+                        return false;
+                }
+            }
+        }
+    }
+}

--- a/src/EntityGraphQL/Extensions/Nullability/NullabilityInfoExtensions.cs
+++ b/src/EntityGraphQL/Extensions/Nullability/NullabilityInfoExtensions.cs
@@ -1,0 +1,227 @@
+﻿#nullable enable
+
+using System.Collections.Concurrent;
+
+
+using NullabilityInfoContext = Nullability.NullabilityInfoContextEx;
+using NullabilityInfo = Nullability.NullabilityInfoEx;
+using NullabilityState = Nullability.NullabilityStateEx;
+using System;
+using System.Reflection;
+using System.Linq.Expressions;
+
+namespace Nullability
+{
+    /// <summary>
+    /// Static and thread safe wrapper around <see cref="NullabilityInfoContext"/>.
+    /// </summary>
+    public static class NullabilityInfoExtensions
+    {
+        static ConcurrentDictionary<ParameterInfo, NullabilityInfo> parameterCache = new();
+        static ConcurrentDictionary<PropertyInfo, NullabilityInfo> propertyCache = new();
+        static ConcurrentDictionary<EventInfo, NullabilityInfo> eventCache = new();
+        static ConcurrentDictionary<FieldInfo, NullabilityInfo> fieldCache = new();
+
+        public static NullabilityInfo GetNullabilityInfo(this MemberInfo info)
+        {
+            if (info is PropertyInfo propertyInfo)
+            {
+                return propertyInfo.GetNullabilityInfo();
+            }
+
+            if (info is EventInfo eventInfo)
+            {
+                return eventInfo.GetNullabilityInfo();
+            }
+
+            if (info is FieldInfo fieldInfo)
+            {
+                return fieldInfo.GetNullabilityInfo();
+            }
+
+            if (info is MethodInfo methodInfo)
+            {
+                return methodInfo.GetNullabilityInfo();
+            }
+
+            throw new ArgumentException($"Unsupported type:{info.GetType().FullName}");
+        }
+
+        public static NullabilityInfo Unwrap(this NullabilityInfo info)
+        {
+            if(info.GenericTypeArguments.Length == 0)
+            {
+                return info;
+            }
+
+            if(info.Type.GetGenericTypeDefinition() == typeof(Expression<>))
+            {
+                return info.GenericTypeArguments[0].Unwrap();
+            }
+
+            if (info.Type.Name.StartsWith("Func`"))
+            {
+                return info.GenericTypeArguments[info.GenericTypeArguments.Length -1].Unwrap();
+            }
+
+            return info;
+        }
+
+        public static NullabilityInfo GetNullabilityInfo(this MethodInfo info)
+        {
+            return info.ReturnParameter.GetNullabilityInfo();
+        }
+       
+        public static NullabilityState GetNullability(this MemberInfo info)
+        {
+            return GetReadOrWriteState(info.Name, info.GetNullabilityInfo());
+        }
+
+        public static bool IsNullable(this MemberInfo info)
+        {
+            var nullability = info.GetNullabilityInfo();
+            return IsNullable(info.Name, nullability);
+        }
+
+        public static NullabilityInfo GetNullabilityInfo(this FieldInfo info)
+        {
+            return fieldCache.GetOrAdd(info, inner =>
+            {
+                var nullabilityContext = new NullabilityInfoContext();
+                return nullabilityContext.Create(inner);
+            });
+        }
+
+        public static NullabilityState GetNullability(this FieldInfo info)
+        {
+            return GetReadOrWriteState(info.Name, info.GetNullabilityInfo());
+        }
+
+        public static bool IsNullable(this FieldInfo info)
+        {
+            var nullability = info.GetNullabilityInfo();
+            return IsNullable(info.Name, nullability);
+        }
+
+        public static NullabilityInfo GetNullabilityInfo(this EventInfo info)
+        {
+            return eventCache.GetOrAdd(info, inner =>
+            {
+                var nullabilityContext = new NullabilityInfoContext();
+                return nullabilityContext.Create(inner);
+            });
+        }
+
+        public static NullabilityState GetNullability(this EventInfo info)
+        {
+            return GetReadOrWriteState(info.Name, info.GetNullabilityInfo());
+        }
+
+        public static bool IsNullable(this EventInfo info)
+        {
+            var nullability = info.GetNullabilityInfo();
+            return IsNullable(info.Name, nullability);
+        }
+
+        public static NullabilityInfo GetNullabilityInfo(this PropertyInfo info)
+        {
+            return propertyCache.GetOrAdd(info, inner =>
+            {
+                var nullabilityContext = new NullabilityInfoContext();
+                return nullabilityContext.Create(inner);
+            });
+        }
+
+        public static NullabilityState GetNullability(this PropertyInfo info)
+        {
+            return GetReadOrWriteState(info.Name, info.GetNullabilityInfo());
+        }
+
+        public static bool IsNullable(this PropertyInfo info)
+        {
+            var nullability = info.GetNullabilityInfo();
+            return IsNullable(info.Name, nullability);
+        }
+
+        public static NullabilityInfo GetNullabilityInfo(this ParameterInfo info)
+        {
+            return parameterCache.GetOrAdd(info, inner =>
+            {
+                var nullabilityContext = new NullabilityInfoContext();
+                return nullabilityContext.Create(inner);
+            });
+        }
+
+        public static NullabilityState GetNullability(this ParameterInfo info)
+        {
+            return GetReadOrWriteState(info.Name!, info.GetNullabilityInfo());
+        }
+
+        public static bool IsNullable(this ParameterInfo info)
+        {
+            var nullability = info.GetNullabilityInfo();
+            return IsNullable(info.Name!, nullability);
+        }
+
+        static NullabilityState GetReadOrWriteState(string name, NullabilityInfo nullability)
+        {
+            if (nullability.ReadState != NullabilityState.Unknown)
+            {
+                return nullability.ReadState;
+            }
+
+            return nullability.WriteState;
+        }
+
+        static NullabilityState GetKnownState(string name, NullabilityInfo nullability)
+        {
+            var readState = nullability.ReadState;
+            if (readState != NullabilityState.Unknown)
+            {
+                return readState;
+            }
+
+            var writeState = nullability.WriteState;
+            if (writeState != NullabilityState.Unknown)
+            {
+                return writeState;
+            }
+
+            throw new($"The nullability of '{nullability.Type.FullName}.{name}' is unknown. Assembly: {nullability.Type.Assembly.FullName}.");
+        }
+
+        static bool IsNullable(string name, NullabilityInfo nullability)
+        {
+            return GetKnownState(name, nullability) == NullabilityState.Nullable;
+        }
+
+        //Patching
+        public static MemberInfo GetMemberWithSameMetadataDefinitionAs(Type type, MemberInfo member)
+        {
+            const BindingFlags all = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.Instance;
+            foreach (var info in type.GetMembers(all))
+            {
+                if (info.HasSameMetadataDefinitionAs(member))
+                {
+                    return info;
+                }
+            }
+
+            throw new MissingMemberException(type.FullName, member.Name);
+        }
+
+        //https://github.com/dotnet/runtime/blob/main/src/coreclr/System.Private.CoreLib/src/System/Reflection/MemberInfo.Internal.cs
+        static bool HasSameMetadataDefinitionAs(this MemberInfo target, MemberInfo other)
+        {
+            return target.MetadataToken == other.MetadataToken &&
+                   target.Module.Equals(other.Module);
+        }
+
+        //https://github.com/dotnet/runtime/issues/23493
+        public static bool IsGenericMethodParameter(this Type target)
+        {
+            return target.IsGenericParameter &&
+                   target.DeclaringMethod != null;
+        }
+    }
+}

--- a/src/EntityGraphQL/Extensions/TypeExtensions.cs
+++ b/src/EntityGraphQL/Extensions/TypeExtensions.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Collections.Generic;
 using System.Reflection;
 using System.Collections.ObjectModel;
+using Nullability;
 
 namespace EntityGraphQL.Extensions
 {
@@ -105,90 +106,6 @@ namespace EntityGraphQL.Extensions
             return t.IsGenericType && t.GetGenericTypeDefinition() == typeof(Nullable<>);
         }
 
-
-        public static bool IsNullable(this MemberInfo memberInfo)
-        {
-            if (memberInfo is PropertyInfo property)
-            {
-                return IsNullableHelper(property.PropertyType, property.DeclaringType, property.CustomAttributes);
-            }
-
-            if (memberInfo is FieldInfo fieldInfo)
-            {
-                return IsNullableHelper(fieldInfo.FieldType, fieldInfo.DeclaringType, fieldInfo.CustomAttributes);
-            }
-
-            if (memberInfo is MethodInfo methodInfo)
-            {
-                return IsNullableHelper(
-                    methodInfo.GetActualReturnType(),
-                    methodInfo,
-                    methodInfo.ReturnParameter.CustomAttributes
-                );
-            }
-
-            return true;
-        }
-
-        public static bool IsNullable(this ParameterInfo parameterInfo)
-        {
-            return IsNullableHelper(parameterInfo.ParameterType, parameterInfo.Member, parameterInfo.CustomAttributes);
-        }
-
-        private static Type GetActualReturnType(this MethodInfo methodInfo)
-        {
-            for (var type = methodInfo.ReturnType; type != null; type = type.GetGenericArguments().Last())
-            {
-                if (!type.IsGenericType)
-                {
-                    return type;
-                }
-            }
-
-            throw new Exception("Could not figure out return type");
-        }
-
-        private static bool IsNullableHelper(Type memberType, MemberInfo? declaringType, IEnumerable<CustomAttributeData> customAttributes)
-        {
-            if (memberType.IsValueType)
-            {
-                return Nullable.GetUnderlyingType(memberType) != null;
-            }
-
-            var nullable = customAttributes
-                .FirstOrDefault(x => x.AttributeType.FullName == "System.Runtime.CompilerServices.NullableAttribute");
-            if (nullable != null && nullable.ConstructorArguments.Count == 1)
-            {
-                var attributeArgument = nullable.ConstructorArguments[0];
-                if (attributeArgument.ArgumentType == typeof(byte[]))
-                {
-                    var args = (ReadOnlyCollection<CustomAttributeTypedArgument>)attributeArgument.Value!;
-                    if (args.Count > 0 && args.Last().ArgumentType == typeof(byte))
-                    {
-                        return (byte)args.Last().Value! == 2;
-                    }
-                }
-                else if (attributeArgument.ArgumentType == typeof(byte))
-                {
-                    return (byte)attributeArgument.Value! == 2;
-                }
-            }
-
-            for (var type = declaringType; type != null; type = type.DeclaringType)
-            {
-                var context = type.CustomAttributes
-                    .FirstOrDefault(x => x.AttributeType.FullName == "System.Runtime.CompilerServices.NullableContextAttribute");
-                if (context != null &&
-                    context.ConstructorArguments.Count == 1 &&
-                    context.ConstructorArguments[0].ArgumentType == typeof(byte))
-                {
-                    return (byte)context.ConstructorArguments[0].Value! == 2;
-                }
-            }
-
-            // Couldn't find a suitable attribute
-            return true;
-        }
         public static bool ImplementsGenericInterface(this Type type, Type genericInterfaceType)
         {
             // Deal with the edge case

--- a/src/EntityGraphQL/Schema/ControllerType.cs
+++ b/src/EntityGraphQL/Schema/ControllerType.cs
@@ -5,6 +5,7 @@ using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using EntityGraphQL.Extensions;
+using Nullability;
 
 namespace EntityGraphQL.Schema;
 
@@ -99,7 +100,9 @@ public abstract class ControllerType
             SchemaBuilder.CacheType(nonListReturnType, SchemaType.Schema, options, false);
         }
         var typeName = SchemaType.Schema.GetSchemaType(nonListReturnType, null).Name;
-        var returnType = new GqlTypeInfo(() => SchemaType.Schema.Type(typeName), actualReturnType, method.IsNullable());
+
+        var nullability = method.GetNullabilityInfo().Unwrap();
+        var returnType = new GqlTypeInfo(() => SchemaType.Schema.Type(typeName), actualReturnType, nullability);
         var field = MakeField(name, method, description, options, isAsync, requiredClaims, returnType);
 
         field.ApplyAttributes(method.GetCustomAttributes());

--- a/src/EntityGraphQL/Schema/GqlTypeInfo.cs
+++ b/src/EntityGraphQL/Schema/GqlTypeInfo.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Reflection;
 using EntityGraphQL.Extensions;
+using Nullability;
 
 namespace EntityGraphQL.Schema
 {
@@ -24,22 +25,22 @@ namespace EntityGraphQL.Schema
             IsList = TypeDotnet.IsEnumerableOrArray();
             TypeNotNullable = TypeDotnet.IsValueType && !TypeDotnet.IsNullableType();
             ElementTypeNullable = false;
-        }
+        }      
 
         /// <summary>
         /// New GqlTypeInfo object that represents information about the return/argument type
         /// </summary>
         /// <param name="schemaTypeGetter">Func to get the ISchemaType. Lookup is func as the type might be added later. It is cached after first look up</param>
         /// <param name="typeDotnet">The dotnet type as it is. E.g. the List<T> etc. </param>
-        /// <param name="typeNullable">True if the type is nullable</param>
-        public GqlTypeInfo(Func<ISchemaType> schemaTypeGetter, Type typeDotnet, bool typeNullable)
+        /// <param name="nullability">Nullability infomation about the property</param>
+        public GqlTypeInfo(Func<ISchemaType> schemaTypeGetter, Type typeDotnet, NullabilityInfoEx nullability)
         {
             SchemaTypeGetter = schemaTypeGetter;
 
             TypeDotnet = typeDotnet;
             IsList = TypeDotnet.IsEnumerableOrArray();
-            TypeNotNullable = !typeNullable;
-            ElementTypeNullable = false;
+            TypeNotNullable = nullability.ReadState == NullabilityStateEx.NotNull;
+            ElementTypeNullable = nullability.GenericTypeArguments.Length > 0 && nullability.GenericTypeArguments[0].ReadState == NullabilityStateEx.Nullable;
         }
 
         /// <summary>

--- a/src/EntityGraphQL/Schema/SchemaBuilder.cs
+++ b/src/EntityGraphQL/Schema/SchemaBuilder.cs
@@ -10,6 +10,7 @@ using EntityGraphQL.Authorization;
 using Microsoft.Extensions.Logging;
 using EntityGraphQL.Extensions;
 using EntityGraphQL.Schema.FieldExtensions;
+using Nullability;
 
 namespace EntityGraphQL.Schema
 {
@@ -201,9 +202,12 @@ namespace EntityGraphQL.Schema
             {
                 CacheType(baseReturnType, schema, options, isInputType);
 
+                var nullabilityInfo = prop.GetNullabilityInfo();
+
                 // see if there is a direct type mapping from the expression return to to something.
                 // otherwise build the type info
-                var returnTypeInfo = schema.GetCustomTypeMapping(le.ReturnType) ?? new GqlTypeInfo(() => schema.GetSchemaType(baseReturnType, null), le.Body.Type, prop.IsNullable());
+                var returnTypeInfo = schema.GetCustomTypeMapping(le.ReturnType) ?? new GqlTypeInfo(() => schema.GetSchemaType(baseReturnType, null), le.Body.Type, nullabilityInfo);
+
                 var field = new Field(schema, fromType, schema.SchemaFieldNamer(prop.Name), le, description, null, returnTypeInfo, requiredClaims);
 
                 if (options.AutoCreateFieldWithIdArguments && (!schema.HasType(prop.DeclaringType!) || schema.GetSchemaType(prop.DeclaringType!, null).GqlType != GqlTypeEnum.Input))

--- a/src/EntityGraphQL/Schema/SchemaType.cs
+++ b/src/EntityGraphQL/Schema/SchemaType.cs
@@ -6,6 +6,7 @@ using System.Reflection;
 using EntityGraphQL.Compiler;
 using EntityGraphQL.Compiler.Util;
 using EntityGraphQL.Extensions;
+using Nullability;
 
 namespace EntityGraphQL.Schema
 {
@@ -62,7 +63,9 @@ namespace EntityGraphQL.Schema
 
                     var enumName = Enum.Parse(TypeDotnet, field.Name).ToString()!;
                     var description = (field.GetCustomAttribute(typeof(DescriptionAttribute)) as DescriptionAttribute)?.Description;
-                    var schemaField = new Field(Schema, this, enumName, null, description, null, new GqlTypeInfo(() => Schema.GetSchemaType(TypeDotnet, null), TypeDotnet, field.IsNullable()), Schema.AuthorizationService.GetRequiredAuthFromMember(field));
+                    var nullability = field.GetNullabilityInfo();
+                    var gqlTypeInfo = new GqlTypeInfo(() => Schema.GetSchemaType(TypeDotnet, null), TypeDotnet, nullability);
+                    var schemaField = new Field(Schema, this, enumName, null, description, null, gqlTypeInfo, Schema.AuthorizationService.GetRequiredAuthFromMember(field));
                     var obsoleteAttribute = field.GetCustomAttribute<ObsoleteAttribute>();
                     schemaField.ApplyAttributes(field.GetCustomAttributes());
 

--- a/src/tests/EntityGraphQL.Tests/SchemaTests/GraphQLSchemaGenerateTests.cs
+++ b/src/tests/EntityGraphQL.Tests/SchemaTests/GraphQLSchemaGenerateTests.cs
@@ -261,8 +261,10 @@ namespace EntityGraphQL.Tests
             var schema = schemaProvider.ToGraphQLSchemaString();
             // this exists as it is not null
             Assert.Contains("addAlbum(name: String!, genre: Genre!): Album", schema);
+            Assert.DoesNotContain("addAlbum(name: String!, genre: Genre!): Album!", schema);
             Assert.Contains("addAlbum2(name: String!, genre: Genre!): Album!", schema);
             Assert.Contains("addAlbum3(name: String!, genre: Genre!): Album", schema);
+            Assert.DoesNotContain("addAlbum3(name: String!, genre: Genre!): Album!", schema);
 
             var gql = new QueryRequest
             {

--- a/src/tests/EntityGraphQL.Tests/Util/NullableReferenceTypeTests.cs
+++ b/src/tests/EntityGraphQL.Tests/Util/NullableReferenceTypeTests.cs
@@ -22,21 +22,6 @@ namespace EntityGraphQL.Tests.Util
         [Fact]
         public void TestNullableWithoutNullableRefEnabled()
         {
-            var propertyInfo = typeof(WithoutNullableRefEnabled).GetProperty("NonNullableInt");
-            Assert.False(propertyInfo.IsNullable());
-
-            propertyInfo = typeof(WithoutNullableRefEnabled).GetProperty("NullableInt");
-            Assert.True(propertyInfo.IsNullable());
-
-            propertyInfo = typeof(WithoutNullableRefEnabled).GetProperty("Nullable");
-            Assert.True(propertyInfo.IsNullable());
-
-            propertyInfo = typeof(WithoutNullableRefEnabled).GetProperty("Tests");
-            Assert.True(propertyInfo.IsNullable());
-
-            var methodInfo = typeof(WithoutNullableRefEnabled).GetMethod("NullableMethod");
-            Assert.True(methodInfo.IsNullable());
-
             var schema = SchemaBuilder.FromObject<WithoutNullableRefEnabled>();
             var schemaString = schema.ToGraphQLSchemaString();
 
@@ -55,6 +40,8 @@ namespace EntityGraphQL.Tests.Util
             public string? Nullable { get; set; }
             public IEnumerable<Test> Tests { get; set; } = new List<Test>();
             public IEnumerable<Test>? Tests2 { get; set; }
+            public IEnumerable<Test?> Tests3 { get; set; } = new List<Test>();
+            public IEnumerable<Test?>? Tests4 { get; set; }
             public IEnumerable<Test> NonNullableMethod() { return null!; }
             public IEnumerable<Test?> NullableMethod() { return null!; }
         }
@@ -63,24 +50,6 @@ namespace EntityGraphQL.Tests.Util
         [Fact]
         public void TestNullableWithNullableRefEnabled()
         {
-            var propertyInfo = typeof(WithoutNullableRefEnabled).GetProperty("NonNullableInt");
-            Assert.False(propertyInfo.IsNullable());
-
-            propertyInfo = typeof(WithoutNullableRefEnabled).GetProperty("NullableInt");
-            Assert.True(propertyInfo.IsNullable());
-
-            propertyInfo = typeof(WithNullableRefEnabled).GetProperty("Nullable");
-            Assert.True(propertyInfo.IsNullable());
-
-            propertyInfo = typeof(WithNullableRefEnabled).GetProperty("NonNullable");
-            Assert.False(propertyInfo.IsNullable());
-
-            var methodInfo = typeof(WithNullableRefEnabled).GetMethod("NullableMethod");
-            Assert.True(methodInfo.IsNullable());
-
-            methodInfo = typeof(WithNullableRefEnabled).GetMethod("NonNullableMethod");
-            Assert.False(methodInfo.IsNullable());
-
             var schema = SchemaBuilder.FromObject<WithNullableRefEnabled>();
             var schemaString = schema.ToGraphQLSchemaString();
 
@@ -88,9 +57,17 @@ namespace EntityGraphQL.Tests.Util
             Assert.Contains(@"nullableInt: Int", schemaString);
             Assert.Contains(@"nullable: String", schemaString);
             Assert.Contains(@"nonNullable: String!", schemaString);
-            Assert.Contains(@"tests: [Test!]!", schemaString);
-            Assert.Contains(@"tests2: [Test!]", schemaString);
 
+            //public IEnumerable<Test> Tests { get; set; } = new List<Test>();
+            Assert.Contains("tests: [Test!]!", schemaString);
+            //public IEnumerable<Test>? Tests2 { get; set; }
+            Assert.Contains("tests2: [Test!]", schemaString);
+            Assert.DoesNotContain("tests2: [Test!]!", schemaString);
+            //public IEnumerable<Test?> Tests3 { get; set; } = new List<Test>();
+            Assert.Contains("tests3: [Test]!", schemaString);
+            //public IEnumerable<Test?>? Tests4 { get; set; }
+            Assert.Contains("tests4: [Test]", schemaString);
+            Assert.DoesNotContain("tests4: [Test]!", schemaString);
 
             var gql = new QueryRequest
             {
@@ -122,13 +99,17 @@ namespace EntityGraphQL.Tests.Util
 
             var type = (dynamic)res.Data["__type"];
 
-            Assert.Equal(@"{""name"":""nullable"",""type"":{""name"":""String"",""kind"":""SCALAR"",""ofType"":null},""args"":[]}", JsonConvert.SerializeObject(type.fields[0]));
-            Assert.Equal(@"{""name"":""nonNullable"",""type"":{""name"":null,""kind"":""NON_NULL"",""ofType"":{""name"":""String"",""kind"":""SCALAR""}},""args"":[]}", JsonConvert.SerializeObject(type.fields[1]));
-            Assert.Equal(@"{""name"":""nonNullableInt"",""type"":{""name"":null,""kind"":""NON_NULL"",""ofType"":{""name"":""Int"",""kind"":""SCALAR""}},""args"":[]}", JsonConvert.SerializeObject(type.fields[2]));
-            Assert.Equal(@"{""name"":""nullableInt"",""type"":{""name"":""Int"",""kind"":""SCALAR"",""ofType"":null},""args"":[]}", JsonConvert.SerializeObject(type.fields[3]));
-            Assert.Equal(@"{""name"":""tests"",""type"":{""name"":null,""kind"":""NON_NULL"",""ofType"":{""name"":null,""kind"":""LIST""}},""args"":[]}", JsonConvert.SerializeObject(type.fields[4]));
-            Assert.Equal(@"{""name"":""tests2"",""type"":{""name"":null,""kind"":""NON_NULL"",""ofType"":{""name"":null,""kind"":""LIST""}},""args"":[]}", JsonConvert.SerializeObject(type.fields[5]));
-        }
+            Assert.Equal(@"{""name"":""nonNullableInt"",""type"":{""name"":null,""kind"":""NON_NULL"",""ofType"":{""name"":""Int"",""kind"":""SCALAR""}},""args"":[]}", JsonConvert.SerializeObject(type.fields[0]));
+            Assert.Equal(@"{""name"":""nullableInt"",""type"":{""name"":""Int"",""kind"":""SCALAR"",""ofType"":null},""args"":[]}", JsonConvert.SerializeObject(type.fields[1]));
+            Assert.Equal(@"{""name"":""nullable"",""type"":{""name"":""String"",""kind"":""SCALAR"",""ofType"":null},""args"":[]}", JsonConvert.SerializeObject(type.fields[3]));
+            Assert.Equal(@"{""name"":""nonNullable"",""type"":{""name"":null,""kind"":""NON_NULL"",""ofType"":{""name"":""String"",""kind"":""SCALAR""}},""args"":[]}", JsonConvert.SerializeObject(type.fields[2]));
+            
+            
 
+            Assert.Equal(@"{""name"":""tests"",""type"":{""name"":null,""kind"":""NON_NULL"",""ofType"":{""name"":null,""kind"":""LIST""}},""args"":[]}", JsonConvert.SerializeObject(type.fields[4]));
+            Assert.Equal(@"{""name"":""tests2"",""type"":{""name"":null,""kind"":""LIST"",""ofType"":{""name"":""Test"",""kind"":""OBJECT""}},""args"":[]}", JsonConvert.SerializeObject(type.fields[5]));
+            Assert.Equal(@"{""name"":""tests3"",""type"":{""name"":null,""kind"":""NON_NULL"",""ofType"":{""name"":null,""kind"":""LIST""}},""args"":[]}", JsonConvert.SerializeObject(type.fields[6]));
+            Assert.Equal(@"{""name"":""tests4"",""type"":{""name"":null,""kind"":""LIST"",""ofType"":{""name"":""Test"",""kind"":""OBJECT""}},""args"":[]}", JsonConvert.SerializeObject(type.fields[7]));
+        }
     }
 }


### PR DESCRIPTION
main change is to make the following correct, although the changes got a bit wider than i'd like and I'm sure there's still issues with the IsNullable method assuming it should look at the first or last byte (unsure if you've ever read on how this byte array works)

```
    //public IEnumerable<Test> Tests { get; set; } = new List<Test>();
            Assert.Contains("tests: [Test!]!", schemaString);
            //public IEnumerable<Test>? Tests2 { get; set; }
            Assert.Contains("tests2: [Test!]\r\n", schemaString);
            //public IEnumerable<Test?> Tests3 { get; set; } = new List<Test>();
            Assert.Contains("tests3: [Test]!", schemaString);
            //public IEnumerable<Test?>? Tests4 { get; set; }
            Assert.Contains("tests4: [Test]\r\n", schemaString);
```