### PR TITLE
Fix for mutation when they return interfaces/unions

### DIFF
--- a/src/EntityGraphQL/Compiler/Util/ExpressionUtil.cs
+++ b/src/EntityGraphQL/Compiler/Util/ExpressionUtil.cs
@@ -430,8 +430,10 @@ namespace EntityGraphQL.Compiler.Util
         {
             if (!fieldExpressions.Any())
                 return baseExp;
-           
-            if (field.Field?.ReturnType.SchemaType.GqlType == GqlTypeEnum.Union || field.Field?.ReturnType.SchemaType.GqlType == GqlTypeEnum.Interface)
+
+            //fallback to parent return type for mutations
+            var gqlType = field.Field?.ReturnType.SchemaType.GqlType ?? field.ParentNode?.Field?.ReturnType.SchemaType.GqlType;
+            if (gqlType == GqlTypeEnum.Union || gqlType == GqlTypeEnum.Interface)
             {
                 // get a list of distinct types asked for in the query (fragments for interfaces)
                 var validTypes = fieldExpressions.Values

--- a/src/tests/EntityGraphQL.Tests/QueryTests/InheritanceTests.cs
+++ b/src/tests/EntityGraphQL.Tests/QueryTests/InheritanceTests.cs
@@ -195,31 +195,23 @@ fragment animalFragment on Animal {
 mutation {
     testMutation(id: 1) {
         id
-        ... on Cat {
-            id
-        }
         ... on Dog {
-            id
+            hasBone
         }
     }
 }
 ");
 
             var context = new TestAbstractDataContext();
-            context.Animals.Add(new Dog() { Name = "steve", HasBone = true });
+            context.Animals.Add(new Dog() { Id = 1, Name = "steve", HasBone = true });
             context.Animals.Add(new Cat() { Name = "george", Lives = 9 });
 
             var qr = gql.ExecuteQuery(context, null, null);
-            dynamic animals = qr.Data["testMutation"];
+            dynamic animal = qr.Data["testMutation"];
             // we only have the fields requested
-            Assert.Equal(2, animals.Count);
 
-            Assert.Equal(0, animals[0].id);
-            Assert.Equal("steve", animals[0].name);
-            Assert.True(animals[0].hasBone);
-            Assert.Equal("Cat", animals[1].__typename);
-            Assert.Equal("george", animals[1].name);
-            Assert.Equal(9, animals[1].lives);
+            Assert.Equal(1, animal.id);
+            Assert.True(animal.hasBone);
         }
     }
 }

--- a/src/tests/EntityGraphQL.Tests/TestAbstractDataContext.cs
+++ b/src/tests/EntityGraphQL.Tests/TestAbstractDataContext.cs
@@ -1,4 +1,8 @@
+using EntityGraphQL.Schema;
+using System;
 using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
 
 namespace EntityGraphQL.Tests
 {
@@ -12,6 +16,12 @@ namespace EntityGraphQL.Tests
         public List<Animal> Animals { get; set; } = new List<Animal>();
         public List<Cat> Cats { get; set; } = new List<Cat>();
         public List<Dog> Dogs { get; set; } = new List<Dog>();
+
+        [GraphQLMutation]
+        public Expression<Func<TestAbstractDataContext, Animal>> TestMutation(int id)
+        {
+            return (db) => db.Animals.First();
+        }
     }
 
     public class TestAbstractDataContextNoAnimals


### PR DESCRIPTION
mutations were running the wrong code if they returned an interface/union type