### PR TITLE
bugfix: remove duplicate fields when creating expression

### DIFF
--- a/src/EntityGraphQL/Compiler/Util/ExpressionUtil.cs
+++ b/src/EntityGraphQL/Compiler/Util/ExpressionUtil.cs
@@ -441,7 +441,8 @@ namespace EntityGraphQL.Compiler.Util
 
                 var fieldsOnBaseType = fieldExpressions.Values
                        .Where(i => RootType(i.Expression) == null || RootType(i.Expression)! == currentContextParam.Type || typeof(ISchemaType).IsAssignableFrom(RootType(i.Expression)))
-                       .ToDictionary(i => i.Field.Name, i => i.Expression);
+                       .ToLookup(i => i.Field.Name, i => i.Expression)
+                       .ToDictionary(i => i.Key, i => i.Last());
 
                 // make a query that checks type of object and returns the valid properties for that specific type
                 var baseDynamicType = LinqRuntimeTypeBuilder.GetDynamicType(
@@ -457,7 +458,8 @@ namespace EntityGraphQL.Compiler.Util
                 {
                     var fieldsOnType = fieldExpressions.Values
                        .Where(i => RootType(i.Expression) == null || RootType(i.Expression)!.IsAssignableFrom(type) || typeof(ISchemaType).IsAssignableFrom(RootType(i.Expression)))
-                       .ToDictionary(i => i.Field.Name, i => i.Expression);
+                       .ToLookup(i => i.Field.Name, i => i.Expression)
+                       .ToDictionary(i => i.Key, i => i.Last());
 
                     var memberInit = CreateNewExpression(field.Name, fieldsOnType, out Type dynamicType, parentType: baseDynamicType);
                     if (memberInit == null)

--- a/src/tests/EntityGraphQL.Tests/QueryTests/InheritanceTests.cs
+++ b/src/tests/EntityGraphQL.Tests/QueryTests/InheritanceTests.cs
@@ -64,6 +64,7 @@ query {
 }
 ");
 
+
             var context = new TestAbstractDataContext();
             context.Animals.Add(new Dog() { Name = "steve", HasBone = true });
             context.Animals.Add(new Cat() { Name = "george", Lives = 9 });
@@ -79,6 +80,40 @@ query {
             Assert.Equal("Cat", animals[1].__typename);
             Assert.Equal("george", animals[1].name);
             Assert.Equal(9, animals[1].lives);
+        }
+
+        [Fact]
+        public void TestInheritancDuplicateFields()
+        {
+            var schemaProvider = new TestAbstractDataGraphSchema();
+            var gql = new GraphQLCompiler(schemaProvider).Compile(@"
+query {
+    animals {
+        __typename
+        id        
+        ... on Cat {
+            id
+        }
+        ...on Dog {
+            id
+        }
+    }
+}
+");
+
+            var context = new TestAbstractDataContext();
+            context.Animals.Add(new Dog() { Id = 1, Name = "steve", HasBone = true });
+            context.Animals.Add(new Cat() { Id = 2, Name = "george", Lives = 9 });
+
+            var qr = gql.ExecuteQuery(context, null, null);
+            dynamic animals = qr.Data["animals"];
+            // we only have the fields requested
+            Assert.Equal(2, animals.Count);
+
+            Assert.Equal("Dog", animals[0].__typename);
+            Assert.Equal(1, animals[0].id);
+            Assert.Equal("Cat", animals[1].__typename);
+            Assert.Equal(2, animals[1].id);
         }
 
         [Fact]


### PR DESCRIPTION
when using strawberry shake client it seems to make queries like this without much control, so i guess it make sense to support them
```

query {
    animals {
        __typename
        id        
        ... on Cat {
            id
        }
        ...on Dog {
            id
        }
    }
}
```