### PR TITLE
ResolveWithService being called twice due to Expression.Condition 

### DIFF
--- a/src/tests/EntityGraphQL.Tests/QueryTests/QueryTests.cs
+++ b/src/tests/EntityGraphQL.Tests/QueryTests/QueryTests.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using EntityGraphQL.Schema;
 using EntityGraphQL.Compiler;
 using System.Collections.Generic;
+using Newtonsoft.Json;
 
 namespace EntityGraphQL.Tests
 {
@@ -416,7 +417,7 @@ query {
             Assert.Equal(1, v);
 
         }
-
+     
         [Fact]
         public void TestResolveWithServiceEvaluatesOnceForEnumerables()
         {
@@ -444,6 +445,34 @@ query {
 
             var results = schema.ExecuteRequest(gql, testSchema, null, null);
             Assert.Equal(1, v);
+        }
+
+
+        public class UserDbContext
+        {
+            public List<string> UserIds { get; set; }
+        }
+
+
+
+        /// <summary>
+        /// from issue https://github.com/EntityGraphQL/EntityGraphQL/issues/221
+        /// </summary>
+        [Fact]
+        public void TestForExtractingDataFromICollectionListEtcThrowsExceptionWhenNull_221()
+        {
+            var schema = SchemaBuilder.FromObject<UserDbContext>();
+
+            var testSchema = new UserDbContext() {  };
+
+            var gql = new QueryRequest
+            {
+                Query = @"query deep { userIds }",
+            };
+
+            var results = schema.ExecuteRequest(gql, testSchema, null, null);
+            Assert.NotNull(((dynamic)results.Data)["userIds"]);
+            Assert.Empty(((dynamic)results.Data)["userIds"]);
         }
     }
 


### PR DESCRIPTION
the fix for #221 added a expression.condition, this accidentally evaluates ResolveWithService calls twice which can make multiple db requests.

Using Expression.Coalesce is a better choice but does mean we need to return an empty list instead of null (don't think that's a bad thing but it is a change).