### PR TITLE
Fix for interface/union types when selecting only single subtype

### DIFF
--- a/src/EntityGraphQL/Compiler/GqlNodes/GraphQLListSelectionField.cs
+++ b/src/EntityGraphQL/Compiler/GqlNodes/GraphQLListSelectionField.cs
@@ -94,7 +94,7 @@ namespace EntityGraphQL.Compiler
                 }
             }
             // build a .Select(...) - returning a IEnumerable<>
-            var resultExpression = ExpressionUtil.MakeSelectWithDynamicType(Name, nextFieldContext!, listContext, selectionFields);
+            var resultExpression = ExpressionUtil.MakeSelectWithDynamicType(this, nextFieldContext!, listContext, selectionFields);
 
             // if selecting final graph make sure lists are evaluated
             if (!isRoot && !withoutServiceFields && resultExpression.Type.IsEnumerableOrArray() && !resultExpression.Type.IsDictionary())
@@ -125,7 +125,7 @@ namespace EntityGraphQL.Compiler
             // this is the parameter used in the null wrap. We pass it to the wrap function which has the value to match
             var nullWrapParam = Expression.Parameter(updatedListContext.Type, "nullwrap");
 
-            var callOnList = ExpressionUtil.MakeSelectWithDynamicType(Name, selectParam, nullWrapParam, selectExpressions);
+            var callOnList = ExpressionUtil.MakeSelectWithDynamicType(this, selectParam, nullWrapParam, selectExpressions);
 
             updatedListContext = ExpressionUtil.WrapListFieldForNullCheck(updatedListContext, callOnList, fieldParams, fieldParamValues, nullWrapParam, schemaContext);
             return updatedListContext;

--- a/src/tests/EntityGraphQL.Tests/QueryTests/UnionTests.cs
+++ b/src/tests/EntityGraphQL.Tests/QueryTests/UnionTests.cs
@@ -1,6 +1,8 @@
 ﻿using Xunit;
 using EntityGraphQL.Compiler;
 using EntityGraphQL.Schema;
+using Microsoft.CSharp.RuntimeBinder;
+using System.Collections.Generic;
 
 namespace EntityGraphQL.Tests
 {
@@ -50,6 +52,160 @@ query {
             Assert.Equal("Cat", animals[1].__typename);
             Assert.Equal("george", animals[1].name);
             Assert.Equal(9, animals[1].lives);
+        }
+
+        [Fact]
+        public void TestAutoUnion_NoTypeName()
+        {
+            var schema = SchemaBuilder.FromObject<TestUnionDataContext>(new SchemaBuilderOptions { AutoCreateInterfaceTypes = true });
+            Assert.True(schema.HasType(typeof(IAnimal)));
+            Assert.True(schema.GetSchemaType(typeof(IAnimal), null).GqlType == GqlTypeEnum.Union);
+
+            schema.Type<IAnimal>().AddPossibleType<Dog>();
+            schema.Type<IAnimal>().AddPossibleType<Cat>();
+            Assert.True(schema.GetSchemaType(typeof(Cat), null).GqlType == GqlTypeEnum.Object);
+            Assert.True(schema.GetSchemaType(typeof(Dog), null).GqlType == GqlTypeEnum.Object);
+
+
+
+            var gql = new GraphQLCompiler(schema).Compile(@"
+query {
+    animals {
+        ... on Dog {
+            name
+            hasBone
+        }
+        ... on Cat {
+            name
+            lives
+        }
+    }
+}");
+            var context = new TestUnionDataContext();
+            context.Animals.Add(new Dog() { Name = "steve", HasBone = true });
+            context.Animals.Add(new Cat() { Name = "george", Lives = 9 });
+
+            var qr = gql.ExecuteQuery(context, null, null);
+            dynamic animals = qr.Data["animals"];
+            // we only have the fields requested
+            Assert.Equal(2, animals.Count);
+
+            Assert.Throws<RuntimeBinderException>(() => animals[0].__typename);
+            Assert.Equal("steve", animals[0].name);
+            Assert.True(animals[0].hasBone);
+            Assert.Throws<RuntimeBinderException>(() => animals[1].__typename);
+            Assert.Equal("george", animals[1].name);
+            Assert.Equal(9, animals[1].lives);
+        }
+
+
+        [Fact]
+        public void TestAutoUnion_DogOnly()
+        {
+            var schema = SchemaBuilder.FromObject<TestUnionDataContext>(new SchemaBuilderOptions { AutoCreateInterfaceTypes = true });
+            Assert.True(schema.HasType(typeof(IAnimal)));
+            Assert.True(schema.GetSchemaType(typeof(IAnimal), null).GqlType == GqlTypeEnum.Union);
+
+            schema.Type<IAnimal>().AddPossibleType<Dog>();
+            schema.Type<IAnimal>().AddPossibleType<Cat>();
+            Assert.True(schema.GetSchemaType(typeof(Cat), null).GqlType == GqlTypeEnum.Object);
+            Assert.True(schema.GetSchemaType(typeof(Dog), null).GqlType == GqlTypeEnum.Object);
+
+
+
+            var gql = new GraphQLCompiler(schema).Compile(@"
+query {
+    animals {
+        ... on Dog {
+            name
+            hasBone
+        }
+    }
+}");
+            var context = new TestUnionDataContext();
+            context.Animals.Add(new Dog() { Name = "steve", HasBone = true });
+            context.Animals.Add(new Cat() { Name = "george", Lives = 9 });
+
+            var qr = gql.ExecuteQuery(context, null, null);
+            dynamic animals = qr.Data["animals"];
+            // we only have the fields requested
+            Assert.Equal(2, animals.Count);
+
+            Assert.Equal("Dog", animals[0].__typename);
+            Assert.Equal("steve", animals[0].name);
+            Assert.True(animals[0].hasBone);
+        }
+
+        [Fact]
+        public void TestAutoUnion_CatOnly()
+        {
+            var schema = SchemaBuilder.FromObject<TestUnionDataContext>(new SchemaBuilderOptions { AutoCreateInterfaceTypes = true });
+            Assert.True(schema.HasType(typeof(IAnimal)));
+            Assert.True(schema.GetSchemaType(typeof(IAnimal), null).GqlType == GqlTypeEnum.Union);
+
+            schema.Type<IAnimal>().AddPossibleType<Dog>();
+            schema.Type<IAnimal>().AddPossibleType<Cat>();
+            Assert.True(schema.GetSchemaType(typeof(Cat), null).GqlType == GqlTypeEnum.Object);
+            Assert.True(schema.GetSchemaType(typeof(Dog), null).GqlType == GqlTypeEnum.Object);
+
+            var gql = new GraphQLCompiler(schema).Compile(@"
+query {
+    animals {
+        ... on Cat {
+            name
+            lives
+        }
+    }
+}");
+            var context = new TestUnionDataContext();
+            context.Animals.Add(new Dog() { Name = "steve", HasBone = true });
+            context.Animals.Add(new Cat() { Name = "george", Lives = 9 });
+
+            var qr = gql.ExecuteQuery(context, null, null);
+            dynamic animals = qr.Data["animals"];
+            // we only have the fields requested
+            Assert.Equal(1, animals.Count);
+            
+            Assert.Equal("Cat", animals[0].__typename);
+            Assert.Equal("george", animals[0].name);
+            Assert.Equal(9, animals[0].lives);
+        }
+
+        [Fact]
+        public void TestAutoUnion_TypeOnly()
+        {
+            var schema = SchemaBuilder.FromObject<TestUnionDataContext>(new SchemaBuilderOptions { AutoCreateInterfaceTypes = true });
+            Assert.True(schema.HasType(typeof(IAnimal)));
+            Assert.True(schema.GetSchemaType(typeof(IAnimal), null).GqlType == GqlTypeEnum.Union);
+
+            schema.Type<IAnimal>().AddPossibleType<Dog>();
+            schema.Type<IAnimal>().AddPossibleType<Cat>();
+            Assert.True(schema.GetSchemaType(typeof(Cat), null).GqlType == GqlTypeEnum.Object);
+            Assert.True(schema.GetSchemaType(typeof(Dog), null).GqlType == GqlTypeEnum.Object);
+
+
+
+            var gql = new GraphQLCompiler(schema).Compile(@"
+query {
+    animals {
+        __typename
+    }
+}");
+            var context = new TestUnionDataContext();
+            context.Animals.Add(new Dog() { Name = "steve", HasBone = true });
+            context.Animals.Add(new Cat() { Name = "george", Lives = 9 });
+
+            var qr = gql.ExecuteQuery(context, null, null);
+            dynamic animals = qr.Data["animals"];
+            // we only have the fields requested
+            Assert.Equal(2, animals.Count);
+
+            Assert.Equal("Dog", animals[0].__typename);
+            Assert.Throws<RuntimeBinderException>(() => animals[0].name);
+            Assert.Throws<RuntimeBinderException>(() => animals[0].hasBone);
+            Assert.Equal("Cat", animals[1].__typename);
+            Assert.Throws<RuntimeBinderException>(() => animals[1].name);
+            Assert.Throws<RuntimeBinderException>(() => animals[1].lives);
         }
     }
 }

--- a/src/tests/EntityGraphQL.Tests/QueryTests/UnionTests.cs
+++ b/src/tests/EntityGraphQL.Tests/QueryTests/UnionTests.cs
@@ -131,9 +131,9 @@ query {
             // we only have the fields requested
             Assert.Equal(2, animals.Count);
 
-            Assert.Equal("Dog", animals[0].__typename);
             Assert.Equal("steve", animals[0].name);
             Assert.True(animals[0].hasBone);
+            Assert.Null(animals[1]);
         }
 
         [Fact]
@@ -164,11 +164,11 @@ query {
             var qr = gql.ExecuteQuery(context, null, null);
             dynamic animals = qr.Data["animals"];
             // we only have the fields requested
-            Assert.Equal(1, animals.Count);
-            
-            Assert.Equal("Cat", animals[0].__typename);
-            Assert.Equal("george", animals[0].name);
-            Assert.Equal(9, animals[0].lives);
+            Assert.Equal(2, animals.Count);
+
+            Assert.Null(animals[0]);
+            Assert.Equal("george", animals[1].name);
+            Assert.Equal(9, animals[1].lives);
         }
 
         [Fact]


### PR DESCRIPTION
as per first issue in #264 
interface/union queries used to require you to query for at least 2 of the subtypes at once.