### PR TITLE
Do not leak exception messages in 'errors'

### DIFF
--- a/src/EntityGraphQL/Compiler/EntityGraphQLCompilerException.cs
+++ b/src/EntityGraphQL/Compiler/EntityGraphQLCompilerException.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Reflection;
 
 namespace EntityGraphQL.Compiler;
 
@@ -15,12 +14,8 @@ public class EntityGraphQLExecutionException : Exception
     public EntityGraphQLExecutionException(string message) : base(message)
     {
     }
-    public EntityGraphQLExecutionException(string field, Exception innerException)
-        : base($"Field '{field}' - {innerException.Message}", innerException)
-    {
-    }
 }
-public class EntityGraphQLAccessException : Exception
+public class EntityGraphQLAccessException : Exception, IExposableException
 {
     public EntityGraphQLAccessException(string message) : base(message)
     {

--- a/src/EntityGraphQL/Compiler/EntityGraphQLValidationException.cs
+++ b/src/EntityGraphQL/Compiler/EntityGraphQLValidationException.cs
@@ -4,7 +4,7 @@ using System.Linq;
 
 namespace EntityGraphQL.Compiler;
 
-public class EntityGraphQLValidationException : Exception
+public class EntityGraphQLValidationException : Exception, IExposableException
 {
     public List<string> ValidationErrors { get; }
 

--- a/src/EntityGraphQL/Compiler/GqlNodes/ExecutableGraphQLStatement.cs
+++ b/src/EntityGraphQL/Compiler/GqlNodes/ExecutableGraphQLStatement.cs
@@ -91,28 +91,17 @@ namespace EntityGraphQL.Compiler
                     if (didExecute)
                         result[fieldNode.Name] = data;
                 }
-                catch (EntityGraphQLException ex)
-                {
-                    throw new EntityGraphQLException(fieldNode.Name, ex);
-                }
-                catch (AggregateException aex)
-                {
-                    var errors = aex.InnerExceptions.SelectMany<Exception, string>(ex => ex is EntityGraphQLValidationException vex ? vex.ValidationErrors : new[] { $"Field '{fieldNode.Name}' - {ex.Message}" });
-                    throw new EntityGraphQLValidationException(errors);
-                }
-                catch (TargetInvocationException ex)
-                {
-                    if (ex.InnerException is EntityGraphQLException vex)
-                        throw new EntityGraphQLException(fieldNode.Name, vex);
-                    throw new EntityGraphQLExecutionException(fieldNode.Name, ex.InnerException!);
-                }
                 catch (EntityGraphQLValidationException)
+                {
+                    throw;
+                }
+                catch (EntityGraphQLFieldException)
                 {
                     throw;
                 }
                 catch (Exception ex)
                 {
-                    throw new EntityGraphQLExecutionException(fieldNode.Name, ex);
+                    throw new EntityGraphQLFieldException(fieldNode.Name, ex);
                 }
             }
             return Task.FromResult(result);

--- a/src/EntityGraphQL/Compiler/GqlNodes/GraphQLMutationStatement.cs
+++ b/src/EntityGraphQL/Compiler/GqlNodes/GraphQLMutationStatement.cs
@@ -53,17 +53,17 @@ namespace EntityGraphQL.Compiler
                         result[node.Name] = data;
                     }
                 }
-                catch (EntityGraphQLException ex)
-                {
-                    throw new EntityGraphQLException(field.Name, ex);
-                }
                 catch (EntityGraphQLValidationException)
+                {
+                    throw;
+                }
+                catch (EntityGraphQLFieldException)
                 {
                     throw;
                 }
                 catch (Exception ex)
                 {
-                    throw new EntityGraphQLExecutionException(field.Name, ex);
+                    throw new EntityGraphQLFieldException(field.Name, ex);
                 }
             }
             return result;

--- a/src/EntityGraphQL/Compiler/GqlNodes/GraphQLSubscriptionStatement.cs
+++ b/src/EntityGraphQL/Compiler/GqlNodes/GraphQLSubscriptionStatement.cs
@@ -61,17 +61,17 @@ namespace EntityGraphQL.Compiler
                         result[node.Name] = data;
                     }
                 }
-                catch (EntityGraphQLException ex)
-                {
-                    throw new EntityGraphQLException(field.Name, ex);
-                }
                 catch (EntityGraphQLValidationException)
+                {
+                    throw;
+                }
+                catch (EntityGraphQLFieldException)
                 {
                     throw;
                 }
                 catch (Exception ex)
                 {
-                    throw new EntityGraphQLExecutionException(field.Name, ex);
+                    throw new EntityGraphQLFieldException(field.Name, ex);
                 }
             }
             return result;

--- a/src/EntityGraphQL/EntityGraphQLArgumentException.cs
+++ b/src/EntityGraphQL/EntityGraphQLArgumentException.cs
@@ -1,0 +1,10 @@
+﻿using System;
+
+namespace EntityGraphQL
+{
+    public class EntityGraphQLArgumentException : Exception, IExposableException
+    {
+        public EntityGraphQLArgumentException(string message) : base(message) { }
+        public EntityGraphQLArgumentException(string parameterName, string message) : base($"{message} (Parameter '{parameterName}')") { }
+    }
+}

--- a/src/EntityGraphQL/EntityGraphQLException.cs
+++ b/src/EntityGraphQL/EntityGraphQLException.cs
@@ -4,16 +4,12 @@ using System.Collections.ObjectModel;
 
 namespace EntityGraphQL;
 
-public class EntityGraphQLException : Exception
+public class EntityGraphQLException : Exception, IExposableException
 {
     public ReadOnlyDictionary<string, object> Extensions { get; }
 
     public EntityGraphQLException(string message, IDictionary<string, object> extensions) : base(message)
     {
         Extensions = new ReadOnlyDictionary<string, object>(extensions);
-    }
-    public EntityGraphQLException(string fieldName, EntityGraphQLException ex) : base($"Field '{fieldName}' - {ex.Message}")
-    {
-        Extensions = ex.Extensions;
     }
 }

--- a/src/EntityGraphQL/EntityGraphQLFieldException.cs
+++ b/src/EntityGraphQL/EntityGraphQLFieldException.cs
@@ -1,0 +1,14 @@
+﻿using System;
+
+namespace EntityGraphQL
+{
+    internal sealed class EntityGraphQLFieldException : Exception, IExposableException
+    {
+        public readonly string FieldName;
+
+        public EntityGraphQLFieldException(string fieldName, Exception innerException) : base(null, innerException)
+        {
+            FieldName = fieldName;
+        }
+    }
+}

--- a/src/EntityGraphQL/IExposableException.cs
+++ b/src/EntityGraphQL/IExposableException.cs
@@ -1,0 +1,9 @@
+﻿namespace EntityGraphQL
+{
+    /// <summary>
+    /// Exceptions implementing this interface will have their message displayed in the 'errors' field even while running outside of Development
+    /// </summary>
+    public interface IExposableException
+    {
+    }
+}

--- a/src/EntityGraphQL/Schema/FieldExtensions/ConnectionPaging/ConnectionEdgeExtension.cs
+++ b/src/EntityGraphQL/Schema/FieldExtensions/ConnectionPaging/ConnectionEdgeExtension.cs
@@ -47,11 +47,11 @@ internal class ConnectionEdgeExtension : BaseFieldExtension
 
         // check and set up arguments
         if (arguments.Before != null && arguments.After != null)
-            throw new ArgumentException($"Field only supports either before or after being supplied, not both.");
+            throw new EntityGraphQLArgumentException($"Field only supports either before or after being supplied, not both.");
         if (arguments.First != null && arguments.First < 0)
-            throw new ArgumentException($"first argument can not be less than 0.");
+            throw new EntityGraphQLArgumentException($"first argument can not be less than 0.");
         if (arguments.Last != null && arguments.Last < 0)
-            throw new ArgumentException($"last argument can not be less than 0.");
+            throw new EntityGraphQLArgumentException($"last argument can not be less than 0.");
 
         // deserialize cursors here once (not many times in the fields)
         arguments.AfterNum = ConnectionHelper.DeserializeCursor(arguments.After);
@@ -60,9 +60,9 @@ internal class ConnectionEdgeExtension : BaseFieldExtension
         if (maxPageSize.HasValue)
         {
             if (arguments.First != null && arguments.First > maxPageSize.Value)
-                throw new ArgumentException($"first argument can not be greater than {maxPageSize.Value}.");
+                throw new EntityGraphQLArgumentException($"first argument can not be greater than {maxPageSize.Value}.");
             if (arguments.Last != null && arguments.Last > maxPageSize.Value)
-                throw new ArgumentException($"last argument can not be greater than {maxPageSize.Value}.");
+                throw new EntityGraphQLArgumentException($"last argument can not be greater than {maxPageSize.Value}.");
         }
 
         if (arguments.First == null && arguments.Last == null && defaultPageSize != null)

--- a/src/EntityGraphQL/Schema/FieldExtensions/OffsetPaging/OffsetPagingExtension.cs
+++ b/src/EntityGraphQL/Schema/FieldExtensions/OffsetPaging/OffsetPagingExtension.cs
@@ -100,7 +100,7 @@ public class OffsetPagingExtension : BaseFieldExtension
             return expression; // we don't need to do anything. items field is there to handle it now
 
         if (maxPageSize != null && arguments?.Take > maxPageSize.Value)
-            throw new ArgumentException($"Argument take can not be greater than {maxPageSize}.");
+            throw new EntityGraphQLArgumentException($"Argument take can not be greater than {maxPageSize}.");
 
         // other extensions expect to run on the collection not our new shape
         var newItemsExp = itemsField!.ResolveExpression!;

--- a/src/EntityGraphQL/Schema/SchemaBuilder.cs
+++ b/src/EntityGraphQL/Schema/SchemaBuilder.cs
@@ -31,7 +31,7 @@ namespace EntityGraphQL.Schema
         {
             if (options == null)
                 options = new SchemaBuilderSchemaOptions();
-            return new SchemaProvider<TContext>(options.AuthorizationService, options.FieldNamer, logger, options.IntrospectionEnabled);
+            return new SchemaProvider<TContext>(options.AuthorizationService, options.FieldNamer, logger, options.IntrospectionEnabled, options.IsDevelopment);
         }
 
         /// <summary>
@@ -47,7 +47,7 @@ namespace EntityGraphQL.Schema
                 buildOptions = new SchemaBuilderOptions();
             var schemaOptions = new SchemaBuilderSchemaOptions();
 
-            var schema = new SchemaProvider<TContextType>(schemaOptions.AuthorizationService, schemaOptions.FieldNamer, logger, schemaOptions.IntrospectionEnabled);
+            var schema = new SchemaProvider<TContextType>(schemaOptions.AuthorizationService, schemaOptions.FieldNamer, logger, schemaOptions.IntrospectionEnabled, schemaOptions.IsDevelopment);
             return FromObject(schema, buildOptions);
         }
 
@@ -66,7 +66,7 @@ namespace EntityGraphQL.Schema
             if (schemaOptions == null)
                 schemaOptions = new SchemaBuilderSchemaOptions();
 
-            var schema = new SchemaProvider<TContextType>(schemaOptions.AuthorizationService, schemaOptions.FieldNamer, logger, schemaOptions.IntrospectionEnabled);
+            var schema = new SchemaProvider<TContextType>(schemaOptions.AuthorizationService, schemaOptions.FieldNamer, logger, schemaOptions.IntrospectionEnabled, schemaOptions.IsDevelopment);
             schemaOptions.PreBuildSchemaFromContext?.Invoke(schema);
             return FromObject(schema, buildOptions);
         }

--- a/src/EntityGraphQL/Schema/SchemaBuilderOptions.cs
+++ b/src/EntityGraphQL/Schema/SchemaBuilderOptions.cs
@@ -93,5 +93,11 @@ namespace EntityGraphQL.Schema
         /// anything that may be needed for the schema to be built correctly.
         /// </summary>
         public Action<ISchemaProvider>? PreBuildSchemaFromContext { get; set; } = null;
+
+        /// <summary>
+        /// If true (default), exceptions not implementing IExposableException will have their messages rendered in the 'errors' object
+        /// If false, exceptions not implementing IExposableException will have their message replaced with 'Error occurred'
+        /// </summary>
+        public bool IsDevelopment { get; set; } = true;
     }
 }

--- a/src/EntityGraphQL/Schema/SchemaProvider.cs
+++ b/src/EntityGraphQL/Schema/SchemaProvider.cs
@@ -9,6 +9,7 @@ using EntityGraphQL.Compiler;
 using EntityGraphQL.Compiler.Util;
 using EntityGraphQL.Directives;
 using EntityGraphQL.Schema.Directives;
+using HotChocolate.Language;
 using Microsoft.Extensions.Logging;
 
 namespace EntityGraphQL.Schema
@@ -37,6 +38,7 @@ namespace EntityGraphQL.Schema
         private readonly ILogger<SchemaProvider<TContextType>>? logger;
         private readonly GraphQLCompiler graphQLCompiler;
         private readonly bool introspectionEnabled;
+        private readonly bool isDevelopment;
         private readonly MutationType mutationType;
         private readonly SubscriptionType subscriptionType;
         private readonly IDictionary<Type, IExtensionAttributeHandler> attributeHandlers = new Dictionary<Type, IExtensionAttributeHandler>();
@@ -50,13 +52,14 @@ namespace EntityGraphQL.Schema
         /// Create a new GraphQL Schema provider that defines all the types and fields etc.
         /// </summary>
         /// <param name="fieldNamer">A naming function for fields that will be used when using methods that automatically create field names e.g. SchemaType.AddAllFields()</param>
-        public SchemaProvider(IGqlAuthorizationService? authorizationService = null, Func<string, string>? fieldNamer = null, ILogger<SchemaProvider<TContextType>>? logger = null, bool introspectionEnabled = true)
+        public SchemaProvider(IGqlAuthorizationService? authorizationService = null, Func<string, string>? fieldNamer = null, ILogger<SchemaProvider<TContextType>>? logger = null, bool introspectionEnabled = true, bool isDevelopment = true)
         {
             AuthorizationService = authorizationService ?? new RoleBasedAuthorization();
             SchemaFieldNamer = fieldNamer ?? SchemaBuilderSchemaOptions.DefaultFieldNamer;
             this.logger = logger;
             this.graphQLCompiler = new GraphQLCompiler(this);
             this.introspectionEnabled = introspectionEnabled;
+            this.isDevelopment = isDevelopment;
             queryCache = new QueryCache();
 
             // default GQL scalar types
@@ -233,40 +236,43 @@ namespace EntityGraphQL.Schema
 
                 result = compiledQuery.ExecuteQuery(context, serviceProvider, gql.Variables, gql.OperationName, options);
             }
-            catch (EntityGraphQLValidationException ex)
-            {
-                logger?.LogError(ex, "Error executing QueryRequest");
-                result = new QueryResult();
-                ex.ValidationErrors.ForEach(e => result.AddError(e));
-            }
-            catch (AggregateException aex)
-            {
-                logger?.LogError(aex, "Error executing QueryRequest");
-                result = new QueryResult();
-
-                foreach (var ex in aex.InnerExceptions)
-                {
-                    if (ex is EntityGraphQLValidationException exception)
-                        exception.ValidationErrors.ForEach(e => result.AddError(e));
-                    else if (ex is EntityGraphQLException gqlException)
-                        result.AddError(ex.Message, gqlException.Extensions);
-                    else
-                        result.AddError(ex.Message);
-                }
-            }
-            catch (EntityGraphQLException ex)
-            {
-                result = new QueryResult();
-                result.AddError(ex.Message, ex.Extensions);
-            }
             catch (Exception ex)
             {
-                logger?.LogError(ex, "Error executing QueryRequest");
-                // error with the whole query
-                result = new QueryResult(new GraphQLError(ex.Message, null));
+                result = HandleException(ex);
             }
 
             return Task.FromResult(result);
+        }
+
+        private QueryResult HandleException(Exception exception)
+        {
+            logger?.LogError(exception, "Error executing QueryRequest");
+            
+            var result = new QueryResult();
+            foreach (var (errorMessage, extensions) in GenerateMessage(exception))
+                result.AddError(errorMessage, extensions);
+            return result;
+        }
+        
+        private IEnumerable<(string errorMessage, IDictionary<string, object>? extensions)> GenerateMessage(Exception exception)
+        {
+            switch (exception)
+            {
+                case EntityGraphQLValidationException validationException:
+                    return validationException.ValidationErrors.Select(v => (v, (IDictionary<string, object>?)null));
+                case AggregateException aggregateException:
+                    return aggregateException.InnerExceptions.SelectMany(GenerateMessage);
+                case EntityGraphQLException graphqlException:
+                    return new[] { (graphqlException.Message, (IDictionary<string, object>?)graphqlException.Extensions) };
+                case TargetInvocationException targetInvocationException:
+                    return GenerateMessage(targetInvocationException.InnerException!);
+                case EntityGraphQLFieldException fieldException:
+                    return GenerateMessage(fieldException.InnerException!).Select(f => ($"Field '{fieldException.FieldName}' - {f.errorMessage}", f.Item2));
+                default:
+                    if (isDevelopment || exception is IExposableException)
+                        return new[] { (exception.Message, (IDictionary<string, object>?)null) };
+                    return new[] { ("Error occurred", (IDictionary<string, object>?)null) };
+            }
         }
 
         private GraphQLDocument CompileQueryWithCache(QueryRequest gql, ClaimsPrincipal? user)

--- a/src/tests/EntityGraphQL.Tests/MutationTests/MutationTests.cs
+++ b/src/tests/EntityGraphQL.Tests/MutationTests/MutationTests.cs
@@ -979,7 +979,7 @@ namespace EntityGraphQL.Tests
             var schemaProvider = SchemaBuilder.FromObject<TestDataContext>();
             schemaProvider.Mutation().AddFrom<IMutations>(new SchemaBuilderMethodOptions { AutoCreateInputTypes = true });
 
-            Assert.Equal(30, schemaProvider.Mutation().SchemaType.GetFields().Count());
+            Assert.Equal(31, schemaProvider.Mutation().SchemaType.GetFields().Count());
         }
 
         public class NonAttributeMarkedMethod

--- a/src/tests/EntityGraphQL.Tests/MutationTests/PeopleMutations.cs
+++ b/src/tests/EntityGraphQL.Tests/MutationTests/PeopleMutations.cs
@@ -160,7 +160,13 @@ namespace EntityGraphQL.Tests
         [GraphQLMutation]
         public int AddPersonError(PeopleMutationsArgs args)
         {
-            throw new ArgumentNullException("name", "Name can not be null");
+            throw new EntityGraphQLArgumentException("name", "Name can not be null");
+        }
+
+        [GraphQLMutation]
+        public int AddPersonErrorUnexposedException(PeopleMutationsArgs args)
+        {
+            throw new Exception("You should not see this message outside of Development");
         }
 
         [GraphQLMutation]

--- a/src/tests/EntityGraphQL.Tests/SortTests/SortTests.cs
+++ b/src/tests/EntityGraphQL.Tests/SortTests/SortTests.cs
@@ -168,7 +168,7 @@ namespace EntityGraphQL.Tests
             Assert.Equal("Zoo", person.lastName);
             var schemaType = schema.Type("PeopleSortInput");
             var fields = schemaType.GetFields().ToList();
-            Assert.Equal(9, fields.Count);
+            Assert.Equal(10, fields.Count);
         }
         [Fact]
         public void SupportUseSortOnNonRoot()

--- a/src/tests/EntityGraphQL.Tests/TestDataContext.cs
+++ b/src/tests/EntityGraphQL.Tests/TestDataContext.cs
@@ -83,6 +83,11 @@ namespace EntityGraphQL.Tests
             get => throw new EntityGraphQLException("Field failed to execute", new Dictionary<string, object> { { "code", 1 } }); set => throw new Exception("Field failed to execute");
         }
 
+        public string Error_UnexposedException
+        {
+            get => throw new Exception("You should not see this message outside of Development"); set => throw new Exception("You should not see this message outside of Development");
+        }
+
         public double GetHeight(HeightUnit unit)
         {
             return unit switch


### PR DESCRIPTION
This change stops leaking exceptions into the 'errors' field on a result. This has been raised here: https://github.com/EntityGraphQL/EntityGraphQL/issues/205  

When running in development (read via `IWebHostEnvironment.IsEnvironment("Development")` or when manually creating `SchemaProvider`), messages of exceptions will not be dumped out into the 'errors' field of a query result, unless they implement the newly created (and empty) interface `IExposableException`.

Part of this change was to modify where we're catching and unwrapping exceptions (for example, see [src/EntityGraphQL/Compiler/GqlNodes/ExecutableGraphQLStatement.cs](https://github.com/EntityGraphQL/EntityGraphQL/compare/master...rjrudman:EntityGraphQL:feature/205?expand=1#diff-2649053fc8256fcc5e8681e63a4eeb6c04ce96d96b04b83cafcee6cb7e18b34fL94)) as we were previously immediately rendering the exception message, including that of inner exceptions which should be hidden.

The bulk of the change is [here](https://github.com/EntityGraphQL/EntityGraphQL/compare/master...rjrudman:EntityGraphQL:feature/205?expand=1#diff-35b1d9d391614be9a7d3221dc28bc7c6db245b5a4483da2544b880c2a840a88bL236) which handles the unwrapping and possible obfuscation of thrown errors.