### PR TITLE
bugfix: stop double sql query on base type (4.1 regression)

### DIFF
--- a/src/EntityGraphQL/Compiler/Util/ExpressionUtil.cs
+++ b/src/EntityGraphQL/Compiler/Util/ExpressionUtil.cs
@@ -511,14 +511,6 @@ namespace EntityGraphQL.Compiler.Util
                     fieldExpressionsByName[item.Key] = item.Value;
             }
 
-            //dynamicType = typeof(object);
-            //if (!fieldExpressionsByName.Any())
-            //    return null;
-
-            //dynamicType = LinqRuntimeTypeBuilder.GetDynamicType(fieldExpressionsByName.ToDictionary(f => f.Key, f => f.Value.Type), fieldDescription, parentType: parentType);
-            //if (dynamicType == null)
-            //    throw new EntityGraphQLCompilerException("Could not create dynamic type");
-
             var bindings = type.GetFields().Select(p => Expression.Bind(p, fieldExpressionsByName[p.Name])).OfType<MemberBinding>();
             var constructor = type.GetConstructor(Type.EmptyTypes);
             if (constructor == null)

--- a/src/tests/EntityGraphQL.Tests/QueryTests/UnionTests.cs
+++ b/src/tests/EntityGraphQL.Tests/QueryTests/UnionTests.cs
@@ -133,7 +133,11 @@ query {
 
             Assert.Equal("steve", animals[0].name);
             Assert.True(animals[0].hasBone);
-            Assert.Null(animals[1]);
+
+
+            //Cats are not null but have 0 fields
+            Assert.NotNull(animals[1]);
+            Assert.Empty(animals[1].GetType().GetFields());
         }
 
         [Fact]
@@ -166,7 +170,10 @@ query {
             // we only have the fields requested
             Assert.Equal(2, animals.Count);
 
-            Assert.Null(animals[0]);
+            //Dogs are not null but have 0 fields
+            Assert.NotNull(animals[0]);
+            Assert.Empty(animals[0].GetType().GetFields());
+
             Assert.Equal("george", animals[1].name);
             Assert.Equal(9, animals[1].lives);
         }


### PR DESCRIPTION
So it appears the Expression.TypeIs strategy for interfaces/unions causes entityframework to perform extra queries when AsSplitQuery is enabled

I made a tweak in 4.1 to fix some cases around querying unions without querying multiple types, this meant that when used in conjunction with AsSplitQuery it queried the database once for each type and twice for the base type.

This PR fixes the twice for the base type issue (but not for the once for each type issue).
 