### PR TITLE
feat: optionalfield arguments - (null, undefined or value)

### DIFF
--- a/src/EntityGraphQL/Compiler/EntityQuery/EntityQueryNodeVisitor.cs
+++ b/src/EntityGraphQL/Compiler/EntityQuery/EntityQueryNodeVisitor.cs
@@ -160,7 +160,7 @@ namespace EntityGraphQL.Compiler.EntityQuery
             }
 
             var gqlField = schemaType.GetField(field, requestContext);
-            (var exp, _) = gqlField.GetExpression(gqlField.ResolveExpression!, currentContext, null, null, null, new Dictionary<string, object>(), null, null, new List<GraphQLDirective>(), false, new Util.ParameterReplacer());
+            (var exp, _) = gqlField.GetExpression(gqlField.ResolveExpression!, currentContext, null, null, null, new Dictionary<string, object?>(), null, null, new List<GraphQLDirective>(), false, new Util.ParameterReplacer());
             return exp!;
         }
 

--- a/src/EntityGraphQL/Compiler/GqlNodes/BaseGraphQLField.cs
+++ b/src/EntityGraphQL/Compiler/GqlNodes/BaseGraphQLField.cs
@@ -57,19 +57,19 @@ namespace EntityGraphQL.Compiler
         /// <summary>
         /// Arguments from inline in the query - not $ variables
         /// </summary>
-        public IReadOnlyDictionary<string, object> Arguments { get; }
+        public IReadOnlyDictionary<string, object?> Arguments { get; }
         /// <summary>
         /// True if this field has services
         /// </summary>
         public bool HasServices { get => Field?.Services.Any() == true; }
 
-        public BaseGraphQLField(ISchemaProvider schema, IField? field, string name, Expression? nextFieldContext, ParameterExpression? rootParameter, IGraphQLNode? parentNode, IReadOnlyDictionary<string, object>? arguments)
+        public BaseGraphQLField(ISchemaProvider schema, IField? field, string name, Expression? nextFieldContext, ParameterExpression? rootParameter, IGraphQLNode? parentNode, IReadOnlyDictionary<string, object?>? arguments)
         {
             Name = name;
             NextFieldContext = nextFieldContext;
             RootParameter = rootParameter;
             ParentNode = parentNode;
-            this.Arguments = arguments ?? new Dictionary<string, object>();
+            this.Arguments = arguments ?? new Dictionary<string, object?>();
             this.schema = schema;
             Field = field;
         }
@@ -80,7 +80,7 @@ namespace EntityGraphQL.Compiler
             NextFieldContext = nextFieldContext;
             RootParameter = context.RootParameter;
             ParentNode = context.ParentNode;
-            this.Arguments = context.Arguments ?? new Dictionary<string, object>();
+            this.Arguments = context.Arguments ?? new Dictionary<string, object?>();
             this.schema = context.schema;
             Field = context.Field;
         }

--- a/src/EntityGraphQL/Compiler/GqlNodes/BaseGraphQLQueryField.cs
+++ b/src/EntityGraphQL/Compiler/GqlNodes/BaseGraphQLQueryField.cs
@@ -12,7 +12,7 @@ namespace EntityGraphQL.Compiler
     /// </summary>
     public abstract class BaseGraphQLQueryField : BaseGraphQLField
     {
-        protected BaseGraphQLQueryField(ISchemaProvider schema, IField? field, string name, Expression? nextFieldContext, ParameterExpression? rootParameter, IGraphQLNode? parentNode, IReadOnlyDictionary<string, object>? arguments)
+        protected BaseGraphQLQueryField(ISchemaProvider schema, IField? field, string name, Expression? nextFieldContext, ParameterExpression? rootParameter, IGraphQLNode? parentNode, IReadOnlyDictionary<string, object?>? arguments)
             : base(schema, field, name, nextFieldContext, rootParameter, parentNode, arguments)
         {
         }

--- a/src/EntityGraphQL/Compiler/GqlNodes/ExecutableGraphQLStatement.cs
+++ b/src/EntityGraphQL/Compiler/GqlNodes/ExecutableGraphQLStatement.cs
@@ -32,7 +32,7 @@ namespace EntityGraphQL.Compiler
         public IField? Field { get; }
         public bool HasServices { get => Field?.Services.Any() == true; }
 
-        public IReadOnlyDictionary<string, object> Arguments { get; }
+        public IReadOnlyDictionary<string, object?> Arguments { get; }
 
         public string Name { get; }
 
@@ -45,7 +45,7 @@ namespace EntityGraphQL.Compiler
             RootParameter = rootParameter;
             opDefinedVariables = opVariables;
             this.schema = schema;
-            Arguments = new Dictionary<string, object>();
+            Arguments = new Dictionary<string, object?>();
             if (opDefinedVariables.Any())
             {
                 var variableType = LinqRuntimeTypeBuilder.GetDynamicType(opDefinedVariables.ToDictionary(f => f.Key, f => f.Value.RawType), "docVars");

--- a/src/EntityGraphQL/Compiler/GqlNodes/GraphQLDirective.cs
+++ b/src/EntityGraphQL/Compiler/GqlNodes/GraphQLDirective.cs
@@ -9,17 +9,17 @@ namespace EntityGraphQL.Compiler;
 public class GraphQLDirective
 {
     private readonly IDirectiveProcessor processor;
-    private readonly Dictionary<string, object> inlineArgValues;
+    private readonly Dictionary<string, object?> inlineArgValues;
     private readonly string name;
 
-    public GraphQLDirective(string name, IDirectiveProcessor processor, Dictionary<string, object> inlineArgValues)
+    public GraphQLDirective(string name, IDirectiveProcessor processor, Dictionary<string, object?> inlineArgValues)
     {
         this.processor = processor;
         this.inlineArgValues = inlineArgValues;
         this.name = name;
     }
 
-    public Expression? Process(ISchemaProvider schema, Expression fieldExpression, IReadOnlyDictionary<string, object> args, ParameterExpression? docParam, object? docVariables)
+    public Expression? Process(ISchemaProvider schema, Expression fieldExpression, IReadOnlyDictionary<string, object?> args, ParameterExpression? docParam, object? docVariables)
     {
         var validationErrors = new List<string>();
         var arguments = ArgumentUtil.BuildArgumentsObject(schema, name, null, inlineArgValues.MergeNew(args), processor.GetArguments(schema), processor.GetArgumentsType(), docParam, docVariables, validationErrors);
@@ -32,7 +32,7 @@ public class GraphQLDirective
         return processor.ProcessExpression(fieldExpression, arguments);
     }
 
-    public BaseGraphQLField? ProcessField(ISchemaProvider schema, BaseGraphQLField field, IReadOnlyDictionary<string, object> args, ParameterExpression? docParam, object? docVariables)
+    public BaseGraphQLField? ProcessField(ISchemaProvider schema, BaseGraphQLField field, IReadOnlyDictionary<string, object?> args, ParameterExpression? docParam, object? docVariables)
     {
         var validationErrors = new List<string>();
         var arguments = ArgumentUtil.BuildArgumentsObject(schema, name, null, inlineArgValues.MergeNew(args), processor.GetArguments(schema), processor.GetArgumentsType(), docParam, docVariables, validationErrors);

--- a/src/EntityGraphQL/Compiler/GqlNodes/GraphQLDocument.cs
+++ b/src/EntityGraphQL/Compiler/GqlNodes/GraphQLDocument.cs
@@ -43,7 +43,7 @@ namespace EntityGraphQL.Compiler
             Operations = new List<ExecutableGraphQLStatement>();
             Fragments = new List<GraphQLFragmentStatement>();
             this.fieldNamer = fieldNamer;
-            Arguments = new Dictionary<string, object>();
+            Arguments = new Dictionary<string, object?>();
         }
 
         public string Name
@@ -54,7 +54,7 @@ namespace EntityGraphQL.Compiler
         public IField? Field { get; }
         public bool HasServices { get => Field?.Services.Any() == true; }
 
-        public IReadOnlyDictionary<string, object> Arguments { get; }
+        public IReadOnlyDictionary<string, object?> Arguments { get; }
 
         public QueryResult ExecuteQuery<TContext>(TContext context, IServiceProvider? services, QueryVariables? variables, string? operationName = null, ExecutionOptions? options = null)
         {

--- a/src/EntityGraphQL/Compiler/GqlNodes/GraphQLFragmentStatement.cs
+++ b/src/EntityGraphQL/Compiler/GqlNodes/GraphQLFragmentStatement.cs
@@ -14,7 +14,7 @@ namespace EntityGraphQL.Compiler
         public IField? Field { get; }
         public bool HasServices { get => Field?.Services.Any() == true; }
 
-        public IReadOnlyDictionary<string, object> Arguments { get; }
+        public IReadOnlyDictionary<string, object?> Arguments { get; }
 
         public string Name { get; }
 
@@ -25,7 +25,7 @@ namespace EntityGraphQL.Compiler
             Name = name;
             NextFieldContext = selectContext;
             RootParameter = rootParameter;
-            Arguments = new Dictionary<string, object>();
+            Arguments = new Dictionary<string, object?>();
         }
 
         public GraphQLFragmentStatement(GraphQLFragmentStatement context, ParameterExpression? nextFieldContext)
@@ -33,7 +33,7 @@ namespace EntityGraphQL.Compiler
             Name = context.Name;
             RootParameter = context.RootParameter;
             NextFieldContext = nextFieldContext;
-            Arguments = new Dictionary<string, object>();
+            Arguments = new Dictionary<string, object?>();
         }
 
         public void AddField(BaseGraphQLField field)

--- a/src/EntityGraphQL/Compiler/GqlNodes/GraphQLListSelectionField.cs
+++ b/src/EntityGraphQL/Compiler/GqlNodes/GraphQLListSelectionField.cs
@@ -32,7 +32,7 @@ namespace EntityGraphQL.Compiler
         /// <param name="nodeExpression">Expression for the list</param>
         /// <param name="context">Partent node</param>
         /// <param name="arguments"></param>
-        public GraphQLListSelectionField(ISchemaProvider schema, IField? field, string name, ParameterExpression? nextFieldContext, ParameterExpression? rootParameter, Expression nodeExpression, IGraphQLNode context, Dictionary<string, object>? arguments)
+        public GraphQLListSelectionField(ISchemaProvider schema, IField? field, string name, ParameterExpression? nextFieldContext, ParameterExpression? rootParameter, Expression nodeExpression, IGraphQLNode context, Dictionary<string, object?>? arguments)
             : base(schema, field, name, nextFieldContext, rootParameter, context, arguments)
         {
             this.ListExpression = nodeExpression;

--- a/src/EntityGraphQL/Compiler/GqlNodes/GraphQLMutationField.cs
+++ b/src/EntityGraphQL/Compiler/GqlNodes/GraphQLMutationField.cs
@@ -13,7 +13,7 @@ namespace EntityGraphQL.Compiler
 
         public BaseGraphQLQueryField? ResultSelection { get; set; }
 
-        public GraphQLMutationField(ISchemaProvider schema, string name, MutationField mutationField, Dictionary<string, object>? args, Expression nextFieldContext, ParameterExpression rootParameter, IGraphQLNode parentNode)
+        public GraphQLMutationField(ISchemaProvider schema, string name, MutationField mutationField, Dictionary<string, object?>? args, Expression nextFieldContext, ParameterExpression rootParameter, IGraphQLNode parentNode)
             : base(schema, mutationField, name, nextFieldContext, rootParameter, parentNode, args)
         {
             this.MutationField = mutationField;

--- a/src/EntityGraphQL/Compiler/GqlNodes/GraphQLObjectProjectionField.cs
+++ b/src/EntityGraphQL/Compiler/GqlNodes/GraphQLObjectProjectionField.cs
@@ -30,7 +30,7 @@ namespace EntityGraphQL.Compiler
         /// <param name="nextFieldContext">The next context expression for ObjectProjection is also our field expression e..g person.manager</param>
         /// <param name="rootParameter">The root parameter</param>
         /// <param name="parentNode"></param>
-        public GraphQLObjectProjectionField(ISchemaProvider schema, IField? field, string name, Expression nextFieldContext, ParameterExpression rootParameter, IGraphQLNode parentNode, IReadOnlyDictionary<string, object>? arguments)
+        public GraphQLObjectProjectionField(ISchemaProvider schema, IField? field, string name, Expression nextFieldContext, ParameterExpression rootParameter, IGraphQLNode parentNode, IReadOnlyDictionary<string, object?>? arguments)
             : base(schema, field, name, nextFieldContext, rootParameter, parentNode, arguments)
         {
         }

--- a/src/EntityGraphQL/Compiler/GqlNodes/GraphQLScalarField.cs
+++ b/src/EntityGraphQL/Compiler/GqlNodes/GraphQLScalarField.cs
@@ -9,7 +9,7 @@ namespace EntityGraphQL.Compiler
 {
     public class GraphQLScalarField : BaseGraphQLField
     {
-        public GraphQLScalarField(ISchemaProvider schema, IField field, string name, Expression nextFieldContext, ParameterExpression? rootParameter, IGraphQLNode parentNode, Dictionary<string, object>? arguments)
+        public GraphQLScalarField(ISchemaProvider schema, IField field, string name, Expression nextFieldContext, ParameterExpression? rootParameter, IGraphQLNode parentNode, Dictionary<string, object?>? arguments)
             : base(schema, field, name, nextFieldContext, rootParameter, parentNode, arguments)
         {
         }

--- a/src/EntityGraphQL/Compiler/GqlNodes/GraphQLSubscriptionField.cs
+++ b/src/EntityGraphQL/Compiler/GqlNodes/GraphQLSubscriptionField.cs
@@ -13,7 +13,7 @@ namespace EntityGraphQL.Compiler
 
         public BaseGraphQLQueryField? ResultSelection { get; set; }
 
-        public GraphQLSubscriptionField(ISchemaProvider schema, string name, SubscriptionField subscriptionField, Dictionary<string, object>? args, Expression nextFieldContext, ParameterExpression rootParameter, IGraphQLNode parentNode)
+        public GraphQLSubscriptionField(ISchemaProvider schema, string name, SubscriptionField subscriptionField, Dictionary<string, object?>? args, Expression nextFieldContext, ParameterExpression rootParameter, IGraphQLNode parentNode)
             : base(schema, subscriptionField, name, nextFieldContext, rootParameter, parentNode, args)
         {
             this.SubscriptionField = subscriptionField;

--- a/src/EntityGraphQL/Compiler/GqlNodes/IGraphQLNode.cs
+++ b/src/EntityGraphQL/Compiler/GqlNodes/IGraphQLNode.cs
@@ -24,6 +24,6 @@ namespace EntityGraphQL.Compiler
         void AddField(BaseGraphQLField field);
         IField? Field { get; }
         bool HasServices { get; }
-        IReadOnlyDictionary<string, object> Arguments { get; }
+        IReadOnlyDictionary<string, object?> Arguments { get; }
     }
 }

--- a/src/EntityGraphQL/Compiler/Util/ArgumentUtil.cs
+++ b/src/EntityGraphQL/Compiler/Util/ArgumentUtil.cs
@@ -139,6 +139,34 @@ public static class ArgumentUtil
             var typedVal = constructor.Invoke(new[] { item });
             return typedVal;
         }
+        else if (memberType.GetGenericArguments().Any() &&  memberType.GetGenericTypeDefinition() == typeof(OptionalField<>))
+        {
+            if (args != null && args.ContainsKey(argName)) {
+                var item = args[argName];
+                var constructor = memberType.GetConstructor(new[] { item.GetType() });
+
+                if (constructor == null)
+                {
+                    validationErrors.Add($"Could not find a constructor for type {memberType.Name} that takes value '{item}'");
+                    return null;
+                }
+
+                var typedVal = constructor.Invoke(new[] { item });
+                return typedVal;
+            } else
+            {
+                var constructor = memberType.GetConstructor(Array.Empty<Type>());
+
+                if (constructor == null)
+                {
+                    validationErrors.Add($"Could not find a constructor for type {memberType.Name}");
+                    return null;
+                }
+
+                var typedVal = constructor.Invoke(Array.Empty<object>());
+                return typedVal;
+            }
+        }
         else if (defaultValue != null && defaultValue.GetType().IsConstructedGenericType && defaultValue.GetType().GetGenericTypeDefinition() == typeof(EntityQueryType<>))
         {
             return args != null && args.ContainsKey(argName) ? args[argName] : Activator.CreateInstance(memberType);

--- a/src/EntityGraphQL/Compiler/Util/ExpressionUtil.cs
+++ b/src/EntityGraphQL/Compiler/Util/ExpressionUtil.cs
@@ -195,11 +195,13 @@ namespace EntityGraphQL.Compiler.Util
             {
                 return Guid.Parse(value!.ToString()!);
             }
-            if (toType.IsGenericType && toType.GetGenericTypeDefinition() == typeof(RequiredField<>))
+            if (toType.IsGenericType && (toType.GetGenericTypeDefinition() == typeof(RequiredField<>) || toType.GetGenericTypeDefinition() == typeof(OptionalField<>)))
             {
                 if (fromType == toType.GetGenericArguments()[0])
                     return Activator.CreateInstance(toType, value);
                 else if (toType.IsGenericType && toType.GetGenericTypeDefinition() == typeof(RequiredField<>))
+                    return Activator.CreateInstance(toType, ChangeType(value, toType.GetGenericArguments()[0], schema));
+                else if (toType.IsGenericType && toType.GetGenericTypeDefinition() == typeof(OptionalField<>))
                     return Activator.CreateInstance(toType, ChangeType(value, toType.GetGenericArguments()[0], schema));
             }
             if (argumentNonNullType.IsClass && typeof(string) != argumentNonNullType && !fromType.IsEnumerableOrArray())

--- a/src/EntityGraphQL/Compiler/Util/ExpressionUtil.cs
+++ b/src/EntityGraphQL/Compiler/Util/ExpressionUtil.cs
@@ -55,8 +55,15 @@ namespace EntityGraphQL.Compiler.Util
             {
                 if (toType.IsConstructedGenericType && toType.GetGenericTypeDefinition() == typeof(EntityQueryType<>))
                 {
-                    // we don't want a null value. We want an empty EntityQueryType
+                    // we don't want a null value. We want an empty EntityQueryType/OptionalField
                     var entityQuery = Activator.CreateInstance(toType);
+                    return entityQuery;
+                }
+
+                if (toType.IsConstructedGenericType && toType.GetGenericTypeDefinition() == typeof(OptionalField<>))
+                {
+                    // we don't want a null value. We want an empty EntityQueryType/OptionalField
+                    var entityQuery = Activator.CreateInstance(toType, value);
                     return entityQuery;
                 }
 

--- a/src/EntityGraphQL/Compiler/Util/ExpressionUtil.cs
+++ b/src/EntityGraphQL/Compiler/Util/ExpressionUtil.cs
@@ -199,9 +199,9 @@ namespace EntityGraphQL.Compiler.Util
             {
                 if (fromType == toType.GetGenericArguments()[0])
                     return Activator.CreateInstance(toType, value);
-                else if (toType.IsGenericType && toType.GetGenericTypeDefinition() == typeof(RequiredField<>))
+                else if (toType.GetGenericTypeDefinition() == typeof(RequiredField<>))
                     return Activator.CreateInstance(toType, ChangeType(value, toType.GetGenericArguments()[0], schema));
-                else if (toType.IsGenericType && toType.GetGenericTypeDefinition() == typeof(OptionalField<>))
+                else if (toType.GetGenericTypeDefinition() == typeof(OptionalField<>))
                     return Activator.CreateInstance(toType, ChangeType(value, toType.GetGenericArguments()[0], schema));
             }
             if (argumentNonNullType.IsClass && typeof(string) != argumentNonNullType && !fromType.IsEnumerableOrArray())

--- a/src/EntityGraphQL/Extensions/DictionaryExtensions.cs
+++ b/src/EntityGraphQL/Extensions/DictionaryExtensions.cs
@@ -5,9 +5,9 @@ namespace EntityGraphQL.Extensions;
 
 public static class DictionaryExtensions
 {
-    public static Dictionary<TKey, TElement> MergeNew<TKey, TElement>(this IDictionary<TKey, TElement> source, IReadOnlyDictionary<TKey, TElement>? other) where TKey : notnull
+    public static Dictionary<TKey, TElement?> MergeNew<TKey, TElement>(this IDictionary<TKey, TElement?> source, IReadOnlyDictionary<TKey, TElement?>? other) where TKey : notnull
     {
-        var result = source != null ? source.ToDictionary(kvp => kvp.Key, kvp => kvp.Value) : new Dictionary<TKey, TElement>();
+        var result = source != null ? source.ToDictionary(kvp => kvp.Key, kvp => kvp.Value) : new Dictionary<TKey, TElement?>();
         if (other != null)
             foreach (var kvp in other)
                 result[kvp.Key] = kvp.Value;

--- a/src/EntityGraphQL/Schema/ArgType.cs
+++ b/src/EntityGraphQL/Schema/ArgType.cs
@@ -72,6 +72,14 @@ namespace EntityGraphQL.Schema
                 defaultValue = null;
             }
 
+            if (type.IsConstructedGenericType && type.GetGenericTypeDefinition() == typeof(OptionalField<>))
+            {
+                typeToUse = type.GetGenericArguments()[0];
+                // default value will often be the default value of the non-null type (e.g. 0 for int). 
+                // We are saying here it must be provided by the query
+                defaultValue = null;
+            }
+
             var gqlTypeInfo = new GqlTypeInfo(() => schema.GetSchemaType(typeToUse.IsConstructedGenericType && typeToUse.GetGenericTypeDefinition() == typeof(EntityQueryType<>) ? typeof(string) : typeToUse.GetNonNullableOrEnumerableType(), null), typeToUse, nullability);
             var arg = new ArgType(schema.SchemaFieldNamer(name), name, gqlTypeInfo, memberInfo, type)
             {

--- a/src/EntityGraphQL/Schema/ArgType.cs
+++ b/src/EntityGraphQL/Schema/ArgType.cs
@@ -59,7 +59,7 @@ namespace EntityGraphQL.Schema
             return arg;
         }
 
-        private static ArgType MakeArgType(ISchemaProvider schema, string name, MemberInfo? memberInfo, IEnumerable<Attribute> attributes, Type type, object? defaultValue, NullabilityInfoEx nullability)
+        public static ArgType MakeArgType(ISchemaProvider schema, string name, MemberInfo? memberInfo, IEnumerable<Attribute> attributes, Type type, object? defaultValue, NullabilityInfoEx nullability)
         {
             var markedRequired = false;
             var typeToUse = type;
@@ -75,9 +75,8 @@ namespace EntityGraphQL.Schema
             if (type.IsConstructedGenericType && type.GetGenericTypeDefinition() == typeof(OptionalField<>))
             {
                 typeToUse = type.GetGenericArguments()[0];
-                // default value will often be the default value of the non-null type (e.g. 0 for int). 
-                // We are saying here it must be provided by the query
-                defaultValue = null;
+                //default value is the 'undefined' state
+                defaultValue = Activator.CreateInstance(type);
             }
 
             var gqlTypeInfo = new GqlTypeInfo(() => schema.GetSchemaType(typeToUse.IsConstructedGenericType && typeToUse.GetGenericTypeDefinition() == typeof(EntityQueryType<>) ? typeof(string) : typeToUse.GetNonNullableOrEnumerableType(), null), typeToUse, nullability);

--- a/src/EntityGraphQL/Schema/ArgumentHelper.cs
+++ b/src/EntityGraphQL/Schema/ArgumentHelper.cs
@@ -21,6 +21,16 @@ namespace EntityGraphQL.Schema
         }
 
         /// <summary>
+        /// Creates an optional argument with the specified type.
+        /// </summary>
+        /// <typeparam name="TType"></typeparam>
+        /// <returns></returns>
+        public static OptionalField<TType> Optional<TType>()
+        {
+            return new OptionalField<TType>();
+        }
+
+        /// <summary>
         /// Creates a field argument that takes a String value which will be compiled into an expression and used to filter the collection
         /// The argument will not be null if not supplied. Has .HasValue on this argument to test if it have a filter expression.
         /// </summary>
@@ -69,6 +79,47 @@ namespace EntityGraphQL.Schema
         {
             return Value?.ToString() ?? "null";
         }
+    }
+
+    /// <summary>
+    /// Wraps a field/argument, marking it as optional (null/undefined/TType) when building schemas
+    /// </summary>
+    /// <typeparam name="TType"></typeparam>
+    public class OptionalField<TType>
+    {
+        public Type Type { get; }
+
+        public OptionalField()
+        {
+            Type = typeof(TType);
+        }
+
+        public OptionalField(TType value)
+        {
+            Type = typeof(TType);
+            Value = value;
+        }
+
+        private TType? value;
+        public TType? Value
+        {
+            get => value;
+
+            set
+            {
+                HasValue = true;
+                this.value = value;
+            }
+        }
+
+        public bool HasValue { get; set; }
+
+        public static implicit operator TType?(OptionalField<TType> field) {
+            if (!field.HasValue)
+                throw new EntityGraphQLExecutionException($"Optional field argument cannot be read if it is not set");
+            return field.Value;
+        }
+        public static implicit operator OptionalField<TType>(TType value) => new OptionalField<TType>(value);
     }
 
     public class EntityQueryType<TType> : BaseEntityQueryType

--- a/src/EntityGraphQL/Schema/BaseField.cs
+++ b/src/EntityGraphQL/Schema/BaseField.cs
@@ -106,7 +106,7 @@ namespace EntityGraphQL.Schema
             return Arguments[argName];
         }
 
-        public abstract (Expression? expression, ParameterExpression? argumentParam) GetExpression(Expression fieldExpression, Expression? fieldContext, IGraphQLNode? parentNode, ParameterExpression? schemaContext, CompileContext? compileContext, IReadOnlyDictionary<string, object> args, ParameterExpression? docParam, object? docVariables, IEnumerable<GraphQLDirective> directives, bool contextChanged, ParameterReplacer replacer);
+        public abstract (Expression? expression, ParameterExpression? argumentParam) GetExpression(Expression fieldExpression, Expression? fieldContext, IGraphQLNode? parentNode, ParameterExpression? schemaContext, CompileContext? compileContext, IReadOnlyDictionary<string, object?> args, ParameterExpression? docParam, object? docVariables, IEnumerable<GraphQLDirective> directives, bool contextChanged, ParameterReplacer replacer);
         public bool HasArgumentByName(string argName)
         {
             return Arguments.ContainsKey(argName);

--- a/src/EntityGraphQL/Schema/Field.cs
+++ b/src/EntityGraphQL/Schema/Field.cs
@@ -97,7 +97,7 @@ namespace EntityGraphQL.Schema
             return this;
         }
 
-        public override (Expression? expression, ParameterExpression? argumentParam) GetExpression(Expression fieldExpression, Expression? fieldContext, IGraphQLNode? parentNode, ParameterExpression? schemaContext, CompileContext? compileContext, IReadOnlyDictionary<string, object> args, ParameterExpression? docParam, object? docVariables, IEnumerable<GraphQLDirective> directives, bool contextChanged, ParameterReplacer replacer)
+        public override (Expression? expression, ParameterExpression? argumentParam) GetExpression(Expression fieldExpression, Expression? fieldContext, IGraphQLNode? parentNode, ParameterExpression? schemaContext, CompileContext? compileContext, IReadOnlyDictionary<string, object?> args, ParameterExpression? docParam, object? docVariables, IEnumerable<GraphQLDirective> directives, bool contextChanged, ParameterReplacer replacer)
         {
             Expression? expression = fieldExpression;
             foreach (var directive in directives)
@@ -126,7 +126,7 @@ namespace EntityGraphQL.Schema
             return (result, argumentParam);
         }
 
-        private (Expression? fieldExpression, ParameterExpression? argumentParam) PrepareFieldExpression(IReadOnlyDictionary<string, object> args, Field field, Expression fieldExpression, ParameterReplacer replacer, Expression context, IGraphQLNode? parentNode, ParameterExpression? docParam, object? docVariables, bool servicesPass, CompileContext? compileContext)
+        private (Expression? fieldExpression, ParameterExpression? argumentParam) PrepareFieldExpression(IReadOnlyDictionary<string, object?> args, Field field, Expression fieldExpression, ParameterReplacer replacer, Expression context, IGraphQLNode? parentNode, ParameterExpression? docParam, object? docVariables, bool servicesPass, CompileContext? compileContext)
         {
             object? argumentValues = null;
             Expression? result = fieldExpression;

--- a/src/EntityGraphQL/Schema/IField.cs
+++ b/src/EntityGraphQL/Schema/IField.cs
@@ -57,7 +57,7 @@ namespace EntityGraphQL.Schema
         /// <param name="previousContext"></param>
         /// <param name="args"></param>
         /// <returns></returns>
-        (Expression? expression, ParameterExpression? argumentParam) GetExpression(Expression fieldExpression, Expression? fieldContext, IGraphQLNode? parentNode, ParameterExpression? schemaContext, CompileContext? compileContext, IReadOnlyDictionary<string, object> args, ParameterExpression? docParam, object? docVariables, IEnumerable<GraphQLDirective> directives, bool contextChanged, ParameterReplacer replacer);
+        (Expression? expression, ParameterExpression? argumentParam) GetExpression(Expression fieldExpression, Expression? fieldContext, IGraphQLNode? parentNode, ParameterExpression? schemaContext, CompileContext? compileContext, IReadOnlyDictionary<string, object?> args, ParameterExpression? docParam, object? docVariables, IEnumerable<GraphQLDirective> directives, bool contextChanged, ParameterReplacer replacer);
         Expression? ResolveExpression { get; }
 
         IField UpdateExpression(Expression expression);

--- a/src/EntityGraphQL/Schema/MethodField.cs
+++ b/src/EntityGraphQL/Schema/MethodField.cs
@@ -79,7 +79,7 @@ namespace EntityGraphQL.Schema
                 schema.AddInputType(inputType, inputType.Name, null).AddAllFields();
         }
 
-        public virtual async Task<object?> CallAsync(object? context, IReadOnlyDictionary<string, object>? gqlRequestArgs, GraphQLValidator validator, IServiceProvider? serviceProvider, ParameterExpression? variableParameter, object? docVariables)
+        public virtual async Task<object?> CallAsync(object? context, IReadOnlyDictionary<string, object?>? gqlRequestArgs, GraphQLValidator validator, IServiceProvider? serviceProvider, ParameterExpression? variableParameter, object? docVariables)
         {
             if (context == null)
                 return null;
@@ -95,7 +95,7 @@ namespace EntityGraphQL.Schema
             {
                 if (p.GetCustomAttribute(typeof(GraphQLArgumentsAttribute)) != null || p.ParameterType.GetTypeInfo().GetCustomAttribute(typeof(GraphQLArgumentsAttribute)) != null)
                 {
-                    argInstance = ArgumentUtil.BuildArgumentsObject(Schema, Name, this, gqlRequestArgs ?? new Dictionary<string, object>(), Arguments.Values, ArgumentsType, variableParameter, docVariables, validationErrors)!;
+                    argInstance = ArgumentUtil.BuildArgumentsObject(Schema, Name, this, gqlRequestArgs ?? new Dictionary<string, object?>(), Arguments.Values, ArgumentsType, variableParameter, docVariables, validationErrors)!;
                     allArgs.Add(argInstance);
                 }
                 else if (gqlRequestArgs != null && gqlRequestArgs.ContainsKey(p.Name!))
@@ -198,7 +198,7 @@ namespace EntityGraphQL.Schema
             return result;
         }
 
-        public override (Expression? expression, ParameterExpression? argumentParam) GetExpression(Expression fieldExpression, Expression? fieldContext, IGraphQLNode? parentNode, ParameterExpression? schemaContext, CompileContext? compileContext, IReadOnlyDictionary<string, object> args, ParameterExpression? docParam, object? docVariables, IEnumerable<GraphQLDirective> directives, bool contextChanged, ParameterReplacer replacer)
+        public override (Expression? expression, ParameterExpression? argumentParam) GetExpression(Expression fieldExpression, Expression? fieldContext, IGraphQLNode? parentNode, ParameterExpression? schemaContext, CompileContext? compileContext, IReadOnlyDictionary<string, object?> args, ParameterExpression? docParam, object? docVariables, IEnumerable<GraphQLDirective> directives, bool contextChanged, ParameterReplacer replacer)
         {
             var result = fieldExpression;
 

--- a/src/EntityGraphQL/Schema/SchemaGenerator.cs
+++ b/src/EntityGraphQL/Schema/SchemaGenerator.cs
@@ -175,6 +175,10 @@ namespace EntityGraphQL.Schema
                 }
                 return string.Empty;
             }
+            else if (valueType.IsConstructedGenericType && valueType.GetGenericTypeDefinition() == typeof(OptionalField<>))
+            {
+                return string.Empty;
+            }
             else if (value is object o)
             {
                 ret += "{ ";

--- a/src/EntityGraphQL/Schema/Validators/DataAnnotationsValidator.cs
+++ b/src/EntityGraphQL/Schema/Validators/DataAnnotationsValidator.cs
@@ -94,12 +94,12 @@ namespace EntityGraphQL.Schema.Validators
                 {
                     var value = property.GetValue(obj, null);
 
-                    if (property.PropertyType == typeof(string) || property.PropertyType.IsValueType)
+                    if (property.PropertyType == typeof(string) || property.PropertyType.IsPrimitive)
                     {
                         continue;
                     }
 
-                    if (property.PropertyType.GetGenericArguments().Any() && property.PropertyType.GetGenericTypeDefinition() == typeof(RequiredField<>))
+                    if (property.PropertyType.IsGenericType && property.PropertyType.GetGenericArguments().Any() && property.PropertyType.GetGenericTypeDefinition() == typeof(RequiredField<>))
                     {
                         if (value == null)
                         {
@@ -108,7 +108,7 @@ namespace EntityGraphQL.Schema.Validators
                         continue;
                     }
 
-                    if (property.PropertyType.GetGenericArguments().Any() && property.PropertyType.GetGenericTypeDefinition() == typeof(EntityQueryType<>))
+                    if (property.PropertyType.IsGenericType && property.PropertyType.GetGenericArguments().Any() && (property.PropertyType.GetGenericTypeDefinition() == typeof(EntityQueryType<>) || property.PropertyType.GetGenericTypeDefinition() == typeof(OptionalField<>)))
                     {
                         continue;
                     }

--- a/src/tests/EntityGraphQL.Tests/QueryTests/ArgumentTests.cs
+++ b/src/tests/EntityGraphQL.Tests/QueryTests/ArgumentTests.cs
@@ -604,6 +604,69 @@ namespace EntityGraphQL.Tests
             Assert.Equal(2, task2.id);
         }
 
+        [Fact]
+        public void SupportsOptionalArguments_Undefined()
+        {
+            var schema = SchemaBuilder.FromObject<TestDataContext>(new SchemaBuilderOptions { AutoCreateFieldWithIdArguments = false });
+            // Add a argument field with a require parameter
+            schema.Query().AddField("optionalField", new { id = ArgumentHelper.Optional<int>() }, 
+                (ctx, param) => param.id.HasValue,
+                "Return a user by ID"
+            );
+            var tree = new GraphQLCompiler(schema).Compile(@"query {
+        	    optionalField
+            }");
+            
+            dynamic result = tree.ExecuteQuery(new TestDataContext(), null, null);
+
+            Assert.Contains("optionalField(id: Int): Boolean!", schema.ToGraphQLSchemaString());
+
+            // we only have the fields requested
+            Assert.Equal(false, (dynamic)result.Data["optionalField"]);
+        }
+
+        [Fact]
+        public void SupportsOptionalArguments_Null()
+        {
+            var schema = SchemaBuilder.FromObject<TestDataContext>(new SchemaBuilderOptions { AutoCreateFieldWithIdArguments = false });
+            // Add a argument field with a require parameter
+            schema.Query().AddField("optionalField", new { id = ArgumentHelper.Optional<int>() },
+                (ctx, param) => param.id.HasValue,
+                "Return a user by ID"
+            );
+            var tree = new GraphQLCompiler(schema).Compile(@"query {
+        	    optionalField(id: null)
+            }");
+
+            dynamic result = tree.ExecuteQuery(new TestDataContext(), null, null);
+
+            Assert.Contains("optionalField(id: Int): Boolean!", schema.ToGraphQLSchemaString());
+
+            // we only have the fields requested
+            Assert.Equal(true, (dynamic)result.Data["optionalField"]);
+        }
+
+        [Fact]
+        public void SupportsOptionalArguments_Defined()
+        {
+            var schema = SchemaBuilder.FromObject<TestDataContext>(new SchemaBuilderOptions { AutoCreateFieldWithIdArguments = false });
+            // Add a argument field with a require parameter
+            schema.Query().AddField("optionalField", new { id = ArgumentHelper.Optional<int>() },
+                (ctx, param) => param.id.HasValue,
+                "Return a user by ID"
+            );
+            var tree = new GraphQLCompiler(schema).Compile(@"query {
+        	    optionalField(id: 1)
+            }");
+
+            dynamic result = tree.ExecuteQuery(new TestDataContext(), null, null);
+
+            Assert.Contains("optionalField(id: Int): Boolean!", schema.ToGraphQLSchemaString());
+
+            // we only have the fields requested
+            Assert.Equal(true, (dynamic)result.Data["optionalField"]);
+        }
+
         private static void MakePersonIdGuid(SchemaProvider<TestDataContext> schema)
         {
             schema.Query().ReplaceField("person",


### PR DESCRIPTION
Sometimes have the usecase where I want something akin to undefined in javascript that I can treat differently to a null value - for example a nullable date in the database that I don't want to overwrite in a mutation if it's considered undefined.

needs more tests and documentation, but any thought on the direction?