### PR TITLE
#205 - Only return unique error messages

### DIFF
--- a/src/EntityGraphQL/Schema/SchemaProvider.cs
+++ b/src/EntityGraphQL/Schema/SchemaProvider.cs
@@ -249,7 +249,7 @@ namespace EntityGraphQL.Schema
             logger?.LogError(exception, "Error executing QueryRequest");
             
             var result = new QueryResult();
-            foreach (var (errorMessage, extensions) in GenerateMessage(exception))
+            foreach (var (errorMessage, extensions) in GenerateMessage(exception).Distinct())
                 result.AddError(errorMessage, extensions);
             return result;
         }

--- a/src/tests/EntityGraphQL.Tests/ErrorTests.cs
+++ b/src/tests/EntityGraphQL.Tests/ErrorTests.cs
@@ -176,5 +176,23 @@ namespace EntityGraphQL.Tests
             Assert.NotNull(results.Errors);
             Assert.Equal("Field 'people' - You should not see this message outside of Development", results.Errors[0].Message);
         }
+
+        [Fact]
+        public void QueryReportsError_DistinctErrors()
+        {
+            var schemaProvider = SchemaBuilder.FromObject<TestDataContext>(new SchemaBuilderSchemaOptions { IsDevelopment = false });
+            var gql = new QueryRequest
+            {
+                Query = @"{
+    people { error_AggregateException }
+}",
+            };
+
+            var testSchema = new TestDataContext().FillWithTestData();
+            var results = schemaProvider.ExecuteRequest(gql, testSchema, null, null);
+            Assert.NotNull(results.Errors);
+            Assert.Single(results.Errors);
+            Assert.Equal("Field 'people' - Error occurred", results.Errors[0].Message);
+        }
     }
 }

--- a/src/tests/EntityGraphQL.Tests/SortTests/SortTests.cs
+++ b/src/tests/EntityGraphQL.Tests/SortTests/SortTests.cs
@@ -168,7 +168,7 @@ namespace EntityGraphQL.Tests
             Assert.Equal("Zoo", person.lastName);
             var schemaType = schema.Type("PeopleSortInput");
             var fields = schemaType.GetFields().ToList();
-            Assert.Equal(10, fields.Count);
+            Assert.Equal(11, fields.Count);
         }
         [Fact]
         public void SupportUseSortOnNonRoot()

--- a/src/tests/EntityGraphQL.Tests/TestDataContext.cs
+++ b/src/tests/EntityGraphQL.Tests/TestDataContext.cs
@@ -89,6 +89,12 @@ namespace EntityGraphQL.Tests
             get => throw new Exception("You should not see this message outside of Development"); set => throw new Exception("You should not see this message outside of Development");
         }
 
+        public string Error_AggregateException
+        {
+            get => throw new AggregateException(Enumerable.Range(0, 2).Select(_ => new Exception("You should not see this message outside of Development")));
+            set => throw new AggregateException(Enumerable.Range(0, 2).Select(_ => new Exception("You should not see this message outside of Development")));
+        }
+
         public double GetHeight(HeightUnit unit)
         {
             return unit switch


### PR DESCRIPTION
Rather than returning duplicate error messages, we now only return distinct messages. 

Raised here: https://github.com/EntityGraphQL/EntityGraphQL/pull/262#pullrequestreview-1131619981