### PR TITLE
Implement whitelisted exceptions

### DIFF
--- a/src/EntityGraphQL/Schema/AllowedException.cs
+++ b/src/EntityGraphQL/Schema/AllowedException.cs
@@ -2,12 +2,12 @@
 
 namespace EntityGraphQL.Schema
 {
-    public class WhitelistedException
+    public class AllowedException
     {
         private readonly Type exceptionType;
         private readonly bool exactMatch;
 
-        public WhitelistedException(Type exceptionType, bool exactMatch = false)
+        public AllowedException(Type exceptionType, bool exactMatch = false)
         {
             this.exceptionType = exceptionType;
             this.exactMatch = exactMatch;

--- a/src/EntityGraphQL/Schema/SchemaProvider.cs
+++ b/src/EntityGraphQL/Schema/SchemaProvider.cs
@@ -45,7 +45,7 @@ namespace EntityGraphQL.Schema
 
         public IDictionary<Type, ICustomTypeConverter> TypeConverters { get; } = new Dictionary<Type, ICustomTypeConverter>();
 
-        public List<WhitelistedException> WhitelistedException { get; } = new();
+        public List<AllowedException> AllowedExceptions { get; } = new();
 
         // map some types to scalar types
         protected Dictionary<Type, GqlTypeInfo> customTypeMappings;
@@ -271,7 +271,7 @@ namespace EntityGraphQL.Schema
                 case EntityGraphQLFieldException fieldException:
                     return GenerateMessage(fieldException.InnerException!).Select(f => ($"Field '{fieldException.FieldName}' - {f.errorMessage}", f.Item2));
                 default:
-                    if (isDevelopment || exception is IExposableException || WhitelistedException.Any(e => e.IsAllowed(exception)))
+                    if (isDevelopment || exception is IExposableException || AllowedExceptions.Any(e => e.IsAllowed(exception)))
                         return new[] { (exception.Message, (IDictionary<string, object>?)null) };
                     return new[] { ("Error occurred", (IDictionary<string, object>?)null) };
             }

--- a/src/EntityGraphQL/Schema/SchemaProvider.cs
+++ b/src/EntityGraphQL/Schema/SchemaProvider.cs
@@ -45,6 +45,8 @@ namespace EntityGraphQL.Schema
 
         public IDictionary<Type, ICustomTypeConverter> TypeConverters { get; } = new Dictionary<Type, ICustomTypeConverter>();
 
+        public List<WhitelistedException> WhitelistedException { get; } = new();
+
         // map some types to scalar types
         protected Dictionary<Type, GqlTypeInfo> customTypeMappings;
         public SchemaProvider() : this(null, null) { }
@@ -269,7 +271,7 @@ namespace EntityGraphQL.Schema
                 case EntityGraphQLFieldException fieldException:
                     return GenerateMessage(fieldException.InnerException!).Select(f => ($"Field '{fieldException.FieldName}' - {f.errorMessage}", f.Item2));
                 default:
-                    if (isDevelopment || exception is IExposableException)
+                    if (isDevelopment || exception is IExposableException || WhitelistedException.Any(e => e.IsAllowed(exception)))
                         return new[] { (exception.Message, (IDictionary<string, object>?)null) };
                     return new[] { ("Error occurred", (IDictionary<string, object>?)null) };
             }

--- a/src/EntityGraphQL/Schema/WhitelistedException.cs
+++ b/src/EntityGraphQL/Schema/WhitelistedException.cs
@@ -1,0 +1,22 @@
+﻿using System;
+
+namespace EntityGraphQL.Schema
+{
+    public class WhitelistedException
+    {
+        private readonly Type exceptionType;
+        private readonly bool exactMatch;
+
+        public WhitelistedException(Type exceptionType, bool exactMatch = false)
+        {
+            this.exceptionType = exceptionType;
+            this.exactMatch = exactMatch;
+        }
+
+        public bool IsAllowed(Exception ex)
+        {
+            if (exactMatch) return ex.GetType() == exceptionType;
+            return exceptionType.IsInstanceOfType(ex);
+        }
+    }
+}

--- a/src/tests/EntityGraphQL.Tests/ErrorTests.cs
+++ b/src/tests/EntityGraphQL.Tests/ErrorTests.cs
@@ -1,3 +1,4 @@
+using System;
 using Xunit;
 using EntityGraphQL.Schema;
 
@@ -168,6 +169,120 @@ namespace EntityGraphQL.Tests
             {
                 Query = @"{
     people { error_UnexposedException }
+}",
+            };
+
+            var testSchema = new TestDataContext().FillWithTestData();
+            var results = schemaProvider.ExecuteRequest(gql, testSchema, null, null);
+            Assert.NotNull(results.Errors);
+            Assert.Equal("Field 'people' - You should not see this message outside of Development", results.Errors[0].Message);
+        }
+
+        [Fact]
+        public void QueryReportsError_UnexposedException_WithWhitelist()
+        {
+            var schemaProvider = SchemaBuilder.FromObject<TestDataContext>(new SchemaBuilderSchemaOptions { IsDevelopment = false });
+            schemaProvider.WhitelistedException.Add(new WhitelistedException(typeof(Exception)));
+            // Add a argument field with a require parameter
+            var gql = new QueryRequest
+            {
+                Query = @"{
+    people { error_UnexposedArgumentException }
+}",
+            };
+
+            var testSchema = new TestDataContext().FillWithTestData();
+            var results = schemaProvider.ExecuteRequest(gql, testSchema, null, null);
+            Assert.NotNull(results.Errors);
+            Assert.Equal("Field 'people' - You should not see this message outside of Development", results.Errors[0].Message);
+        }
+
+        [Fact]
+        public void QueryReportsError_UnexposedException_WithWhitelist_Development()
+        {
+            var schemaProvider = SchemaBuilder.FromObject<TestDataContext>();
+            schemaProvider.WhitelistedException.Add(new WhitelistedException(typeof(Exception)));
+            // Add a argument field with a require parameter
+            var gql = new QueryRequest
+            {
+                Query = @"{
+    people { error_UnexposedArgumentException }
+}",
+            };
+
+            var testSchema = new TestDataContext().FillWithTestData();
+            var results = schemaProvider.ExecuteRequest(gql, testSchema, null, null);
+            Assert.NotNull(results.Errors);
+            Assert.Equal("Field 'people' - You should not see this message outside of Development", results.Errors[0].Message);
+        }
+
+        [Fact]
+        public void QueryReportsError_UnexposedException_Exact_WithWhitelist()
+        {
+            var schemaProvider = SchemaBuilder.FromObject<TestDataContext>(new SchemaBuilderSchemaOptions { IsDevelopment = false });
+            schemaProvider.WhitelistedException.Add(new WhitelistedException(typeof(ArgumentException), true));
+            // Add a argument field with a require parameter
+            var gql = new QueryRequest
+            {
+                Query = @"{
+    people { error_UnexposedArgumentException }
+}",
+            };
+
+            var testSchema = new TestDataContext().FillWithTestData();
+            var results = schemaProvider.ExecuteRequest(gql, testSchema, null, null);
+            Assert.NotNull(results.Errors);
+            Assert.Equal("Field 'people' - You should not see this message outside of Development", results.Errors[0].Message);
+        }
+
+        [Fact]
+        public void QueryReportsError_UnexposedException_WithWhitelist_Exact_Development()
+        {
+            var schemaProvider = SchemaBuilder.FromObject<TestDataContext>();
+            schemaProvider.WhitelistedException.Add(new WhitelistedException(typeof(ArgumentException), true));
+            // Add a argument field with a require parameter
+            var gql = new QueryRequest
+            {
+                Query = @"{
+    people { error_UnexposedArgumentException }
+}",
+            };
+
+            var testSchema = new TestDataContext().FillWithTestData();
+            var results = schemaProvider.ExecuteRequest(gql, testSchema, null, null);
+            Assert.NotNull(results.Errors);
+            Assert.Equal("Field 'people' - You should not see this message outside of Development", results.Errors[0].Message);
+        }
+
+        [Fact]
+        public void QueryReportsError_UnexposedException_Exact_Mismatch_WithWhitelist()
+        {
+            var schemaProvider = SchemaBuilder.FromObject<TestDataContext>(new SchemaBuilderSchemaOptions { IsDevelopment = false });
+            schemaProvider.WhitelistedException.Add(new WhitelistedException(typeof(Exception), true));
+            // Add a argument field with a require parameter
+            var gql = new QueryRequest
+            {
+                Query = @"{
+    people { error_UnexposedArgumentException }
+}",
+            };
+
+            var testSchema = new TestDataContext().FillWithTestData();
+            var results = schemaProvider.ExecuteRequest(gql, testSchema, null, null);
+            Assert.NotNull(results.Errors);
+            Assert.Equal("Field 'people' - Error occurred", results.Errors[0].Message);
+        }
+
+        [Fact]
+        public void QueryReportsError_UnexposedException_WithWhitelist_Exact_Mismatch_Development()
+        {
+            var schemaProvider = SchemaBuilder.FromObject<TestDataContext>();
+            schemaProvider.WhitelistedException.Add(new WhitelistedException(typeof(Exception), true));
+            // Add a argument field with a require parameter
+            var gql = new QueryRequest
+            {
+                Query = @"{
+    people { error_UnexposedArgumentException }
 }",
             };
 

--- a/src/tests/EntityGraphQL.Tests/ErrorTests.cs
+++ b/src/tests/EntityGraphQL.Tests/ErrorTests.cs
@@ -182,7 +182,7 @@ namespace EntityGraphQL.Tests
         public void QueryReportsError_UnexposedException_WithWhitelist()
         {
             var schemaProvider = SchemaBuilder.FromObject<TestDataContext>(new SchemaBuilderSchemaOptions { IsDevelopment = false });
-            schemaProvider.WhitelistedException.Add(new WhitelistedException(typeof(Exception)));
+            schemaProvider.AllowedExceptions.Add(new AllowedException(typeof(Exception)));
             // Add a argument field with a require parameter
             var gql = new QueryRequest
             {
@@ -201,7 +201,7 @@ namespace EntityGraphQL.Tests
         public void QueryReportsError_UnexposedException_WithWhitelist_Development()
         {
             var schemaProvider = SchemaBuilder.FromObject<TestDataContext>();
-            schemaProvider.WhitelistedException.Add(new WhitelistedException(typeof(Exception)));
+            schemaProvider.AllowedExceptions.Add(new AllowedException(typeof(Exception)));
             // Add a argument field with a require parameter
             var gql = new QueryRequest
             {
@@ -220,7 +220,7 @@ namespace EntityGraphQL.Tests
         public void QueryReportsError_UnexposedException_Exact_WithWhitelist()
         {
             var schemaProvider = SchemaBuilder.FromObject<TestDataContext>(new SchemaBuilderSchemaOptions { IsDevelopment = false });
-            schemaProvider.WhitelistedException.Add(new WhitelistedException(typeof(ArgumentException), true));
+            schemaProvider.AllowedExceptions.Add(new AllowedException(typeof(ArgumentException), true));
             // Add a argument field with a require parameter
             var gql = new QueryRequest
             {
@@ -239,7 +239,7 @@ namespace EntityGraphQL.Tests
         public void QueryReportsError_UnexposedException_WithWhitelist_Exact_Development()
         {
             var schemaProvider = SchemaBuilder.FromObject<TestDataContext>();
-            schemaProvider.WhitelistedException.Add(new WhitelistedException(typeof(ArgumentException), true));
+            schemaProvider.AllowedExceptions.Add(new AllowedException(typeof(ArgumentException), true));
             // Add a argument field with a require parameter
             var gql = new QueryRequest
             {
@@ -258,7 +258,7 @@ namespace EntityGraphQL.Tests
         public void QueryReportsError_UnexposedException_Exact_Mismatch_WithWhitelist()
         {
             var schemaProvider = SchemaBuilder.FromObject<TestDataContext>(new SchemaBuilderSchemaOptions { IsDevelopment = false });
-            schemaProvider.WhitelistedException.Add(new WhitelistedException(typeof(Exception), true));
+            schemaProvider.AllowedExceptions.Add(new AllowedException(typeof(Exception), true));
             // Add a argument field with a require parameter
             var gql = new QueryRequest
             {
@@ -277,7 +277,7 @@ namespace EntityGraphQL.Tests
         public void QueryReportsError_UnexposedException_WithWhitelist_Exact_Mismatch_Development()
         {
             var schemaProvider = SchemaBuilder.FromObject<TestDataContext>();
-            schemaProvider.WhitelistedException.Add(new WhitelistedException(typeof(Exception), true));
+            schemaProvider.AllowedExceptions.Add(new AllowedException(typeof(Exception), true));
             // Add a argument field with a require parameter
             var gql = new QueryRequest
             {

--- a/src/tests/EntityGraphQL.Tests/SortTests/SortTests.cs
+++ b/src/tests/EntityGraphQL.Tests/SortTests/SortTests.cs
@@ -168,7 +168,7 @@ namespace EntityGraphQL.Tests
             Assert.Equal("Zoo", person.lastName);
             var schemaType = schema.Type("PeopleSortInput");
             var fields = schemaType.GetFields().ToList();
-            Assert.Equal(11, fields.Count);
+            Assert.Equal(12, fields.Count);
             Assert.Contains("people(sort: [PeopleSortInput!] = [{ height: ASC }]): [Person!]", schema.ToGraphQLSchemaString());
         }
         [Fact]

--- a/src/tests/EntityGraphQL.Tests/TestDataContext.cs
+++ b/src/tests/EntityGraphQL.Tests/TestDataContext.cs
@@ -89,6 +89,11 @@ namespace EntityGraphQL.Tests
             get => throw new Exception("You should not see this message outside of Development"); set => throw new Exception("You should not see this message outside of Development");
         }
 
+        public string Error_UnexposedArgumentException
+        {
+            get => throw new ArgumentException("You should not see this message outside of Development"); set => throw new ArgumentException("You should not see this message outside of Development");
+        }
+
         public string Error_AggregateException
         {
             get => throw new AggregateException(Enumerable.Range(0, 2).Select(_ => new Exception("You should not see this message outside of Development")));


### PR DESCRIPTION
Related to #270  

This change allows consumers of the library to specify whitelisted exceptions on top of the provided `IExposableException`.

This is required because users may not be able to modify the exceptions being thrown in order to have them implement `IExposableException`.

Exceptions may be whitelisted with an exact type match, or whitelisted including all types that inherit it.