### PR TITLE
#288 - fixing stack overflow in runtimejsonconverter

### DIFF
--- a/src/EntityGraphQL.AspNet/Extensions/RuntimeTypeJsonConverter.cs
+++ b/src/EntityGraphQL.AspNet/Extensions/RuntimeTypeJsonConverter.cs
@@ -46,7 +46,7 @@ namespace EntityGraphQL.AspNet.Extensions
             }
             else //otherwise just call the default serializer implementation of this Converter is asked to serialize anything not handled in the other two cases
             {
-                JsonSerializer.Serialize(writer, value, options);
+                JsonSerializer.Serialize(writer, value, value!.GetType(), options);
             }
         }
 

--- a/src/tests/EntityGraphQL.AspNet.Tests/RuntimeTypeJsonConverterTests.cs
+++ b/src/tests/EntityGraphQL.AspNet.Tests/RuntimeTypeJsonConverterTests.cs
@@ -1,9 +1,11 @@
 ﻿using EntityGraphQL.AspNet.Extensions;
+using EntityGraphQL.Schema.FieldExtensions;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -11,9 +13,16 @@ namespace EntityGraphQL.AspNet.Tests
 {
     public class RuntimeTypeJsonConverterTests
     {
+        public enum Enum
+        {
+            First,
+            Second
+        }
+
         public class BaseClass
         {
             public int Id { get; set; }
+            public Enum E { get; set; }
         }
 
         public class SubClass : BaseClass
@@ -27,24 +36,118 @@ namespace EntityGraphQL.AspNet.Tests
         {
             BaseClass item = new SubClass() { Id = 1, Name = "Fred", NameField = "Included" };
             var result = System.Text.Json.JsonSerializer.Serialize(item);
-            Assert.Equal("{\"Id\":1}", result);
+            Assert.Equal("{\"Id\":1,\"E\":0}", result);
 
             var options = new JsonSerializerOptions();
             options.Converters.Add(new RuntimeTypeJsonConverter());
             result = System.Text.Json.JsonSerializer.Serialize(item, options);
-            Assert.Equal("{\"Name\":\"Fred\",\"Id\":1}", result);
+            Assert.Equal("{\"Name\":\"Fred\",\"Id\":1,\"E\":0}", result);
 
             options = new JsonSerializerOptions();
             options.Converters.Add(new RuntimeTypeJsonConverter());
             options.IncludeFields = true;
             result = System.Text.Json.JsonSerializer.Serialize(item, options);
-            Assert.Equal("{\"Name\":\"Fred\",\"Id\":1,\"NameField\":\"Included\"}", result);
+            Assert.Equal("{\"Name\":\"Fred\",\"Id\":1,\"E\":0,\"NameField\":\"Included\"}", result);
 
             var graphqlResponseSerializer = new DefaultGraphQLResponseSerializer();
             var memoryStream = new MemoryStream();
             graphqlResponseSerializer.SerializeAsync(memoryStream, item);
             result = Encoding.ASCII.GetString(memoryStream.ToArray());
-            Assert.Equal("{\"Name\":\"Fred\",\"Id\":1,\"NameField\":\"Included\"}", result);
+            Assert.Equal("{\"Name\":\"Fred\",\"Id\":1,\"E\":\"First\",\"NameField\":\"Included\"}", result);
+        }
+
+        [Fact]
+        public void SerializeOffsetPage()
+        {
+            var item = new OffsetPage<SubClass>(0, 0, 10) { Items = new List<SubClass>() };
+
+            var graphqlResponseSerializer = new DefaultGraphQLResponseSerializer();
+            var memoryStream = new MemoryStream();
+            graphqlResponseSerializer.SerializeAsync(memoryStream, item);
+            var result = Encoding.ASCII.GetString(memoryStream.ToArray());
+
+            Assert.Equal("{\"Items\":[],\"HasPreviousPage\":false,\"HasNextPage\":false,\"TotalItems\":0}", result);
+        }
+
+        [Fact]
+        public void SerializeDynamicOffsetPage()
+        {
+            dynamic item = new { items = new List<SubClass>(), hasNextPage = false };
+
+            var graphqlResponseSerializer = new DefaultGraphQLResponseSerializer();
+            var memoryStream = new MemoryStream();
+            graphqlResponseSerializer.SerializeAsync(memoryStream, item);
+            var result = Encoding.ASCII.GetString(memoryStream.ToArray());
+
+            Assert.Equal("{\"items\":[],\"hasNextPage\":false}", result);
+        }
+
+        struct Test
+        {
+            public List<SubClass> items;
+            public bool hasNextPage;
+        }
+
+        [Fact]
+        public void SerializeStruct()
+        {
+            dynamic item = new Test { items = new List<SubClass>(), hasNextPage = false };
+
+            var graphqlResponseSerializer = new DefaultGraphQLResponseSerializer();
+            var memoryStream = new MemoryStream();
+            graphqlResponseSerializer.SerializeAsync(memoryStream, item);
+            var result = Encoding.ASCII.GetString(memoryStream.ToArray());
+
+            Assert.Equal("{\"items\":[],\"hasNextPage\":false}", result);
+        }
+
+        [Fact]
+        public void SerializeDictionary()
+        {
+            dynamic item = new Dictionary<string, object>() { { "test", new Test { items = new List<SubClass>(), hasNextPage = false } } };
+
+            var graphqlResponseSerializer = new DefaultGraphQLResponseSerializer();
+            var memoryStream = new MemoryStream();
+            graphqlResponseSerializer.SerializeAsync(memoryStream, item);
+            var result = Encoding.ASCII.GetString(memoryStream.ToArray());
+
+            Assert.Equal("{\"test\":{\"items\":[],\"hasNextPage\":false}}", result);
+        }
+
+        [Fact]
+        public void SerializeBoolean()
+        {
+            var item = new { value = false};
+
+            var options = new JsonSerializerOptions
+            {
+                IncludeFields = true,
+                PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            };
+            options.Converters.Add(new JsonStringEnumConverter());
+            options.Converters.Add(new RuntimeTypeJsonConverter());
+
+            var result = System.Text.Json.JsonSerializer.Serialize(item, options);
+            Assert.Equal("{\"value\":false}", result);
+        }
+
+
+        [Fact]
+        public void SerializeNestedObject()
+        {
+            var item = new { child = new { value = 3.4 } };
+
+            var options = new JsonSerializerOptions
+            {
+                IncludeFields = true,
+                PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            };
+            options.Converters.Add(new JsonStringEnumConverter());
+            options.Converters.Add(new RuntimeTypeJsonConverter());
+            options.IncludeFields = true;
+
+            var result = System.Text.Json.JsonSerializer.Serialize(item, options);
+            Assert.Equal("{\"child\":{\"value\":3.4}}", result);
         }
 
         [Fact]
@@ -57,7 +160,7 @@ namespace EntityGraphQL.AspNet.Tests
                     "users",
                     new List<SubClass>() {
                           new SubClass() { Id = 1, Name = "Fred", NameField = "Included" },
-                          new SubClass() { Id = 2, Name = "Wilma", NameField = null }
+                          new SubClass() { Id = 2, Name = "Wilma", NameField = null, E = Enum.Second }
                     }
                 }
             });
@@ -66,7 +169,7 @@ namespace EntityGraphQL.AspNet.Tests
             var memoryStream = new MemoryStream();
             graphqlResponseSerializer.SerializeAsync(memoryStream, item);
             var result = Encoding.ASCII.GetString(memoryStream.ToArray());
-            Assert.Equal("{\"data\":{\"users\":[{\"Name\":\"Fred\",\"Id\":1,\"NameField\":\"Included\"},{\"Name\":\"Wilma\",\"Id\":2}]}}", result);
+            Assert.Equal("{\"data\":{\"users\":[{\"Name\":\"Fred\",\"Id\":1,\"E\":\"First\",\"NameField\":\"Included\"},{\"Name\":\"Wilma\",\"Id\":2,\"E\":\"Second\"}]}}", result);
         }
 
     }


### PR DESCRIPTION
for #288 
* added some extra tests - none replicated the issue, had to verify the fix by referencing in the example project
* this is one of 3 possible fixes i found

1) remove RuntimeJsonConverter from options on nested calls
2) detect isPrimitive like we do with 'is string' and handle it separately
3) (this fix) pass the type down to the serialize function 

