### PR TITLE
ExpressionUtil.ChangeType support implicit operators

### DIFF
--- a/src/EntityGraphQL/Compiler/Util/ExpressionUtil.cs
+++ b/src/EntityGraphQL/Compiler/Util/ExpressionUtil.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Linq.Expressions;
+using System.Reflection;
 using System.Text.Json;
 using EntityGraphQL.Compiler.EntityQuery;
 using EntityGraphQL.Extensions;
@@ -208,9 +209,16 @@ namespace EntityGraphQL.Compiler.Util
             }
             if (argumentNonNullType != valueNonNullType)
             {
+                var implicitCastOperator = argumentNonNullType.GetMethod("op_Implicit", new[] { valueNonNullType });
+                if (implicitCastOperator !=  null)
+                {
+                    return implicitCastOperator.Invoke(null, new[] { value });
+                }
+          
                 var newVal = Convert.ChangeType(value, argumentNonNullType);
                 return newVal;
-            }
+            }            
+
             return value;
         }
 

--- a/src/tests/EntityGraphQL.Tests/ChangeTypeTests.cs
+++ b/src/tests/EntityGraphQL.Tests/ChangeTypeTests.cs
@@ -77,4 +77,30 @@ public class ChangeTypeTests
         var res = ExpressionUtil.ChangeType(null, typeof(decimal?), null);
         Assert.Equal((decimal?)null, res);
     }
+
+    [Fact]
+    public void TestImplicitOperator()
+    {
+        var res = ExpressionUtil.ChangeType(3, typeof(ImplicitOperatorConversionTest), null);
+        Assert.NotNull(res);
+    }
+
+    public struct ImplicitOperatorConversionTest
+    {
+        public ImplicitOperatorConversionTest(int value)
+        {
+            Value = value;
+        }
+
+        public int Value { get; }
+
+        /// <summary>
+        /// Converts the given TValue into an Optional(TValue)
+        /// </summary>
+        /// <param name="value"></param>
+        public static implicit operator ImplicitOperatorConversionTest(int value)
+        {
+            return new ImplicitOperatorConversionTest(value);
+        }
+    }
 }


### PR DESCRIPTION
Detect and use implict cast operatiors - useful for using something like https://github.com/Foritus/optional-dot-net in input types