### PR TITLE
Changes to Method Argument Reflection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - `SchemaBuilderMethodOptions` removed, see updated properties on `SchemaBuilderOptions` and upgrade docs. This was because you can also now add methods ad query fields with `GraphQLFieldAttribute`
 - `SchemaBuilderOptions.AutoCreateInputTypes` now defaults to `true`. Meaning in `SchemaBuilder` when adding mutations etc any complex types will be added to the schema if they are not there already.
 - The rules for reflection on method parameters have been changed to make them clearer. Teh the upgrade to 5.0 docs and the mutation docs that cover examples.
+- `GraphQLValidator` is no longer magically added to your method fields (mutations/subscriptions). If you wish to use it please register it in your services. There is a new helper method in EntityGraphQL.AspNet `AddGraphQLValidator()`
 
 ## Changes
 
@@ -16,6 +17,7 @@
 - Introduce `GraphQLFieldAttribute` to allow you to rename fields in the schema as well as mark methods are fields in the schema. Method parameters will become field arguments in the same way as mutation methods. See updated docs for more information.
 - Argument types used for directvies now read `DescriptionAttribute` and `GraphQLFieldAttribute` to use different field name in the schema and set a description
 - Added `GraphQLInputTypeAttribute`. Whereas `GraphQLArgumentsAttribute` flattens the types properties into the schema, `GraphQLInputTypeAttribute` assumes the type is an input type and uses that as the schema argument
+- You may implement you own `GraphQLValidator` by implementing (and registering) `IGraphQLValidator`
 
 ## Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,14 @@
 -  `IDirectiveProcessor` interface has changed. See upgrade docs for changes
 - `SchemaBuilderMethodOptions` removed, see updated properties on `SchemaBuilderOptions` and upgrade docs. This was because you can also now add methods ad query fields with `GraphQLFieldAttribute`
 - `SchemaBuilderOptions.AutoCreateInputTypes` now defaults to `true`. Meaning in `SchemaBuilder` when adding mutations etc any complex types will be added to the schema if they are not there already.
+- The rules for reflection on method parameters have been changed to make them clearer. Teh the upgrade to 5.0 docs and the mutation docs that cover examples.
 
 ## Changes
 
 - `EntityGraphQL` (the core implementation) targets both `netstandard2.1` & `net6`. `netstandard2.1` will be dropped around the time of `net8.0` being released.
 - Introduce `GraphQLFieldAttribute` to allow you to rename fields in the schema as well as mark methods are fields in the schema. Method parameters will become field arguments in the same way as mutation methods. See updated docs for more information.
 - Argument types used for directvies now read `DescriptionAttribute` and `GraphQLFieldAttribute` to use different field name in the schema and set a description
+- Added `GraphQLInputTypeAttribute`. Whereas `GraphQLArgumentsAttribute` flattens the types properties into the schema, `GraphQLInputTypeAttribute` assumes the type is an input type and uses that as the schema argument
 
 ## Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - #254 - Previously passing `null` for the `ClaimsPrincipal` in `ExecuteRequest()` would skip any authorization checks. All authorization checks are now done regardless of the `ClaimsPrincipal` value. Meaning `null` will fail if there is fields requiring authorization.
 -  `IDirectiveProcessor` interface has changed. See upgrade docs for changes
 - `SchemaBuilderMethodOptions` removed, see updated properties on `SchemaBuilderOptions` and upgrade docs. This was because you can also now add methods ad query fields with `GraphQLFieldAttribute`
+- `SchemaBuilderOptions.AutoCreateInputTypes` now defaults to `true`. Meaning in `SchemaBuilder` when adding mutations etc any complex types will be added to the schema if they are not there already.
 
 ## Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,15 +6,15 @@
 - Interface `IExposableException` has been removed. Use `SchemaBuilderSchemaOptions.AllowedExceptions` or the new `AllowedExceptionAttribute` to define which exceptions are rendered into the results
 - #254 - Previously passing `null` for the `ClaimsPrincipal` in `ExecuteRequest()` would skip any authorization checks. All authorization checks are now done regardless of the `ClaimsPrincipal` value. Meaning `null` will fail if there is fields requiring authorization.
 -  `IDirectiveProcessor` interface has changed. See upgrade docs for changes
-- `SchemaBuilderMethodOptions` removed, see updated properties on `SchemaBuilderOptions` and upgrade docs. This was because you can also now add methods ad query fields with `GraphQLFieldAttribute`
+- `SchemaBuilderMethodOptions` removed, see updated properties on `SchemaBuilderOptions` and upgrade docs. This was because you can also now add methods as query fields with `GraphQLFieldAttribute`
 - `SchemaBuilderOptions.AutoCreateInputTypes` now defaults to `true`. Meaning in `SchemaBuilder` when adding mutations etc any complex types will be added to the schema if they are not there already.
-- The rules for reflection on method parameters have been changed to make them clearer. Teh the upgrade to 5.0 docs and the mutation docs that cover examples.
-- `GraphQLValidator` is no longer magically added to your method fields (mutations/subscriptions). If you wish to use it please register it in your services. There is a new helper method in EntityGraphQL.AspNet `AddGraphQLValidator()`
+- The rules for reflection on method parameters have been changed to make them clearer. See the upgrade to 5.0 docs and the mutation docs that cover examples.
+- `GraphQLValidator` is no longer magically added to your method fields (mutations/subscriptions). If you wish to use it please register it in your services. There is a new helper method in EntityGraphQL.AspNet `AddGraphQLValidator()`. This means you can implement and register your own implementation.
 
 ## Changes
 
-- `EntityGraphQL` (the core implementation) targets both `netstandard2.1` & `net6`. `netstandard2.1` will be dropped around the time of `net8.0` being released.
-- Introduce `GraphQLFieldAttribute` to allow you to rename fields in the schema as well as mark methods are fields in the schema. Method parameters will become field arguments in the same way as mutation methods. See updated docs for more information.
+- `EntityGraphQL` (the core library) targets both `netstandard2.1` & `net6`. `netstandard2.1` will be dropped around the time of `net8.0` being released.
+- Introduced `GraphQLFieldAttribute` to allow you to rename fields in the schema as well as mark methods as fields in the schema. Method parameters will become field arguments in the same way as mutation methods. See updated docs for more information.
 - Argument types used for directvies now read `DescriptionAttribute` and `GraphQLFieldAttribute` to use different field name in the schema and set a description
 - Added `GraphQLInputTypeAttribute`. Whereas `GraphQLArgumentsAttribute` flattens the types properties into the schema, `GraphQLInputTypeAttribute` assumes the type is an input type and uses that as the schema argument
 - You may implement you own `GraphQLValidator` by implementing (and registering) `IGraphQLValidator`

--- a/docs/docs/schema-creation/mutations.md
+++ b/docs/docs/schema-creation/mutations.md
@@ -205,6 +205,8 @@ EntityGraphQL needs to build a schema for output and introspection. We do not kn
 
 We know `DemoContext` is the root query context of the schema so that will not be included as an argument in the schema. Between the other 2 we need to tell EntityGraphQL.
 
+When looking for a methods parameters, EntityGraphQL will
+
 1. First all scalar / non-complex types will be added at arguments in the schema.
 
 2. If parameter type or enum type is already in the schema it will be added at an argument.

--- a/docs/docs/schema-creation/mutations.md
+++ b/docs/docs/schema-creation/mutations.md
@@ -187,9 +187,99 @@ class PeopleMutations(IDemoService demoService)
 
 Later we'll learn how to access services within query fields of the schema.
 
-### `GraphQLArguments` classes
+### Service vs. Schema Argument
 
-Depending on the complexity of your mutation you may end up with many method arguments to build the mutation field schema arguments. Consider a mutation that creates an object and lets you pass all the properties in.
+Given the example
+
+```cs
+public Expression<Func<DemoContext, Person>> AddPerson(DemoContext db, AddPersonArgs args, string token, IDemoService demoService) {}
+
+public class AddPersonArgs
+{
+  public String FirstName { get; set; }
+  public String LastName { get; set; }
+}
+```
+
+EntityGraphQL needs to build a schema for output and introspection. We do not know the services registered until we execute a query. Therefore EntityGraphQL provides a few options for you to help define your schema.
+
+We know `DemoContext` is the root query context of the schema so that will not be included as an argument in the schema. Between the other 2 we need to tell EntityGraphQL.
+
+1. First all scalar / non-complex types will be added at arguments in the schema.
+
+2. If parameter type or enum type is already in the schema it will be added at an argument.
+
+2. Any argument or type with `GraphQLInputTypeAttribute` or `GraphQLArgumentsAttribute` found will be added as schema arguments.
+
+3. If no attributes are found it will assume they are services and not add them to the schema. *I.e. Label your arguments with the attributes or add them to the schema beforehand.*
+
+These rules are also used for subscription methods and query field methods defined with `GraphQLFieldAttribute`.
+
+#### Example: No attributes
+
+```cs
+public Expression<Func<DemoContext, Person>> AddPerson(DemoContext db, AddPersonArgs args, string token, IDemoService demoService) {}
+```
+
+Will incorrectly try to make a schema
+
+```graphql
+type Mutation {
+  addPerson(args: AddPersonArgs, token: String, demoService: IDemoService)
+}
+```
+
+This is not what we want and will likely fail on creation unless you also set the other types.
+
+_Note this is fine if you have no DI services in your mutation methods._
+
+#### Example: `GraphQLArgumentsAttribute`
+
+Note the `s` in Argumentments.
+
+```cs
+public Expression<Func<DemoContext, Person>> AddPerson(DemoContext db, [GraphQLArguments] AddPersonArgs args, string token, IDemoService demoService) {}
+```
+
+Will correctly make the below schema as we know what is in the schema and what is not.
+
+```graphql
+type Mutation {
+  addPerson(
+    firstName: String
+    lastName: String
+    token: String
+  )
+}
+```
+
+`GraphQLArgumentsAttribute` puts all of the properties from that class as top level arguments in the GraphQL schema.
+
+#### Example: `GraphQLInputTypeAttribute`
+
+```cs
+public Expression<Func<DemoContext, Person>> AddPerson(DemoContext db, [GraphQLArgument] AddPersonArgs args, string token, IDemoService demoService) {}
+```
+
+Will correctly make the below schema as we know what is in the schema and what is not.
+
+```graphql
+type Mutation {
+  addPerson(
+    args: AddPersonArgs
+    token: String
+  )
+}
+
+# ...
+input type AddPersonArgs {}
+```
+
+`GraphQLInputTypeAttribute` puts all that class as top level argument in the GraphQL schema. If `AutoCreateNewComplexTypes` is true (default) `AddPersonArgs` will be added as an input type. Otherwise you will need to add this yourself.
+
+`GraphQLInputTypeAttribute` and `GraphQLArgumentsAttribute` can also be defined on the class instead of inline on the method parameters. They give you options to encapsulate arguments by grouping them and reusing them while letting you define how they appear in the schema.
+
+Depending on the complexity of your mutation and the design of your schema will determine which method best suits you. You may end up with many method arguments to build the mutation field schema arguments. Consider a mutation that creates an object and lets you pass all the properties in.
 
 ```cs
 [GraphQLMutation("Add a new person to the system.")]
@@ -216,7 +306,7 @@ public Expression<Func<DemoContext, Person>> AddNewPerson(DemoContext db, AddPer
     // use args.*
 }
 
-[GraphQLArguments]
+[GraphQLArguments] // or [GraphQLArgument] if you want the AddPersonArgs as an input type
 public class AddPersonArgs
 {
     public String FirstName { get; set; }

--- a/docs/docs/upgrade-5-0.md
+++ b/docs/docs/upgrade-5-0.md
@@ -12,7 +12,7 @@ You can see the full changelog which includes other changes and bug fixes as wel
 
 ## Changes to Method Argument Reflection
 
-Previously if `AutoCreateInputTypes` was enabled we didn't know if a parameter should be a GraphQL argument or an injected service unless you used `[GraphQLArguments]`. But this meant you couldn't have complex types as parameters in the method and have them reflected in the schema (`[GraphQLArguments]` flattens the arguments in the schema). This has been refactored to be predictable. 
+Previously if `AutoCreateInputTypes` was enabled we didn't know if a parameter should be a GraphQL argument or an injected service unless you used `[GraphQLArguments]`. But this meant you couldn't have complex types as parameters in the method and have them reflected in the schema (`[GraphQLArguments]` flattens the properties in the schema as arguments). This has been refactored to be predictable.
 
 `AutoCreateInputTypes` now defaults to `true` and you will have to add some attributes to your parameters or classes.
 
@@ -24,16 +24,17 @@ When looking for a methods parameters, EntityGraphQL will
 
 2. If parameter type or enum type is already in the schema it will be added at an argument.
 
-2. Any argument or type with `GraphQLInputTypeAttribute` or `GraphQLArgumentsAttribute` found will be added as schema arguments.
+3. Any argument or type with `GraphQLInputTypeAttribute` will be added to the schema as a `InputType`
 
-3. If no attributes are found it will assume they are services and not add them to the schema. *I.e. Label your arguments with the attributes or add them to the schema beforehand.*
+4. Any argument or type with `GraphQLArgumentsAttribute` found will have the types properties added as schema arguments.
+
+5. If no attributes are found it will assume they are services and not add them to the schema. _I.e. Label your arguments with the attributes or add them to the schema beforehand._
 
 `AutoCreateInputTypes` now only controls if the type of the argument should be added to the schema.
 
 ## `IExposableException` removed
 
 Interface `IExposableException` has been removed. Use the existing `SchemaBuilderSchemaOptions.AllowedExceptions` property to define which exceptions are rendered into the results. Or mark your exceptions with the `AllowedExceptionAttribute` to have exception details in the results when `SchemaBuilderSchemaOptions.IsDevelopment` is `false`.
-
 
 ## `IDirectiveProcessor` updated
 

--- a/docs/docs/upgrade-5-0.md
+++ b/docs/docs/upgrade-5-0.md
@@ -10,6 +10,23 @@ EntityGraphQL aims to respect [Semantic Versioning](https://semver.org/), meanin
 You can see the full changelog which includes other changes and bug fixes as well as links back to GitHub issues/MRs with more information [here on GitHub](https://github.com/EntityGraphQL/EntityGraphQL/blob/master/CHANGELOG.md).
 :::
 
+## Changes to Method Argument Reflection
+
+Previously if `AutoCreateInputTypes` was enabled we didn't know if a parameter should be a GraphQL argument or an injected service. This has been refactored to be predictable. 
+
+`AutoCreateInputTypes` now default to true and you may have to add some attributes to your parameters or classes.
+`[GraphQLInputType]` will include the parameter as an argument and use the type as an input type. `[GraphQLArguments]` will flatten the properties of that parameter type into  many arguments in the schema.
+
+1. First all scalar / non-complex types will be added at arguments in the schema.
+
+2. If parameter type or enum type is already in the schema it will be added at an argument.
+
+2. Any argument or type with `GraphQLInputTypeAttribute` or `GraphQLArgumentsAttribute` found will be added as schema arguments.
+
+3. If no attributes are found it will assume they are services and not add them to the schema. *I.e. Label your arguments with the attributes or add them to the schema beforehand.*
+
+`AutoCreateInputTypes` now only controls if the type of the argument should be added to the schema.
+
 ## `IExposableException` removed
 
 Interface `IExposableException` has been removed. Use the existing `SchemaBuilderSchemaOptions.AllowedExceptions` property to define which exceptions are rendered into the results. Or mark your exceptions with the `AllowedExceptionAttribute` to have exception details in the results when `SchemaBuilderSchemaOptions.IsDevelopment` is `false`.
@@ -23,5 +40,5 @@ Interface `IExposableException` has been removed. Use the existing `SchemaBuilde
 
 ## `SchemaBuilderMethodOptions` removed
 
-- `AutoCreateInputTypes` has been moved to `SchemaBuilderOptions`
+- `AutoCreateInputTypes` has been moved to `SchemaBuilderOptions` and is now defaulted to `true`.
 - `AddNonAttributedMethods` has been move to `SchemaBuilderOptions.AddNonAttributedMethodsInControllers`

--- a/docs/docs/upgrade-5-0.md
+++ b/docs/docs/upgrade-5-0.md
@@ -12,10 +12,13 @@ You can see the full changelog which includes other changes and bug fixes as wel
 
 ## Changes to Method Argument Reflection
 
-Previously if `AutoCreateInputTypes` was enabled we didn't know if a parameter should be a GraphQL argument or an injected service. This has been refactored to be predictable. 
+Previously if `AutoCreateInputTypes` was enabled we didn't know if a parameter should be a GraphQL argument or an injected service unless you used `[GraphQLArguments]`. But this meant you couldn't have complex types as parameters in the method and have them reflected in the schema (`[GraphQLArguments]` flattens the arguments in the schema). This has been refactored to be predictable. 
 
-`AutoCreateInputTypes` now default to true and you may have to add some attributes to your parameters or classes.
-`[GraphQLInputType]` will include the parameter as an argument and use the type as an input type. `[GraphQLArguments]` will flatten the properties of that parameter type into  many arguments in the schema.
+`AutoCreateInputTypes` now defaults to `true` and you will have to add some attributes to your parameters or classes.
+
+`[GraphQLInputType]` will include the parameter as an argument and use the type as an input type. `[GraphQLArguments]` will flatten the properties of that parameter type into many arguments in the schema.
+
+When looking for a methods parameters, EntityGraphQL will
 
 1. First all scalar / non-complex types will be added at arguments in the schema.
 

--- a/docs/docs/validation.md
+++ b/docs/docs/validation.md
@@ -33,7 +33,17 @@ If any of those validations fail, the graph QL result will have errors for each 
 
 Throwing an exception in your mutation will cause the the error to be reported in the GraphQL response. You can also collect multiple error messages instead of throwing an exception on the first error using the `GraphQLValidator` service.
 
+This service needs to be registered in your service provider. You can always implement you own `GraphQLValidator` by implementing the `IGraphQLValidator` interface.
+
 ```cs
+
+// In your Startup.cs
+services.AddGraphQLValidator(); // with EntityGraphQL.AspNet
+
+// Or without / or you own implementation
+services.AddTransient<IGraphQLValidator, GraphQLValidator>();
+
+// your mutation
 public class MovieMutations
 {
   [GraphQLMutation]

--- a/src/EntityGraphQL.AspNet/Extensions/EntityGraphQLAspNetServiceCollectionExtensions.cs
+++ b/src/EntityGraphQL.AspNet/Extensions/EntityGraphQLAspNetServiceCollectionExtensions.cs
@@ -47,7 +47,7 @@ namespace EntityGraphQL.AspNet
             configure(options);
 
             var schema = new SchemaProvider<TSchemaContext>(
-                new PolicyOrRoleBasedAuthorization(authService), options.FieldNamer, 
+                new PolicyOrRoleBasedAuthorization(authService), options.FieldNamer,
                 isDevelopment: webHostEnvironment?.IsEnvironment("Development") ?? true
                 );
             options.PreBuildSchemaFromContext?.Invoke(schema);
@@ -56,6 +56,16 @@ namespace EntityGraphQL.AspNet
             options.ConfigureSchema?.Invoke(schema);
             serviceCollection.AddSingleton(schema);
 
+            return serviceCollection;
+        }
+        /// <summary>
+        /// Registers the default IGraphQLValidator implementation to use as a service in your method fields to report a colletion of errors
+        /// </summary>
+        /// <param name="serviceCollection"></param>
+        /// <returns></returns>
+        public static IServiceCollection AddGraphQLValidator(this IServiceCollection serviceCollection)
+        {
+            serviceCollection.TryAddTransient<IGraphQLValidator, GraphQLValidator>();
             return serviceCollection;
         }
     }

--- a/src/EntityGraphQL/Compiler/GqlNodes/CompileContext.cs
+++ b/src/EntityGraphQL/Compiler/GqlNodes/CompileContext.cs
@@ -12,7 +12,7 @@ namespace EntityGraphQL.Compiler
     {
         private readonly HashSet<Type> servicesCollected = new();
         private readonly Dictionary<ParameterExpression, object?> constantParameters = new();
-        private readonly Dictionary<IField, List<ParameterExpression>> constantParametersForField = new();
+        private readonly Dictionary<IField, ParameterExpression> constantParametersForField = new();
 
         public HashSet<Type> Services { get => servicesCollected; }
         public IReadOnlyDictionary<ParameterExpression, object?> ConstantParameters { get => constantParameters; }
@@ -29,10 +29,10 @@ namespace EntityGraphQL.Compiler
         {
             constantParameters[parameterExpression] = value;
             if (fromField != null)
-                constantParametersForField[fromField] = new List<ParameterExpression> { parameterExpression };
+                constantParametersForField[fromField] = parameterExpression;
         }
 
-        public List<ParameterExpression>? GetConstantParameterForField(IField field)
+        public ParameterExpression? GetConstantParameterForField(IField field)
         {
             if (constantParametersForField.TryGetValue(field, out var param))
                 return param;

--- a/src/EntityGraphQL/Compiler/GqlNodes/CompileContext.cs
+++ b/src/EntityGraphQL/Compiler/GqlNodes/CompileContext.cs
@@ -6,13 +6,13 @@ using EntityGraphQL.Schema;
 namespace EntityGraphQL.Compiler
 {
     /// <summary>
-    /// Class to hold required services ro constant parameters required to execute the compiled query
+    /// Class to hold required services and constant parameters required to execute the compiled query
     /// </summary>
     public class CompileContext
     {
         private readonly HashSet<Type> servicesCollected = new();
         private readonly Dictionary<ParameterExpression, object?> constantParameters = new();
-        private readonly Dictionary<IField, ParameterExpression> constantParametersForField = new();
+        private readonly Dictionary<IField, List<ParameterExpression>> constantParametersForField = new();
 
         public HashSet<Type> Services { get => servicesCollected; }
         public IReadOnlyDictionary<ParameterExpression, object?> ConstantParameters { get => constantParameters; }
@@ -29,10 +29,10 @@ namespace EntityGraphQL.Compiler
         {
             constantParameters[parameterExpression] = value;
             if (fromField != null)
-                constantParametersForField[fromField] = parameterExpression;
+                constantParametersForField[fromField] = new List<ParameterExpression> { parameterExpression };
         }
 
-        public ParameterExpression? GetConstantParameterForField(IField field)
+        public List<ParameterExpression>? GetConstantParameterForField(IField field)
         {
             if (constantParametersForField.TryGetValue(field, out var param))
                 return param;

--- a/src/EntityGraphQL/Compiler/GqlNodes/ExecutableGraphQLStatement.cs
+++ b/src/EntityGraphQL/Compiler/GqlNodes/ExecutableGraphQLStatement.cs
@@ -53,7 +53,7 @@ namespace EntityGraphQL.Compiler
             }
         }
 
-        public virtual async Task<ConcurrentDictionary<string, object?>> ExecuteAsync<TContext>(TContext context, GraphQLValidator validator, IServiceProvider? serviceProvider, List<GraphQLFragmentStatement> fragments, Func<string, string> fieldNamer, ExecutionOptions options, QueryVariables? variables)
+        public virtual async Task<ConcurrentDictionary<string, object?>> ExecuteAsync<TContext>(TContext context, IServiceProvider? serviceProvider, List<GraphQLFragmentStatement> fragments, Func<string, string> fieldNamer, ExecutionOptions options, QueryVariables? variables)
         {
             // build separate expression for all root level nodes in the op e.g. op is
             // query Op1 {

--- a/src/EntityGraphQL/Compiler/GqlNodes/GraphQLDocument.cs
+++ b/src/EntityGraphQL/Compiler/GqlNodes/GraphQLDocument.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Linq.Expressions;
 using System.Threading.Tasks;
 using EntityGraphQL.Schema;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace EntityGraphQL.Compiler
 {
@@ -80,15 +81,15 @@ namespace EntityGraphQL.Compiler
                 throw new EntityGraphQLExecutionException("An operation name must be defined for all operations if there are multiple operations in the request");
             }
             var result = new QueryResult();
-            var validator = new GraphQLValidator();
+            IGraphQLValidator? validator = serviceProvider?.GetService<IGraphQLValidator>();
             var op = string.IsNullOrEmpty(operationName) ? Operations.First() : Operations.First(o => o.Name == operationName);
 
             // execute the selected operation
             options ??= new ExecutionOptions(); // defaults
 
-            result.SetData(await op.ExecuteAsync(context, validator, serviceProvider, Fragments, Schema.SchemaFieldNamer, options, variables));
+            result.SetData(await op.ExecuteAsync(context, serviceProvider, Fragments, Schema.SchemaFieldNamer, options, variables));
 
-            if (validator.Errors.Count > 0)
+            if (validator?.Errors.Count > 0)
                 result.AddErrors(validator.Errors);
 
             return result;

--- a/src/EntityGraphQL/Compiler/GqlNodes/GraphQLListSelectionField.cs
+++ b/src/EntityGraphQL/Compiler/GqlNodes/GraphQLListSelectionField.cs
@@ -62,7 +62,7 @@ namespace EntityGraphQL.Compiler
                 listContext = ReplaceContext(replacementNextFieldContext!, isRoot, replacer, listContext!);
                 nextFieldContext = Expression.Parameter(listContext.Type.GetEnumerableOrArrayType()!, $"{nextFieldContext.Name}2");
             }
-            (listContext, var argumentParam) = Field?.GetExpression(listContext!, replacementNextFieldContext, ParentNode!, schemaContext, compileContext, Arguments, docParam, docVariables, Directives, contextChanged, replacer) ?? (ListExpression, null);
+            (listContext, var argumentParams) = Field?.GetExpression(listContext!, replacementNextFieldContext, ParentNode!, schemaContext, compileContext, Arguments, docParam, docVariables, Directives, contextChanged, replacer) ?? (ListExpression, null);
             if (listContext == null)
                 return null;
 
@@ -79,7 +79,7 @@ namespace EntityGraphQL.Compiler
                 return listContext;
             }
 
-            (listContext, selectionFields, nextFieldContext) = ProcessExtensionsSelection(listContext, selectionFields, nextFieldContext, argumentParam, contextChanged, replacer);
+            (listContext, selectionFields, nextFieldContext) = ProcessExtensionsSelection(listContext, selectionFields, nextFieldContext, argumentParams, contextChanged, replacer);
 
             if (HasServices)
                 compileContext.AddServices(Field!.Services);

--- a/src/EntityGraphQL/Compiler/GqlNodes/GraphQLMutationField.cs
+++ b/src/EntityGraphQL/Compiler/GqlNodes/GraphQLMutationField.cs
@@ -19,11 +19,11 @@ namespace EntityGraphQL.Compiler
             this.MutationField = mutationField;
         }
 
-        public Task<object?> ExecuteMutationAsync<TContext>(TContext context, GraphQLValidator validator, IServiceProvider? serviceProvider, ParameterExpression? variableParameter, object? variablesToUse)
+        public Task<object?> ExecuteMutationAsync<TContext>(TContext context, IServiceProvider? serviceProvider, ParameterExpression? variableParameter, object? variablesToUse)
         {
             try
             {
-                return MutationField.CallAsync(context, Arguments, validator, serviceProvider, variableParameter, variablesToUse);
+                return MutationField.CallAsync(context, Arguments, serviceProvider, variableParameter, variablesToUse);
             }
             catch (EntityQuerySchemaException e)
             {

--- a/src/EntityGraphQL/Compiler/GqlNodes/GraphQLMutationStatement.cs
+++ b/src/EntityGraphQL/Compiler/GqlNodes/GraphQLMutationStatement.cs
@@ -22,7 +22,7 @@ namespace EntityGraphQL.Compiler
         {
         }
 
-        public override async Task<ConcurrentDictionary<string, object?>> ExecuteAsync<TContext>(TContext context, GraphQLValidator validator, IServiceProvider? serviceProvider, List<GraphQLFragmentStatement> fragments, Func<string, string> fieldNamer, ExecutionOptions options, QueryVariables? variables)
+        public override async Task<ConcurrentDictionary<string, object?>> ExecuteAsync<TContext>(TContext context, IServiceProvider? serviceProvider, List<GraphQLFragmentStatement> fragments, Func<string, string> fieldNamer, ExecutionOptions options, QueryVariables? variables)
         {
             var result = new ConcurrentDictionary<string, object?>();
             // pass to directvies
@@ -50,7 +50,7 @@ namespace EntityGraphQL.Compiler
                             timer.Start();
                         }
 #endif
-                        var data = await ExecuteAsync(compileContext, node, context, validator, serviceProvider, fragments, options, docVariables);
+                        var data = await ExecuteAsync(compileContext, node, context, serviceProvider, fragments, options, docVariables);
 #if DEBUG
                         if (options.IncludeDebugInfo)
                         {
@@ -89,12 +89,12 @@ namespace EntityGraphQL.Compiler
         /// <param name="docVariables">Resolved values of variables pass in request</param>
         /// <typeparam name="TContext"></typeparam>
         /// <returns></returns>
-        private async Task<object?> ExecuteAsync<TContext>(CompileContext compileContext, GraphQLMutationField node, TContext context, GraphQLValidator validator, IServiceProvider? serviceProvider, List<GraphQLFragmentStatement> fragments, ExecutionOptions options, object? docVariables)
+        private async Task<object?> ExecuteAsync<TContext>(CompileContext compileContext, GraphQLMutationField node, TContext context, IServiceProvider? serviceProvider, List<GraphQLFragmentStatement> fragments, ExecutionOptions options, object? docVariables)
         {
             if (context == null)
                 return null;
             // run the mutation to get the context for the query select
-            var result = await node.ExecuteMutationAsync(context, validator, serviceProvider, OpVariableParameter, docVariables);
+            var result = await node.ExecuteMutationAsync(context, serviceProvider, OpVariableParameter, docVariables);
 
             if (result == null || // result is null and don't need to do anything more
                 node.ResultSelection == null) // mutation must return a scalar type

--- a/src/EntityGraphQL/Compiler/GqlNodes/GraphQLMutationStatement.cs
+++ b/src/EntityGraphQL/Compiler/GqlNodes/GraphQLMutationStatement.cs
@@ -40,7 +40,7 @@ namespace EntityGraphQL.Compiler
                 try
                 {
                     object? docVariables = BuildDocumentVariables(ref variables);
-                    foreach (var node in field.Expand(compileContext, fragments, true, NextFieldContext!, OpVariableParameter, docVariables).Cast<GraphQLMutationField>())
+                    foreach (var node in field.Expand(compileContext, fragments, false, NextFieldContext!, OpVariableParameter, docVariables).Cast<GraphQLMutationField>())
                     {
 #if DEBUG
                         Stopwatch? timer = null;

--- a/src/EntityGraphQL/Compiler/GqlNodes/GraphQLObjectProjectionField.cs
+++ b/src/EntityGraphQL/Compiler/GqlNodes/GraphQLObjectProjectionField.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
 using EntityGraphQL.Compiler.Util;
-using EntityGraphQL.Directives;
 using EntityGraphQL.Schema;
 
 namespace EntityGraphQL.Compiler

--- a/src/EntityGraphQL/Compiler/GqlNodes/GraphQLQueryStatement.cs
+++ b/src/EntityGraphQL/Compiler/GqlNodes/GraphQLQueryStatement.cs
@@ -15,7 +15,7 @@ namespace EntityGraphQL.Compiler
         {
         }
 
-        public override Task<ConcurrentDictionary<string, object?>> ExecuteAsync<TContext>(TContext context, GraphQLValidator validator, IServiceProvider? serviceProvider, List<GraphQLFragmentStatement> fragments, Func<string, string> fieldNamer, ExecutionOptions options, QueryVariables? variables)
+        public override Task<ConcurrentDictionary<string, object?>> ExecuteAsync<TContext>(TContext context, IServiceProvider? serviceProvider, List<GraphQLFragmentStatement> fragments, Func<string, string> fieldNamer, ExecutionOptions options, QueryVariables? variables)
         {
             var result = new ConcurrentDictionary<string, object?>();
             // pass to directvies
@@ -24,7 +24,7 @@ namespace EntityGraphQL.Compiler
                 if (directive.VisitNode(ExecutableDirectiveLocation.QUERY, Schema, this, Arguments, null, null) == null)
                     return Task.FromResult(result);
             }
-            return base.ExecuteAsync(context, validator, serviceProvider, fragments, fieldNamer, options, variables);
+            return base.ExecuteAsync(context, serviceProvider, fragments, fieldNamer, options, variables);
         }
     }
 }

--- a/src/EntityGraphQL/Compiler/GqlNodes/GraphQLSubscriptionField.cs
+++ b/src/EntityGraphQL/Compiler/GqlNodes/GraphQLSubscriptionField.cs
@@ -19,11 +19,11 @@ namespace EntityGraphQL.Compiler
             this.SubscriptionField = subscriptionField;
         }
 
-        public Task<object?> ExecuteSubscriptionAsync<TContext>(TContext context, GraphQLValidator validator, IServiceProvider? serviceProvider, ParameterExpression? variableParameter, object? variablesToUse)
+        public Task<object?> ExecuteSubscriptionAsync<TContext>(TContext context, IServiceProvider? serviceProvider, ParameterExpression? variableParameter, object? variablesToUse)
         {
             try
             {
-                return SubscriptionField.CallAsync(context, Arguments, validator, serviceProvider, variableParameter, variablesToUse);
+                return SubscriptionField.CallAsync(context, Arguments, serviceProvider, variableParameter, variablesToUse);
             }
             catch (EntityQuerySchemaException e)
             {

--- a/src/EntityGraphQL/Compiler/GqlNodes/GraphQLSubscriptionStatement.cs
+++ b/src/EntityGraphQL/Compiler/GqlNodes/GraphQLSubscriptionStatement.cs
@@ -29,7 +29,7 @@ namespace EntityGraphQL.Compiler
         {
         }
 
-        public override async Task<ConcurrentDictionary<string, object?>> ExecuteAsync<TContext>(TContext context, GraphQLValidator validator, IServiceProvider? serviceProvider, List<GraphQLFragmentStatement> fragments, Func<string, string> fieldNamer, ExecutionOptions options, QueryVariables? variables)
+        public override async Task<ConcurrentDictionary<string, object?>> ExecuteAsync<TContext>(TContext context, IServiceProvider? serviceProvider, List<GraphQLFragmentStatement> fragments, Func<string, string> fieldNamer, ExecutionOptions options, QueryVariables? variables)
         {
             this.serviceProvider = serviceProvider;
             this.fragments = fragments;
@@ -59,7 +59,7 @@ namespace EntityGraphQL.Compiler
                             timer.Start();
                         }
 #endif
-                        var data = await ExecuteAsync(node, context, validator, serviceProvider, docVariables);
+                        var data = await ExecuteAsync(node, context, serviceProvider, docVariables);
 #if DEBUG
                         if (options.IncludeDebugInfo)
                         {
@@ -86,12 +86,12 @@ namespace EntityGraphQL.Compiler
             return result;
         }
 
-        private async Task<object?> ExecuteAsync<TContext>(GraphQLSubscriptionField node, TContext context, GraphQLValidator validator, IServiceProvider? serviceProvider, object? docVariables)
+        private async Task<object?> ExecuteAsync<TContext>(GraphQLSubscriptionField node, TContext context, IServiceProvider? serviceProvider, object? docVariables)
         {
             if (context == null)
                 return null;
             // execute the subscription set up method. It returns in IObservable<T>
-            var result = await node.ExecuteSubscriptionAsync(context, validator, serviceProvider, OpVariableParameter, docVariables);
+            var result = await node.ExecuteSubscriptionAsync(context, serviceProvider, OpVariableParameter, docVariables);
 
             if (result == null || node.ResultSelection == null)
                 throw new EntityGraphQLExecutionException($"Subscription {node.Name} returned null. It must return an IObservable<T>");

--- a/src/EntityGraphQL/Compiler/GqlNodes/GraphQLSubscriptionStatement.cs
+++ b/src/EntityGraphQL/Compiler/GqlNodes/GraphQLSubscriptionStatement.cs
@@ -49,7 +49,7 @@ namespace EntityGraphQL.Compiler
             {
                 try
                 {
-                    foreach (var node in field.Expand(compileContext, fragments, true, NextFieldContext!, OpVariableParameter, docVariables).Cast<GraphQLSubscriptionField>())
+                    foreach (var node in field.Expand(compileContext, fragments, false, NextFieldContext!, OpVariableParameter, docVariables).Cast<GraphQLSubscriptionField>())
                     {
 #if DEBUG
                         Stopwatch? timer = null;

--- a/src/EntityGraphQL/Compiler/Util/ArgumentUtil.cs
+++ b/src/EntityGraphQL/Compiler/Util/ArgumentUtil.cs
@@ -77,7 +77,7 @@ public static class ArgumentUtil
             var validators = argumentsType!.GetCustomAttributes<ArgumentValidatorAttribute>();
             if (validators != null)
             {
-                var context = new ArgumentValidatorContext(field, new List<object> { argumentValues });
+                var context = new ArgumentValidatorContext(field, argumentValues);
                 foreach (var validator in validators)
                 {
                     validator.Validator.ValidateAsync(context).GetAwaiter().GetResult();

--- a/src/EntityGraphQL/Compiler/Util/ArgumentUtil.cs
+++ b/src/EntityGraphQL/Compiler/Util/ArgumentUtil.cs
@@ -77,7 +77,7 @@ public static class ArgumentUtil
             var validators = argumentsType!.GetCustomAttributes<ArgumentValidatorAttribute>();
             if (validators != null)
             {
-                var context = new ArgumentValidatorContext(field, argumentValues);
+                var context = new ArgumentValidatorContext(field, new List<object> { argumentValues });
                 foreach (var validator in validators)
                 {
                     validator.Validator.ValidateAsync(context).GetAwaiter().GetResult();

--- a/src/EntityGraphQL/Compiler/Util/ExpressionUtil.cs
+++ b/src/EntityGraphQL/Compiler/Util/ExpressionUtil.cs
@@ -507,7 +507,7 @@ namespace EntityGraphQL.Compiler.Util
         }
 
 
-        public static Expression? CreateNewExpression(IDictionary<string, Expression> fieldExpressions, Type type)
+        public static Expression? CreateNewExpression(IDictionary<string, Expression> fieldExpressions, Type type, bool includeProperties = false)
         {
             var fieldExpressionsByName = new Dictionary<string, Expression>();
 
@@ -518,7 +518,9 @@ namespace EntityGraphQL.Compiler.Util
                     fieldExpressionsByName[item.Key] = item.Value;
             }
 
-            var bindings = type.GetFields().Select(p => Expression.Bind(p, fieldExpressionsByName[p.Name])).OfType<MemberBinding>();
+            var bindings = type.GetFields().Select(p => Expression.Bind(p, fieldExpressionsByName[p.Name])).OfType<MemberBinding>().ToList();
+            if (includeProperties)
+                bindings.AddRange(type.GetProperties().Select(p => Expression.Bind(p, fieldExpressionsByName[p.Name])).OfType<MemberBinding>());
             var constructor = type.GetConstructor(Type.EmptyTypes) ?? throw new EntityGraphQLCompilerException("Could not create dynamic type");
             var newExp = Expression.New(constructor);
             var mi = Expression.MemberInit(newExp, bindings);

--- a/src/EntityGraphQL/GraphQLVaildation.cs
+++ b/src/EntityGraphQL/GraphQLVaildation.cs
@@ -3,12 +3,12 @@ using System.Linq;
 
 namespace EntityGraphQL
 {
-    public class GraphQLValidator
+    public class GraphQLValidator : IGraphQLValidator
     {
         public List<GraphQLError> Errors { get; set; } = new List<GraphQLError>();
         public bool HasErrors => Errors.Any();
 
-        public void AddError(string error) => Errors.Add(new GraphQLError(error, null));
-        public void AddError(string error, Dictionary<string, object> extensions) => Errors.Add(new GraphQLError(error, extensions));
+        public void AddError(string message) => Errors.Add(new GraphQLError(message, null));
+        public void AddError(string message, Dictionary<string, object> extensions) => Errors.Add(new GraphQLError(message, extensions));
     }
 }

--- a/src/EntityGraphQL/IGraphQLValidator.cs
+++ b/src/EntityGraphQL/IGraphQLValidator.cs
@@ -1,0 +1,13 @@
+using System.Collections.Generic;
+
+namespace EntityGraphQL
+{
+    public interface IGraphQLValidator
+    {
+        List<GraphQLError> Errors { get; }
+        bool HasErrors { get; }
+
+        void AddError(string message);
+        void AddError(string message, Dictionary<string, object> extensions);
+    }
+}

--- a/src/EntityGraphQL/Schema/Attributes/GraphQLArgumentsAttribute.cs
+++ b/src/EntityGraphQL/Schema/Attributes/GraphQLArgumentsAttribute.cs
@@ -1,12 +1,9 @@
 using System;
 
-namespace EntityGraphQL.Schema
-{
-    /// <summary>
-    /// Have your mutation/subscription argument class implement this interface.
-    /// Allows EntityGraphQL to know which argument of the mutation/subscription needs to be
-    /// populated with the mutation/subscription arguments from the query
-    /// </summary>
-    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Parameter)]
-    public class GraphQLArgumentsAttribute : Attribute { }
-}
+namespace EntityGraphQL.Schema;
+/// <summary>
+/// Use on your mutation/subscription/field argument class.
+/// Properties on this class will be used as arguments to the method.
+/// </summary>
+[AttributeUsage(AttributeTargets.Class | AttributeTargets.Parameter)]
+public class GraphQLArgumentsAttribute : Attribute { }

--- a/src/EntityGraphQL/Schema/Attributes/GraphQLInputTypeAttribute.cs
+++ b/src/EntityGraphQL/Schema/Attributes/GraphQLInputTypeAttribute.cs
@@ -1,0 +1,11 @@
+using System;
+
+namespace EntityGraphQL.Schema;
+
+/// <summary>
+/// Tells EntityGraphQL that this class or parameter type is an InputType in the schema.
+/// Use on your mutation/subscription/field argument class.
+/// Method parameter will be added as a single argument with an Input Type.
+/// </summary>
+[AttributeUsage(AttributeTargets.Class | AttributeTargets.Parameter)]
+public class GraphQLInputTypeAttribute : Attribute { }

--- a/src/EntityGraphQL/Schema/BaseField.cs
+++ b/src/EntityGraphQL/Schema/BaseField.cs
@@ -51,8 +51,8 @@ namespace EntityGraphQL.Schema
         /// <summary>
         /// Name of the dotnet parameter and its types that was flattened into the schema.
         /// </summary>
-        public Dictionary<string, Type> FlattenArgmentTypes { get; private set; } = new();
-        private const string DefaultArgmentsTypeName = "egql_generated_args";
+        public Dictionary<string, Type> FlattenArgmentTypes { get; internal set; } = new();
+        internal const string DefaultArgmentsTypeName = "egql_generated_args";
         public Type? DefaultArgmentsType
         {
             get => FlattenArgmentTypes.ContainsKey(DefaultArgmentsTypeName) ? FlattenArgmentTypes[DefaultArgmentsTypeName] : null;

--- a/src/EntityGraphQL/Schema/BaseField.cs
+++ b/src/EntityGraphQL/Schema/BaseField.cs
@@ -107,12 +107,7 @@ namespace EntityGraphQL.Schema
             return this;
         }
 
-        /// <summary>
-        /// Adds a argument object to the field. The fields on the object will be added as arguments.
-        /// Any exisiting arguments with the same name will be overwritten.
-        /// </summary>
-        /// <param name="args"></param>
-        public void AddArguments(string name, object args)
+        public void AddArguments(object args)
         {
             // get new argument values
             var newArgs = ExpressionUtil.ObjectToDictionaryArgs(Schema, args);

--- a/src/EntityGraphQL/Schema/BaseField.cs
+++ b/src/EntityGraphQL/Schema/BaseField.cs
@@ -22,7 +22,7 @@ namespace EntityGraphQL.Schema
         public string Description { get; protected set; }
         public IDictionary<string, ArgType> Arguments { get; set; } = new Dictionary<string, ArgType>();
         public ParameterExpression? ArgumentsParameter { get; set; }
-        public Dictionary<string, Type> ExpressionArgmentTypes { get; internal set; } = new();
+        public Type? ExpressionArgmentType { get; internal set; }
         public string Name { get; internal set; }
         public ISchemaType FromType { get; }
         public GqlTypeInfo ReturnType { get; protected set; }
@@ -112,15 +112,14 @@ namespace EntityGraphQL.Schema
         /// Any exisiting arguments with the same name will be overwritten.
         /// </summary>
         /// <param name="args"></param>
-        public void AddArguments(object args)
+        public void AddArguments(string name, object args)
         {
             // get new argument values
             var newArgs = ExpressionUtil.ObjectToDictionaryArgs(Schema, args);
-            // build new argument Type
-            ExpressionArgmentTypes.TryGetValue(DefaultArgmentsTypeName, out var argType);
-            var newArgType = ExpressionUtil.MergeTypes(argType, args.GetType());
+            var newArgType = args.GetType();
             // Update the values - we don't read new values from this as the type has now lost any default values etc but we have them in allArguments
             newArgs.ToList().ForEach(k => Arguments.Add(k.Key, k.Value));
+
             // now we need to update the MemberInfo
             foreach (var item in Arguments)
             {
@@ -134,7 +133,7 @@ namespace EntityGraphQL.Schema
                 ResolveExpression = parameterReplacer.Replace(ResolveExpression, ArgumentsParameter, argParam);
 
             ArgumentsParameter = argParam;
-            ExpressionArgmentTypes[DefaultArgmentsTypeName] = newArgType;
+            ExpressionArgmentType = newArgType;
         }
         public IField Returns(GqlTypeInfo gqlTypeInfo)
         {
@@ -146,7 +145,7 @@ namespace EntityGraphQL.Schema
         {
             // Move the arguments definition to the new field as it needs them for processing
             // don't push field.FieldParam over 
-            ExpressionArgmentTypes = field.ExpressionArgmentTypes;
+            ExpressionArgmentType = field.ExpressionArgmentType;
             ArgumentsParameter = field.ArgumentsParameter;
             Arguments = field.Arguments;
             ArgumentsAreInternal = true;

--- a/src/EntityGraphQL/Schema/BaseField.cs
+++ b/src/EntityGraphQL/Schema/BaseField.cs
@@ -22,7 +22,7 @@ namespace EntityGraphQL.Schema
         public string Description { get; protected set; }
         public IDictionary<string, ArgType> Arguments { get; set; } = new Dictionary<string, ArgType>();
         public ParameterExpression? ArgumentsParameter { get; set; }
-        public Type? ExpressionArgmentType { get; internal set; }
+        public Type? ExpressionArgumentType { get; internal set; }
         public string Name { get; internal set; }
         public ISchemaType FromType { get; }
         public GqlTypeInfo ReturnType { get; protected set; }
@@ -116,7 +116,8 @@ namespace EntityGraphQL.Schema
         {
             // get new argument values
             var newArgs = ExpressionUtil.ObjectToDictionaryArgs(Schema, args);
-            var newArgType = args.GetType();
+            // build a new type with the new arguments
+            var newArgType = ExpressionUtil.MergeTypes(ExpressionArgumentType, args.GetType());
             // Update the values - we don't read new values from this as the type has now lost any default values etc but we have them in allArguments
             newArgs.ToList().ForEach(k => Arguments.Add(k.Key, k.Value));
 
@@ -133,7 +134,7 @@ namespace EntityGraphQL.Schema
                 ResolveExpression = parameterReplacer.Replace(ResolveExpression, ArgumentsParameter, argParam);
 
             ArgumentsParameter = argParam;
-            ExpressionArgmentType = newArgType;
+            ExpressionArgumentType = newArgType;
         }
         public IField Returns(GqlTypeInfo gqlTypeInfo)
         {
@@ -145,7 +146,7 @@ namespace EntityGraphQL.Schema
         {
             // Move the arguments definition to the new field as it needs them for processing
             // don't push field.FieldParam over 
-            ExpressionArgmentType = field.ExpressionArgmentType;
+            ExpressionArgumentType = field.ExpressionArgumentType;
             ArgumentsParameter = field.ArgumentsParameter;
             Arguments = field.Arguments;
             ArgumentsAreInternal = true;

--- a/src/EntityGraphQL/Schema/Field.cs
+++ b/src/EntityGraphQL/Schema/Field.cs
@@ -172,8 +172,8 @@ namespace EntityGraphQL.Schema
             // check if we are taking args from elsewhere (extensions do this)
             if (UseArgumentsFromField != null && compileContext != null)
             {
-                var newArgValue = compileContext.GetConstantParameterForField(UseArgumentsFromField) ?? throw new EntityGraphQLCompilerException($"Could not find arguments for field {UseArgumentsFromField.Name} in compile context.");
-                argumentValue = compileContext.ConstantParameters[newArgValue];
+                newArgParam = compileContext.GetConstantParameterForField(UseArgumentsFromField) ?? throw new EntityGraphQLCompilerException($"Could not find arguments for field {UseArgumentsFromField.Name} in compile context.");
+                argumentValue = compileContext.ConstantParameters[newArgParam];
             }
             else
             {
@@ -206,14 +206,14 @@ namespace EntityGraphQL.Schema
             if (ArgumentValidators.Count > 0)
             {
                 // TODO I think we only want to send the default args to this (user defined)
-                // var invokeContext = new ArgumentValidatorContext(this, argumentValues[DefaultArgmentsTypeName]);
-                // foreach (var m in ArgumentValidators)
-                // {
-                //     m(invokeContext);
-                //     argumentValues = invokeContext.Arguments;
-                // }
+                var invokeContext = new ArgumentValidatorContext(this, argumentValue);
+                foreach (var m in ArgumentValidators)
+                {
+                    m(invokeContext);
+                    argumentValue = invokeContext.Arguments;
+                }
 
-                // validationErrors.AddRange(invokeContext.Errors);
+                validationErrors.AddRange(invokeContext.Errors);
             }
 
             if (validationErrors.Count > 0)

--- a/src/EntityGraphQL/Schema/Field.cs
+++ b/src/EntityGraphQL/Schema/Field.cs
@@ -4,7 +4,6 @@ using System.Linq.Expressions;
 using System.Threading.Tasks;
 using EntityGraphQL.Compiler;
 using EntityGraphQL.Compiler.Util;
-using EntityGraphQL.Directives;
 using EntityGraphQL.Schema.FieldExtensions;
 
 namespace EntityGraphQL.Schema

--- a/src/EntityGraphQL/Schema/Field.cs
+++ b/src/EntityGraphQL/Schema/Field.cs
@@ -205,7 +205,6 @@ namespace EntityGraphQL.Schema
 
             if (ArgumentValidators.Count > 0)
             {
-                // TODO I think we only want to send the default args to this (user defined)
                 var invokeContext = new ArgumentValidatorContext(this, argumentValue);
                 foreach (var m in ArgumentValidators)
                 {

--- a/src/EntityGraphQL/Schema/Field.cs
+++ b/src/EntityGraphQL/Schema/Field.cs
@@ -77,7 +77,7 @@ namespace EntityGraphQL.Schema
             if (fieldArgsObject != null)
             {
                 Arguments = ExpressionUtil.ObjectToDictionaryArgs(schema, fieldArgsObject);
-                ArgumentsType = fieldArgsObject.GetType();
+                DefaultArgmentsType = fieldArgsObject.GetType();
             }
         }
 
@@ -103,8 +103,8 @@ namespace EntityGraphQL.Schema
             if (fieldArgs != null)
             {
                 Arguments = fieldArgs;
-                if (ArgumentsType == null)
-                    ArgumentsType = LinqRuntimeTypeBuilder.GetDynamicType(fieldArgs.ToDictionary(x => x.Key, x => x.Value.RawType), name);
+                if (DefaultArgmentsType == null)
+                    DefaultArgmentsType = LinqRuntimeTypeBuilder.GetDynamicType(fieldArgs.ToDictionary(x => x.Key, x => x.Value.RawType), name);
             }
         }
 
@@ -178,9 +178,9 @@ namespace EntityGraphQL.Schema
             }
             else
             {
-                if (field.ArgumentsType != null && FieldParam != null)
+                if (field.DefaultArgmentsType != null && FieldParam != null)
                 {
-                    argumentValues = ArgumentUtil.BuildArgumentsObject(field.Schema, field.Name, field, args, field.Arguments.Values, field.ArgumentsType, docParam, docVariables, validationErrors);
+                    argumentValues = ArgumentUtil.BuildArgumentsObject(field.Schema, field.Name, field, args, field.Arguments.Values, field.DefaultArgmentsType, docParam, docVariables, validationErrors);
                 }
                 // we need to make a copy of the argument parameter as if they select the same field multiple times
                 // i.e. with different alias & arguments we need to have different ParameterExpression instances

--- a/src/EntityGraphQL/Schema/FieldExtensions/BaseFieldExtension.cs
+++ b/src/EntityGraphQL/Schema/FieldExtensions/BaseFieldExtension.cs
@@ -15,15 +15,6 @@ namespace EntityGraphQL.Schema.FieldExtensions
         /// <param name="field"></param>
         public virtual void Configure(ISchemaProvider schema, IField field) { }
 
-        /// <summary>
-        /// Called when the field is used in a query. This is at the compiling of the query stage, it is before the
-        /// field expression is joined with a Select() or built into a new {}.
-        /// Use this as a chance to make any expression changes based on arguments or do rules/error checks on arguments.
-        /// </summary>
-        /// <param name="field"></param>
-        /// <param name="expression">The current expression for the field</param>
-        /// <param name="arguments">The values of the arguments. Null if field have no arguments</param>
-        /// <returns></returns>
         public virtual Expression? GetExpression(IField field, Expression expression, ParameterExpression? argumentParam, dynamic? arguments, Expression context, IGraphQLNode? parentNode, bool servicesPass, ParameterReplacer parameterReplacer)
         {
             return expression;

--- a/src/EntityGraphQL/Schema/FieldExtensions/ConnectionPaging/ConnectionPagingExtension.cs
+++ b/src/EntityGraphQL/Schema/FieldExtensions/ConnectionPaging/ConnectionPagingExtension.cs
@@ -133,7 +133,7 @@ namespace EntityGraphQL.Schema.FieldExtensions
             // need to set this up here as the types are needed as we visiting the query tree
             // we build the real one below in GetExpression()
             var totalCountExp = Expression.Call(isQueryable ? typeof(Queryable) : typeof(Enumerable), "Count", new Type[] { listType }, edgesField.ResolveExpression!);
-            var fieldExpression = Expression.MemberInit(Expression.New(returnType.GetConstructor(new[] { totalCountExp.Type, field.ArgumentParam!.Type })!, totalCountExp, field.ArgumentParam));
+            var fieldExpression = Expression.MemberInit(Expression.New(returnType.GetConstructor(new[] { totalCountExp.Type, field.ArgumentsParameter!.Type })!, totalCountExp, field.ArgumentsParameter));
             field.UpdateExpression(fieldExpression);
         }
 

--- a/src/EntityGraphQL/Schema/FieldExtensions/ConnectionPaging/ConnectionPagingExtension.cs
+++ b/src/EntityGraphQL/Schema/FieldExtensions/ConnectionPaging/ConnectionPagingExtension.cs
@@ -13,7 +13,6 @@ namespace EntityGraphQL.Schema.FieldExtensions
     /// </summary>
     public class ConnectionPagingExtension : BaseFieldExtension
     {
-        internal static readonly string ConnectionPagingArgName = "egql_connectionArgs";
         private readonly int? defaultPageSize;
         private readonly int? maxPageSize;
         private IField? edgesField;
@@ -79,7 +78,7 @@ namespace EntityGraphQL.Schema.FieldExtensions
             field.Returns(SchemaBuilder.MakeGraphQlType(schema, returnType, connectionName));
 
             // Update field arguments
-            field.AddArguments(ConnectionPagingArgName, new ConnectionArgs());
+            field.AddArguments(new ConnectionArgs());
 
             // set up Extension on Edges.Node field to handle the Select() insertion
             edgesField = returnSchemaType.GetField(schema.SchemaFieldNamer("Edges"), null);
@@ -145,6 +144,7 @@ namespace EntityGraphQL.Schema.FieldExtensions
                 field.ArgumentsParameter
             };
             var fieldExpression = Expression.MemberInit(Expression.New(returnType.GetConstructor(argTypes.ToArray())!, paramsArgs));
+
             field.UpdateExpression(fieldExpression);
         }
 

--- a/src/EntityGraphQL/Schema/FieldExtensions/Filter/FilterExpressionExtension.cs
+++ b/src/EntityGraphQL/Schema/FieldExtensions/Filter/FilterExpressionExtension.cs
@@ -29,7 +29,7 @@ namespace EntityGraphQL.Schema.FieldExtensions
 
             // Update field arguments
             var args = Activator.CreateInstance(typeof(FilterArgs<>).MakeGenericType(listType))!;
-            field.AddArguments(args);
+            field.AddArguments("filterArgs", args);
 
             isQueryable = typeof(IQueryable).IsAssignableFrom(field.ResolveExpression.Type);
         }

--- a/src/EntityGraphQL/Schema/FieldExtensions/Filter/FilterExpressionExtension.cs
+++ b/src/EntityGraphQL/Schema/FieldExtensions/Filter/FilterExpressionExtension.cs
@@ -29,7 +29,7 @@ namespace EntityGraphQL.Schema.FieldExtensions
 
             // Update field arguments
             var args = Activator.CreateInstance(typeof(FilterArgs<>).MakeGenericType(listType))!;
-            field.AddArguments("filterArgs", args);
+            field.AddArguments(args);
 
             isQueryable = typeof(IQueryable).IsAssignableFrom(field.ResolveExpression.Type);
         }

--- a/src/EntityGraphQL/Schema/FieldExtensions/IFieldExtension.cs
+++ b/src/EntityGraphQL/Schema/FieldExtensions/IFieldExtension.cs
@@ -25,7 +25,7 @@ namespace EntityGraphQL.Schema.FieldExtensions
         /// <param name="field"></param>
         /// <param name="expression">The current expression for the field</param>
         /// <param name="argumentParam">The ParameterExpression used for accessing the arguments. Null if the field has no augments</param>
-        /// <param name="arguments">The values of the arguments. Null if field have no arguments</param>
+        /// <param name="arguments">The value of the arguments. Null if field have no arguments</param>
         /// <param name="context">The context of the schema</param>
         /// <param name="servicesPass">True if this is the second visit. This means the object graph is built and we are now bringing in fields that use services</param>
         /// <returns></returns>

--- a/src/EntityGraphQL/Schema/FieldExtensions/OffsetPaging/OffsetPagingExtension.cs
+++ b/src/EntityGraphQL/Schema/FieldExtensions/OffsetPaging/OffsetPagingExtension.cs
@@ -13,7 +13,6 @@ namespace EntityGraphQL.Schema.FieldExtensions;
 /// </summary>
 public class OffsetPagingExtension : BaseFieldExtension
 {
-    internal static readonly string OffsetPagingFieldArgName = "egql_offsetArgs";
     private IField? itemsField;
     private IField? field;
     private List<IFieldExtension> extensions = new();
@@ -64,7 +63,7 @@ public class OffsetPagingExtension : BaseFieldExtension
         field.Returns(SchemaBuilder.MakeGraphQlType(schema, returnType, page));
 
         // Update field arguments
-        field.AddArguments(OffsetPagingFieldArgName, new OffsetArgs());
+        field.AddArguments(new OffsetArgs());
         if (defaultPageSize.HasValue)
             field.Arguments["take"].DefaultValue = defaultPageSize.Value;
 

--- a/src/EntityGraphQL/Schema/FieldExtensions/OffsetPaging/OffsetPagingExtension.cs
+++ b/src/EntityGraphQL/Schema/FieldExtensions/OffsetPaging/OffsetPagingExtension.cs
@@ -81,7 +81,7 @@ public class OffsetPagingExtension : BaseFieldExtension
 
         // set up the field's expresison so the types are all good 
         // rebuilt below if needed
-        var fieldExpression = BuildTotalCountExpression(returnType, field.ResolveExpression, field.ArgumentParam!);
+        var fieldExpression = BuildTotalCountExpression(returnType, field.ResolveExpression, field.ArgumentsParameter!);
         field.UpdateExpression(fieldExpression);
     }
 

--- a/src/EntityGraphQL/Schema/FieldExtensions/OffsetPaging/OffsetPagingItemsExtension.cs
+++ b/src/EntityGraphQL/Schema/FieldExtensions/OffsetPaging/OffsetPagingItemsExtension.cs
@@ -35,13 +35,16 @@ public class OffsetPagingItemsExtension : BaseFieldExtension
         if (servicesPass)
             return newItemsExp; // paging is done already
 
+        if (argumentParam == null)
+            throw new EntityGraphQLCompilerException("OffsetPagingItemsExtension requires an argument parameter to be passed in");
+
         // Build our items expression with the paging
         newItemsExp = Expression.Call(isQueryable ? typeof(QueryableExtensions) : typeof(EnumerableExtensions), "Take", new Type[] { listType },
             Expression.Call(isQueryable ? typeof(QueryableExtensions) : typeof(EnumerableExtensions), "Skip", new Type[] { listType },
                 newItemsExp,
-                Expression.PropertyOrField(argumentParam!, "skip")
+                Expression.PropertyOrField(argumentParam, "skip")
             ),
-            Expression.PropertyOrField(argumentParam!, "take")
+            Expression.PropertyOrField(argumentParam, "take")
         );
 
         return newItemsExp;

--- a/src/EntityGraphQL/Schema/FieldExtensions/Sorting/SortExtension.cs
+++ b/src/EntityGraphQL/Schema/FieldExtensions/Sorting/SortExtension.cs
@@ -67,7 +67,7 @@ namespace EntityGraphQL.Schema.FieldExtensions
                     argType.GetProperty("Sort")!.SetValue(argInstance, defaultSortValues);
                 }
             }
-            field.AddArguments(argInstance);
+            field.AddArguments("sortArgs", argInstance);
         }
 
         private Type MakeSortType(IField field)

--- a/src/EntityGraphQL/Schema/FieldExtensions/Sorting/SortExtension.cs
+++ b/src/EntityGraphQL/Schema/FieldExtensions/Sorting/SortExtension.cs
@@ -67,7 +67,7 @@ namespace EntityGraphQL.Schema.FieldExtensions
                     argType.GetProperty("Sort")!.SetValue(argInstance, defaultSortValues);
                 }
             }
-            field.AddArguments("sortArgs", argInstance);
+            field.AddArguments(argInstance);
         }
 
         private Type MakeSortType(IField field)

--- a/src/EntityGraphQL/Schema/IField.cs
+++ b/src/EntityGraphQL/Schema/IField.cs
@@ -39,7 +39,7 @@ namespace EntityGraphQL.Schema
         /// <summary>
         /// This is the Type used in the field's expression. It maps to the arguments of the field.
         /// </summary>
-        Type? ExpressionArgmentType { get; }
+        Type? ExpressionArgumentType { get; }
         string Name { get; }
         /// <summary>
         /// GraphQL type this fiel belongs to

--- a/src/EntityGraphQL/Schema/IField.cs
+++ b/src/EntityGraphQL/Schema/IField.cs
@@ -35,7 +35,7 @@ namespace EntityGraphQL.Schema
         /// These are the Types used in the field's expression. They need to be mapped from the schema arguments which may different as
         /// we can flatten objects out inot many arguments in the schema
         /// </summary>
-        Dictionary<string, Type> FlattenArgmentTypes { get; }
+        Dictionary<string, Type> ExpressionArgmentTypes { get; }
         string Name { get; }
         /// <summary>
         /// GraphQL type this fiel belongs to

--- a/src/EntityGraphQL/Schema/IField.cs
+++ b/src/EntityGraphQL/Schema/IField.cs
@@ -25,13 +25,14 @@ namespace EntityGraphQL.Schema
         List<GraphQLExtractedField>? ExtractedFieldsFromServices { get; }
         string? Description { get; }
         /// <summary>
-        /// Information about each field argument. This is used to map the schema arguments to the expression arguments
+        /// Information about each field argument as represented in the GraphQL schema. 
+        /// This is used to map the schema arguments to the dotnet expression arguments
         /// </summary>
         IDictionary<string, ArgType> Arguments { get; }
         /// <summary>
-        /// This is a ParameterExpression that is used to access all the field's arguments. The type is a type that has all the field's arguemnts as properties.
-        /// E.g. if the field has argsmuents (a, b, c) then expressions access them them like (args) => args.a + args.b + args.c
-        /// This means arguments passed in a query map the the Type of this parameter.
+        /// This is a ParameterExpression that is used to access all the field's arguments in the field expression. 
+        /// The type is a type that has all the field's GraphQL Schema arguments as properties.
+        /// E.g. if the field has arguments (a, b, c) then expressions access them them like (args) => args.a + args.b + args.c
         /// Note that these instances are replaced within the expression at execution time. 
         /// You should not store these at configuration time in field extensions
         /// </summary>
@@ -42,9 +43,12 @@ namespace EntityGraphQL.Schema
         Type? ExpressionArgumentType { get; }
         string Name { get; }
         /// <summary>
-        /// GraphQL type this fiel belongs to
+        /// GraphQL type this field belongs to
         /// </summary>
         ISchemaType FromType { get; }
+        /// <summary>
+        /// Information about the GraphQL type returned by this field
+        /// </summary>
         GqlTypeInfo ReturnType { get; }
         List<IFieldExtension> Extensions { get; set; }
         RequiredAuthorization? RequiredAuthorization { get; }

--- a/src/EntityGraphQL/Schema/IField.cs
+++ b/src/EntityGraphQL/Schema/IField.cs
@@ -30,7 +30,7 @@ namespace EntityGraphQL.Schema
         /// expression at execution time. You should not store this at configuration time in field extensions
         /// </summary>
         ParameterExpression? ArgumentParam { get; }
-        Type? ArgumentsType { get; set; }
+        Dictionary<string, Type> FlattenArgmentTypes { get; }
         string Name { get; }
         /// <summary>
         /// GraphQL type this fiel belongs to

--- a/src/EntityGraphQL/Schema/IField.cs
+++ b/src/EntityGraphQL/Schema/IField.cs
@@ -24,18 +24,22 @@ namespace EntityGraphQL.Schema
         ParameterExpression? FieldParam { get; set; }
         List<GraphQLExtractedField>? ExtractedFieldsFromServices { get; }
         string? Description { get; }
+        /// <summary>
+        /// Information about each field argument. This is used to map the schema arguments to the expression arguments
+        /// </summary>
         IDictionary<string, ArgType> Arguments { get; }
         /// <summary>
-        /// These are the ParameterExpressiond that are used to access all the field's schema arguments. 
+        /// This is a ParameterExpression that is used to access all the field's arguments. The type is a type that has all the field's arguemnts as properties.
+        /// E.g. if the field has argsmuents (a, b, c) then expressions access them them like (args) => args.a + args.b + args.c
+        /// This means arguments passed in a query map the the Type of this parameter.
         /// Note that these instances are replaced within the expression at execution time. 
         /// You should not store these at configuration time in field extensions
         /// </summary>
         ParameterExpression? ArgumentsParameter { get; }
         /// <summary>
-        /// These are the Types used in the field's expression. They need to be mapped from the schema arguments which may different as
-        /// we can flatten objects out inot many arguments in the schema
+        /// This is the Type used in the field's expression. It maps to the arguments of the field.
         /// </summary>
-        Dictionary<string, Type> ExpressionArgmentTypes { get; }
+        Type? ExpressionArgmentType { get; }
         string Name { get; }
         /// <summary>
         /// GraphQL type this fiel belongs to
@@ -75,7 +79,7 @@ namespace EntityGraphQL.Schema
         IField UpdateExpression(Expression expression);
 
         void AddExtension(IFieldExtension extension);
-        void AddArguments(object args);
+        void AddArguments(string name, object args);
         IField Returns(GqlTypeInfo gqlTypeInfo);
         void UseArgumentsFrom(IField field);
         IField AddValidator<TValidator>() where TValidator : IArgumentValidator;

--- a/src/EntityGraphQL/Schema/IField.cs
+++ b/src/EntityGraphQL/Schema/IField.cs
@@ -79,7 +79,11 @@ namespace EntityGraphQL.Schema
         IField UpdateExpression(Expression expression);
 
         void AddExtension(IFieldExtension extension);
-        void AddArguments(string name, object args);
+        /// <summary>
+        /// Add new arguments to the field. Properties on the args object will be merged with any existing arguments on the field.
+        /// </summary>
+        /// <param name="args"></param>
+        void AddArguments(object args);
         IField Returns(GqlTypeInfo gqlTypeInfo);
         void UseArgumentsFrom(IField field);
         IField AddValidator<TValidator>() where TValidator : IArgumentValidator;

--- a/src/EntityGraphQL/Schema/IField.cs
+++ b/src/EntityGraphQL/Schema/IField.cs
@@ -26,10 +26,15 @@ namespace EntityGraphQL.Schema
         string? Description { get; }
         IDictionary<string, ArgType> Arguments { get; }
         /// <summary>
-        /// The parameter expression for the field arguments (if any). Note that this instance is replaced within the
-        /// expression at execution time. You should not store this at configuration time in field extensions
+        /// These are the ParameterExpressiond that are used to access all the field's schema arguments. 
+        /// Note that these instances are replaced within the expression at execution time. 
+        /// You should not store these at configuration time in field extensions
         /// </summary>
-        ParameterExpression? ArgumentParam { get; }
+        ParameterExpression? ArgumentsParameter { get; }
+        /// <summary>
+        /// These are the Types used in the field's expression. They need to be mapped from the schema arguments which may different as
+        /// we can flatten objects out inot many arguments in the schema
+        /// </summary>
         Dictionary<string, Type> FlattenArgmentTypes { get; }
         string Name { get; }
         /// <summary>
@@ -42,10 +47,17 @@ namespace EntityGraphQL.Schema
 
         IList<ISchemaDirective> DirectivesReadOnly { get; }
         IField AddDirective(ISchemaDirective directive);
-
         ArgType GetArgumentType(string argName);
         bool HasArgumentByName(string argName);
+        /// <summary>
+        /// If true the arguments on the field are used internally for processing (usually in extensions that change the 
+        /// shape of the schema and need arguments from the original field)
+        /// Arguments will not be in introspection
+        /// </summary>
         bool ArgumentsAreInternal { get; }
+        /// <summary>
+        /// Services required to be injected for this fields selection
+        /// </summary>
         IEnumerable<Type> Services { get; }
         IReadOnlyCollection<Action<ArgumentValidatorContext>> Validators { get; }
         IField? UseArgumentsFromField { get; }

--- a/src/EntityGraphQL/Schema/MethodField.cs
+++ b/src/EntityGraphQL/Schema/MethodField.cs
@@ -118,7 +118,7 @@ namespace EntityGraphQL.Schema
 
             if (ArgumentValidators.Count > 0)
             {
-                var validatorContext = new ArgumentValidatorContext(this, new List<object> { argInstance ?? argsToValidate }, Method);
+                var validatorContext = new ArgumentValidatorContext(this, argInstance ?? argsToValidate, Method);
                 foreach (var argValidator in ArgumentValidators)
                 {
                     argValidator(validatorContext);

--- a/src/EntityGraphQL/Schema/MethodField.cs
+++ b/src/EntityGraphQL/Schema/MethodField.cs
@@ -42,7 +42,15 @@ namespace EntityGraphQL.Schema
                     // Services will be injected for us below in CallAsync
                     continue;
 
-                Arguments.Add(item.ArgName, item.ArgType!);
+                if (item.ShouldFlatten)
+                {
+                    foreach (var f in item.FlattenArgs!)
+                    {
+                        Arguments.Add(f.ArgName, f.ArgType!);
+                    }
+                }
+                else
+                    Arguments.Add(item.ArgName, item.ArgType!);
             }
             FlattenArgmentTypes = flattenedTypes;
         }

--- a/src/EntityGraphQL/Schema/MethodField.cs
+++ b/src/EntityGraphQL/Schema/MethodField.cs
@@ -41,9 +41,6 @@ namespace EntityGraphQL.Schema
                 if (inputType.IsNullableType())
                     inputType = inputType.GetGenericArguments()[0];
 
-                if (inputType == typeof(GraphQLValidator))
-                    continue;
-
                 // primitive types are arguments or types already known in the schema
                 var shouldBeAddedAsArg = item.ParameterType.IsPrimitive || (schema.HasType(inputType) && (schema.Type(inputType).IsInput || schema.Type(inputType).IsScalar || schema.Type(inputType).IsEnum));
 
@@ -112,7 +109,7 @@ namespace EntityGraphQL.Schema
             return inputType.Name;
         }
 
-        public virtual async Task<object?> CallAsync(object? context, IReadOnlyDictionary<string, object>? gqlRequestArgs, GraphQLValidator validator, IServiceProvider? serviceProvider, ParameterExpression? variableParameter, object? docVariables)
+        public virtual async Task<object?> CallAsync(object? context, IReadOnlyDictionary<string, object>? gqlRequestArgs, IServiceProvider? serviceProvider, ParameterExpression? variableParameter, object? docVariables)
         {
             if (context == null)
                 return null;
@@ -157,11 +154,6 @@ namespace EntityGraphQL.Schema
                 else if (p.ParameterType == context.GetType())
                 {
                     allArgs.Add(context);
-                }
-                // todo we should put this in the IServiceCollection actually...
-                else if (p.ParameterType == typeof(GraphQLValidator))
-                {
-                    allArgs.Add(validator);
                 }
                 else if (serviceProvider != null)
                 {

--- a/src/EntityGraphQL/Schema/MethodField.cs
+++ b/src/EntityGraphQL/Schema/MethodField.cs
@@ -52,7 +52,7 @@ namespace EntityGraphQL.Schema
                 else
                     Arguments.Add(item.ArgName, item.ArgType!);
             }
-            FlattenArgmentTypes = flattenedTypes;
+            ExpressionArgmentTypes = flattenedTypes;
         }
 
         public virtual async Task<object?> CallAsync(object? context, IReadOnlyDictionary<string, object>? gqlRequestArgs, IServiceProvider? serviceProvider, ParameterExpression? variableParameter, object? docVariables)
@@ -71,7 +71,7 @@ namespace EntityGraphQL.Schema
             {
                 if (p.GetCustomAttribute<GraphQLArgumentsAttribute>() != null || p.ParameterType.GetTypeInfo().GetCustomAttribute<GraphQLArgumentsAttribute>() != null)
                 {
-                    var argType = FlattenArgmentTypes[p.Name!];
+                    var argType = ExpressionArgmentTypes[p.Name!];
                     argInstance = ArgumentUtil.BuildArgumentsObject(Schema, Name, this, gqlRequestArgs ?? new Dictionary<string, object>(), Arguments.Values, argType, variableParameter, docVariables, validationErrors)!;
                     allArgs.Add(argInstance);
                 }

--- a/src/EntityGraphQL/Schema/MethodField.cs
+++ b/src/EntityGraphQL/Schema/MethodField.cs
@@ -52,7 +52,7 @@ namespace EntityGraphQL.Schema
                 else
                     Arguments.Add(item.ArgName, item.ArgType!);
             }
-            ExpressionArgmentTypes = flattenedTypes;
+            ExpressionArgmentType = LinqRuntimeTypeBuilder.GetDynamicType(flattenedTypes, method.Name)!;
         }
 
         public virtual async Task<object?> CallAsync(object? context, IReadOnlyDictionary<string, object>? gqlRequestArgs, IServiceProvider? serviceProvider, ParameterExpression? variableParameter, object? docVariables)
@@ -71,7 +71,7 @@ namespace EntityGraphQL.Schema
             {
                 if (p.GetCustomAttribute<GraphQLArgumentsAttribute>() != null || p.ParameterType.GetTypeInfo().GetCustomAttribute<GraphQLArgumentsAttribute>() != null)
                 {
-                    var argType = ExpressionArgmentTypes[p.Name!];
+                    var argType = ExpressionArgmentType;
                     argInstance = ArgumentUtil.BuildArgumentsObject(Schema, Name, this, gqlRequestArgs ?? new Dictionary<string, object>(), Arguments.Values, argType, variableParameter, docVariables, validationErrors)!;
                     allArgs.Add(argInstance);
                 }
@@ -118,7 +118,7 @@ namespace EntityGraphQL.Schema
 
             if (ArgumentValidators.Count > 0)
             {
-                var validatorContext = new ArgumentValidatorContext(this, argInstance ?? argsToValidate, Method);
+                var validatorContext = new ArgumentValidatorContext(this, new List<object> { argInstance ?? argsToValidate }, Method);
                 foreach (var argValidator in ArgumentValidators)
                 {
                     argValidator(validatorContext);

--- a/src/EntityGraphQL/Schema/MethodField.cs
+++ b/src/EntityGraphQL/Schema/MethodField.cs
@@ -32,7 +32,7 @@ namespace EntityGraphQL.Schema
             RequiredAuthorization = requiredAuth;
             IsAsync = isAsync;
             Dictionary<string, Type> flattenedTypes;
-            foreach (var item in SchemaBuilder.GetArgumentsFromMethod(schema, method, options, out flattenedTypes))
+            foreach (var item in SchemaBuilder.GetGraphQlSchemaArgumentsFromMethod(schema, method, options, out flattenedTypes))
             {
                 if (item.IsService)
                     // services are not arguments in the schema
@@ -52,7 +52,7 @@ namespace EntityGraphQL.Schema
                 else
                     Arguments.Add(item.ArgName, item.ArgType!);
             }
-            ExpressionArgmentType = LinqRuntimeTypeBuilder.GetDynamicType(flattenedTypes, method.Name)!;
+            ExpressionArgumentType = LinqRuntimeTypeBuilder.GetDynamicType(flattenedTypes, method.Name)!;
         }
 
         public virtual async Task<object?> CallAsync(object? context, IReadOnlyDictionary<string, object>? gqlRequestArgs, IServiceProvider? serviceProvider, ParameterExpression? variableParameter, object? docVariables)
@@ -71,8 +71,8 @@ namespace EntityGraphQL.Schema
             {
                 if (p.GetCustomAttribute<GraphQLArgumentsAttribute>() != null || p.ParameterType.GetTypeInfo().GetCustomAttribute<GraphQLArgumentsAttribute>() != null)
                 {
-                    var argType = ExpressionArgmentType;
-                    argInstance = ArgumentUtil.BuildArgumentsObject(Schema, Name, this, gqlRequestArgs ?? new Dictionary<string, object>(), Arguments.Values, argType, variableParameter, docVariables, validationErrors)!;
+                    // need to map GQL args to the GraphQLArguments object - p.ParameterType
+                    argInstance = ArgumentUtil.BuildArgumentsObject(Schema, Name, this, gqlRequestArgs ?? new Dictionary<string, object>(), Arguments.Values, p.ParameterType, variableParameter, docVariables, validationErrors)!;
                     allArgs.Add(argInstance);
                 }
                 else if (gqlRequestArgs != null && gqlRequestArgs.ContainsKey(p.Name!))

--- a/src/EntityGraphQL/Schema/SchemaBuilder.cs
+++ b/src/EntityGraphQL/Schema/SchemaBuilder.cs
@@ -259,7 +259,7 @@ namespace EntityGraphQL.Schema
             if (fieldServices.Count > 0)
             {
                 field.Services = fieldServices.Values.Select(x => x.Type).ToList();
-                field.FlattenArgmentTypes = flattenedTypes;
+                field.ExpressionArgmentTypes = flattenedTypes;
             }
 
             field.ApplyAttributes(method.GetCustomAttributes());

--- a/src/EntityGraphQL/Schema/SchemaBuilder.cs
+++ b/src/EntityGraphQL/Schema/SchemaBuilder.cs
@@ -208,7 +208,7 @@ namespace EntityGraphQL.Schema
                 // TODO fieldDotnetArgtypes vs flattenedTypes
                 var fieldDotnetArgtypes = new Dictionary<string, Type>();
                 fieldSchemaArgs = new Dictionary<string, ArgType>();
-                foreach (var item in GetArgumentsFromMethod(schema, method, options, out flattenedTypes))
+                foreach (var item in GetGraphQlSchemaArgumentsFromMethod(schema, method, options, out flattenedTypes))
                 {
                     if (item.IsService)
                     {
@@ -259,7 +259,7 @@ namespace EntityGraphQL.Schema
             if (fieldServices.Count > 0)
             {
                 field.Services = fieldServices.Values.Select(x => x.Type).ToList();
-                field.ExpressionArgmentType = fieldArgType;
+                field.ExpressionArgumentType = fieldArgType;
             }
 
             field.ApplyAttributes(method.GetCustomAttributes());
@@ -458,7 +458,7 @@ namespace EntityGraphQL.Schema
             return new GqlTypeInfo(!string.IsNullOrEmpty(returnSchemaType) ? () => schema.Type(returnSchemaType) : () => schema.GetSchemaType(returnType.GetNonNullableOrEnumerableType(), null), returnType);
         }
 
-        public static IEnumerable<FieldArgInfo> GetArgumentsFromMethod(ISchemaProvider schema, MethodInfo method, SchemaBuilderOptions options, out Dictionary<string, Type> flattenArgmentTypes)
+        public static IEnumerable<FieldArgInfo> GetGraphQlSchemaArgumentsFromMethod(ISchemaProvider schema, MethodInfo method, SchemaBuilderOptions options, out Dictionary<string, Type> flattenArgmentTypes)
         {
             flattenArgmentTypes = new Dictionary<string, Type>();
             var arguments = new List<FieldArgInfo>();

--- a/src/EntityGraphQL/Schema/SchemaBuilderOptions.cs
+++ b/src/EntityGraphQL/Schema/SchemaBuilderOptions.cs
@@ -41,7 +41,7 @@ namespace EntityGraphQL.Schema
         /// </summary>
         public bool AutoCreateEnumTypes { get; set; } = true;
         /// <summary>
-        /// If true (default) and an object type is encountered during reflection of the object graph it will be added to the schema 
+        /// If true (default) and an object type is encountered during reflection of the query object graph it will be added to the schema 
         /// as a Type including it's fields. If that type is an interface it will be added as an interface. This includes return 
         /// types form mutations
         /// </summary>

--- a/src/EntityGraphQL/Schema/SchemaBuilderOptions.cs
+++ b/src/EntityGraphQL/Schema/SchemaBuilderOptions.cs
@@ -53,11 +53,11 @@ namespace EntityGraphQL.Schema
         /// </summary>
         public bool AutoCreateInterfaceTypes { get; set; }
         /// <summary>
-        /// If true (default = false) and an object type is encountered during reflection of the mutation parameters it will be added to the schema as an InputObject type.
+        /// If true (default = true) and an object type is encountered during reflection of method parameters it will be added to the schema as an InputObject type if used as an argument.
         /// 
-        /// If you set it true, EntityGraphQL doesn't know which objects should be InputTypes or a services to be injected at execution.
+        /// If you set it false, you will need to add any InputTypes to the schema before add the methods fields/mutation/subscriptions.
         /// </summary>
-        public bool AutoCreateInputTypes { get; set; }
+        public bool AutoCreateInputTypes { get; set; } = true;
         /// <summary>
         /// If true (default = false) Any public method in the mutation/subscription class will be added to the schema as a mutation/subsscription. 
         /// If false only methodds with GraphQLMutationAttribute/GraphQLSubscriptionAttribute will be added.

--- a/src/EntityGraphQL/Schema/Validators/ArgumentValidatorContext.cs
+++ b/src/EntityGraphQL/Schema/Validators/ArgumentValidatorContext.cs
@@ -6,7 +6,7 @@ public class ArgumentValidatorContext
 {
     private readonly List<string> errors = new();
     // TODO how is these used
-    public ArgumentValidatorContext(IField field, List<object> argumentValues, MethodInfo? method = null)
+    public ArgumentValidatorContext(IField field, object? argumentValues, MethodInfo? method = null)
     {
         Field = field;
         Arguments = argumentValues;
@@ -16,7 +16,7 @@ public class ArgumentValidatorContext
     /// <summary>
     /// The value of the argments for the field.
     /// </summary>
-    public List<object> Arguments { get; set; }
+    public dynamic? Arguments { get; set; }
 
     /// <summary>
     /// The method (mutation) about to be called

--- a/src/EntityGraphQL/Schema/Validators/ArgumentValidatorContext.cs
+++ b/src/EntityGraphQL/Schema/Validators/ArgumentValidatorContext.cs
@@ -5,7 +5,8 @@ namespace EntityGraphQL.Schema;
 public class ArgumentValidatorContext
 {
     private readonly List<string> errors = new();
-    public ArgumentValidatorContext(IField field, object? argumentValues, MethodInfo? method = null)
+    // TODO how is these used
+    public ArgumentValidatorContext(IField field, List<object> argumentValues, MethodInfo? method = null)
     {
         Field = field;
         Arguments = argumentValues;
@@ -15,7 +16,7 @@ public class ArgumentValidatorContext
     /// <summary>
     /// The value of the argments for the field.
     /// </summary>
-    public object? Arguments { get; set; }
+    public List<object> Arguments { get; set; }
 
     /// <summary>
     /// The method (mutation) about to be called

--- a/src/EntityGraphQL/Schema/Validators/ArgumentValidatorContext.cs
+++ b/src/EntityGraphQL/Schema/Validators/ArgumentValidatorContext.cs
@@ -5,7 +5,6 @@ namespace EntityGraphQL.Schema;
 public class ArgumentValidatorContext
 {
     private readonly List<string> errors = new();
-    // TODO how is these used
     public ArgumentValidatorContext(IField field, object? argumentValues, MethodInfo? method = null)
     {
         Field = field;

--- a/src/examples/AzureFunctionApp/Mutations/DemoMutations.cs
+++ b/src/examples/AzureFunctionApp/Mutations/DemoMutations.cs
@@ -56,7 +56,7 @@ namespace demo.Mutations
         }
 
         [GraphQLMutation]
-        public Expression<Func<DemoContext, Person>>? AddActor(DemoContext db, [GraphQLArguments] AddActorArgs args, GraphQLValidator validator)
+        public Expression<Func<DemoContext, Person>>? AddActor(DemoContext db, [GraphQLArguments] AddActorArgs args, IGraphQLValidator validator)
         {
             if (string.IsNullOrEmpty(args.FirstName))
                 validator.AddError("Name argument is required");

--- a/src/examples/AzureFunctionApp/Startup.cs
+++ b/src/examples/AzureFunctionApp/Startup.cs
@@ -1,14 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
-using Microsoft.AspNetCore.Builder;
-using Microsoft.AspNetCore.Hosting;
-using Microsoft.Extensions.Configuration;
+﻿using System.Collections.Generic;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
 using Microsoft.EntityFrameworkCore;
-using System.Text.Json.Serialization;
-using System.Text.Json;
-using EntityGraphQL.Schema;
 using Microsoft.Azure.Functions.Extensions.DependencyInjection;
 using EntityGraphQL.AspNet;
 using demo.Infrastructure;
@@ -37,7 +29,8 @@ namespace demo
                 options.ConfigureSchema = GraphQLSchema.ConfigureSchema;
                 // below this will generate the field names as they are from the reflected dotnet types - i.e matching the case
                 // builder.FieldNamer = name => name;
-            });
+            })
+            .AddGraphQLValidator();
         }
     }
 }

--- a/src/examples/demo/Mutations/DemoMutations.cs
+++ b/src/examples/demo/Mutations/DemoMutations.cs
@@ -56,7 +56,7 @@ namespace demo.Mutations
         }
 
         [GraphQLMutation]
-        public Expression<Func<DemoContext, Person>> AddActor(DemoContext db, [GraphQLArguments] AddActorArgs args, GraphQLValidator validator)
+        public Expression<Func<DemoContext, Person>> AddActor(DemoContext db, [GraphQLArguments] AddActorArgs args, IGraphQLValidator validator)
         {
             if (string.IsNullOrEmpty(args.FirstName))
                 validator.AddError("Name argument is required");

--- a/src/examples/demo/Startup.cs
+++ b/src/examples/demo/Startup.cs
@@ -62,7 +62,8 @@ namespace demo
                 options.ConfigureSchema = GraphQLSchema.ConfigureSchema;
                 // below this will generate the field names as they are from the reflected dotnet types - i.e matching the case
                 // builder.FieldNamer = name => name;
-            });
+            })
+            .AddGraphQLValidator();
 
             services.AddRouting();
             services.AddControllers()

--- a/src/tests/EntityGraphQL.Tests/MutationTests/MutationMethodParameterTests.cs
+++ b/src/tests/EntityGraphQL.Tests/MutationTests/MutationMethodParameterTests.cs
@@ -146,6 +146,7 @@ namespace EntityGraphQL.Tests
             var schema = schemaProvider.ToGraphQLSchemaString();
 
             Assert.Contains("addPersonNullableNestedType(required: NestedInputObject!, optional: NestedInputObject): Person!", schema);
+            Assert.Contains("input NestedInputObject {", schema);
         }
 
         [Fact]

--- a/src/tests/EntityGraphQL.Tests/MutationTests/MutationTests.cs
+++ b/src/tests/EntityGraphQL.Tests/MutationTests/MutationTests.cs
@@ -864,11 +864,13 @@ namespace EntityGraphQL.Tests
         [Fact]
         public void TestNoArgMutationWithService()
         {
-            var schemaProvider = SchemaBuilder.FromObject<TestDataContext>();
-            schemaProvider.Mutation().Add("noArgsWithService", (AgeService ageService) =>
+            var schema = SchemaBuilder.FromObject<TestDataContext>();
+            schema.Mutation().Add("noArgsWithService", (AgeService ageService) =>
             {
                 return ageService != null;
             });
+            var sdl = schema.ToGraphQLSchemaString();
+            Assert.Contains("noArgsWithService: Boolean!", sdl);
             // Add a argument field with a require parameter
             var gql = new QueryRequest
             {
@@ -882,12 +884,11 @@ namespace EntityGraphQL.Tests
             serviceCollection.AddSingleton(service);
 
             var testSchema = new TestDataContext();
-            var results = schemaProvider.ExecuteRequest(gql, testSchema, serviceCollection.BuildServiceProvider(), null);
+            var results = schema.ExecuteRequest(gql, testSchema, serviceCollection.BuildServiceProvider(), null);
             Assert.Null(results.Errors);
             Assert.Equal(true, results.Data["noArgsWithService"]);
-            Assert.Empty(schemaProvider.Mutation().SchemaType.GetField("noArgsWithService", null).Arguments);
+            Assert.Empty(schema.Mutation().SchemaType.GetField("noArgsWithService", null).Arguments);
         }
-
 
         [Fact]
         public void TestNullableGuid()

--- a/src/tests/EntityGraphQL.Tests/MutationTests/MutationTests.cs
+++ b/src/tests/EntityGraphQL.Tests/MutationTests/MutationTests.cs
@@ -562,9 +562,8 @@ namespace EntityGraphQL.Tests
             var gql = new QueryRequest
             {
                 Query = @"mutation {
-          defaultValueTest
-        }
-        ",
+                    defaultValueTest
+                }",
             };
 
             var testSchema = new TestDataContext();
@@ -598,6 +597,7 @@ namespace EntityGraphQL.Tests
 
             results = schemaProvider.ExecuteRequest(gql, testSchema, null, null);
 
+            Assert.Null(results.Errors);
             result = results.Data["__schema"];
 
             var field = ((IEnumerable<dynamic>)result.mutationType.fields).Where(x => x.name == "defaultValueTest");

--- a/src/tests/EntityGraphQL.Tests/MutationTests/PeopleMutations.cs
+++ b/src/tests/EntityGraphQL.Tests/MutationTests/PeopleMutations.cs
@@ -42,7 +42,7 @@ namespace EntityGraphQL.Tests
 
         [GraphQLMutation]
 
-        public Person AddPersonSingleArgument(InputObject nameInput)
+        public Person AddPersonSingleArgument([GraphQLInputType] InputObject nameInput)
         {
             return new Person { Name = string.IsNullOrEmpty(nameInput.Name) ? "Default" : nameInput.Name, Id = 555, Projects = new List<Project>() };
         }
@@ -57,7 +57,7 @@ namespace EntityGraphQL.Tests
 #nullable enable
         [GraphQLMutation]
 
-        public Person AddPersonNullableNestedType(NestedInputObject required, NestedInputObject? optional)
+        public Person AddPersonNullableNestedType([GraphQLInputType] NestedInputObject required, [GraphQLInputType] NestedInputObject? optional)
         {
             return new Person { Name = string.IsNullOrEmpty(required.Name) ? "Default" : required.Name, Id = 555, Projects = new List<Project>() };
         }

--- a/src/tests/EntityGraphQL.Tests/QueryTests/FilteredFieldTests.cs
+++ b/src/tests/EntityGraphQL.Tests/QueryTests/FilteredFieldTests.cs
@@ -101,7 +101,7 @@ namespace EntityGraphQL.Tests
             Assert.Equal("tasks", projectType.GetFields()[0].Name);
         }
 
-        [Fact]
+        [Fact(Skip = "Not implemented yet. Need to know that the filter uses the service field age")]
         public void TestOffsetPagingWithOthersAndServices()
         {
             var schema = SchemaBuilder.FromObject<TestDataContext>();

--- a/src/tests/EntityGraphQL.Tests/QueryTests/GraphQLFieldAttributeTests.cs
+++ b/src/tests/EntityGraphQL.Tests/QueryTests/GraphQLFieldAttributeTests.cs
@@ -396,7 +396,7 @@ public class GraphQLFieldAttributeTests
 
         var res = schema.ExecuteRequest(gql, context, null, null);
         Assert.Null(res.Errors);
-        Assert.Equal("Superman", (dynamic)res.Data["methodFieldWithArgs"]);
+        Assert.Equal("Superman", ((dynamic)res.Data["complex"])[0].methodFieldWithArgs);
     }
 }
 

--- a/src/tests/EntityGraphQL.Tests/QueryTests/GraphQLFieldAttributeTests.cs
+++ b/src/tests/EntityGraphQL.Tests/QueryTests/GraphQLFieldAttributeTests.cs
@@ -337,7 +337,35 @@ public class GraphQLFieldAttributeTests
 
         var res = schemaProvider.ExecuteRequest(gql, context, serviceCollection.BuildServiceProvider(), null);
         Assert.Null(res.Errors);
-        Assert.Equal(44, ((dynamic)res.Data["fields"])[0].methodFieldWithService);
+        Assert.Equal(44, (dynamic)res.Data["methodFieldWithService"]);
+    }
+
+    [Fact]
+    public void TestGraphQLFieldAttributeWithServiceStatic()
+    {
+        var schemaProvider = SchemaBuilder.FromObject<ContextFieldWithMethodService>();
+
+        Assert.True(schemaProvider.Type<ContextFieldWithMethodService>().HasField("methodFieldWithServiceStatic", null));
+
+        var sdl = schemaProvider.ToGraphQLSchemaString();
+
+        Assert.Contains("methodFieldWithServiceStatic(value: Int!): Int!", sdl);
+
+        var gql = new QueryRequest
+        {
+            Query = @"query TypeWithMethod {
+                methodFieldWithServiceStatic(value: 88)
+            }"
+        };
+
+        var context = new ContextFieldWithMethodService();
+        var serviceCollection = new ServiceCollection();
+        var srv = new ConfigService();
+        serviceCollection.AddSingleton(srv);
+
+        var res = schemaProvider.ExecuteRequest(gql, context, serviceCollection.BuildServiceProvider(), null);
+        Assert.Null(res.Errors);
+        Assert.Equal(44, (dynamic)res.Data["methodFieldWithServiceStatic"]);
     }
 }
 
@@ -355,7 +383,12 @@ public class ContextFieldWithMethod
 public class ContextFieldWithMethodService
 {
     [GraphQLField]
-    public static int MethodFieldWithService(ConfigService service, int value)
+    public int MethodFieldWithService(ConfigService service, int value)
+    {
+        return service.GetHalfInt(value);
+    }
+    [GraphQLField]
+    public static int MethodFieldWithServiceStatic(ConfigService service, int value)
     {
         return service.GetHalfInt(value);
     }

--- a/src/tests/EntityGraphQL.Tests/ValidationTests.cs
+++ b/src/tests/EntityGraphQL.Tests/ValidationTests.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Linq.Expressions;
 using EntityGraphQL.Schema;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 
 namespace EntityGraphQL.Tests;
@@ -99,8 +100,10 @@ public class ValidationTests
             }
         };
 
+        var serviceCollection = new ServiceCollection();
+        serviceCollection.AddSingleton<IGraphQLValidator, GraphQLValidator>();
         var testContext = new ValidationTestsContext();
-        var results = schema.ExecuteRequest(gql, testContext, null, null);
+        var results = schema.ExecuteRequest(gql, testContext, serviceCollection.BuildServiceProvider(), null);
         Assert.NotNull(results.Errors);
         Assert.Single(results.Errors);
         Assert.Equal("Test Error", results.Errors[0].Message);
@@ -454,7 +457,7 @@ internal class ValidationTestsMutations
 
 
     [GraphQLMutation]
-    public static bool UpdateCastMemberWithGraphQLValidator(CastMemberArg arg, GraphQLValidator validator)
+    public static bool UpdateCastMemberWithGraphQLValidator(CastMemberArg arg, IGraphQLValidator validator)
     {
         validator.AddError("Test Error");
         return true;

--- a/src/tests/EntityGraphQL.Tests/ValidationTests.cs
+++ b/src/tests/EntityGraphQL.Tests/ValidationTests.cs
@@ -117,13 +117,10 @@ public class ValidationTests
         .Add(AddPerson)
         .AddValidator(context =>
         {
-            foreach (var arg in context.Arguments)
+            if (context.Arguments is PersonArgs args)
             {
-                if (arg is PersonArgs args)
-                {
-                    if (args.Name == "Luke")
-                        context.AddError("Name can't be Luke");
-                }
+                if (args.Name == "Luke")
+                    context.AddError("Name can't be Luke");
             }
         });
         var gql = new QueryRequest
@@ -267,15 +264,12 @@ public class ValidationTests
             "Get a list of Movies")
             .AddValidator((context) =>
             {
-                foreach (var arg in context.Arguments)
+                if (context.Arguments is MovieQueryArgs args)
                 {
-                    if (arg is MovieQueryArgs args)
-                    {
-                        if (args.Price == 150)
-                            context.AddError("You can't use 150 for the price");
-                        if (string.IsNullOrEmpty(args.Title))
-                            context.AddError("Empty or null Title is an invalid search term");
-                    }
+                    if (args.Price == 150)
+                        context.AddError("You can't use 150 for the price");
+                    if (string.IsNullOrEmpty(args.Title))
+                        context.AddError("Empty or null Title is an invalid search term");
                 }
             });
         var gql = new QueryRequest
@@ -306,15 +300,12 @@ public class ValidationTests
                 // pretend await
                 await System.Threading.Tasks.Task.Run(() =>
                 {
-                    foreach (var arg in context.Arguments)
+                    if (context.Arguments is MovieQueryArgs args)
                     {
-                        if (arg is MovieQueryArgs args)
-                        {
-                            if (args.Price == 150)
-                                context.AddError("You can't use 150 for the price");
-                            if (string.IsNullOrEmpty(args.Title))
-                                context.AddError("Empty or null Title is an invalid search term");
-                        }
+                        if (args.Price == 150)
+                            context.AddError("You can't use 150 for the price");
+                        if (string.IsNullOrEmpty(args.Title))
+                            context.AddError("Empty or null Title is an invalid search term");
                     }
                 });
             });
@@ -367,18 +358,15 @@ internal class PersonValidator : IArgumentValidator
 {
     public System.Threading.Tasks.Task ValidateAsync(ArgumentValidatorContext context)
     {
-        foreach (var arg in context.Arguments)
+        if (context.Arguments is PersonArgs args)
         {
-            if (arg is PersonArgs args)
-            {
-                if (args.Name == "Luke")
-                    context.AddError("Name can't be Luke");
-            }
-            else if (arg is PersonArgsWithValidator args2)
-            {
-                if (args2.Name == "Luke")
-                    context.AddError("Name can't be Luke");
-            }
+            if (args.Name == "Luke")
+                context.AddError("Name can't be Luke");
+        }
+        else if (context.Arguments is PersonArgsWithValidator args2)
+        {
+            if (args2.Name == "Luke")
+                context.AddError("Name can't be Luke");
         }
         return System.Threading.Tasks.Task.CompletedTask;
     }
@@ -388,22 +376,19 @@ internal class MovieValidator : IArgumentValidator
 {
     public System.Threading.Tasks.Task ValidateAsync(ArgumentValidatorContext context)
     {
-        foreach (var arg in context.Arguments)
+        if (context.Arguments is MovieQueryArgs args)
         {
-            if (arg is MovieQueryArgs args)
-            {
-                if (args.Price == 150)
-                    context.AddError("You can't use 150 for the price");
-                if (string.IsNullOrEmpty(args.Title))
-                    context.AddError("Empty or null Title is an invalid search term");
-            }
-            else if (arg is MovieQueryArgsWithValidator args2)
-            {
-                if (string.IsNullOrEmpty(args2.Genre))
-                    context.AddError("Genre is required");
-                if (string.IsNullOrEmpty(args2.Title))
-                    context.AddError("Empty or null Title is an invalid search term");
-            }
+            if (args.Price == 150)
+                context.AddError("You can't use 150 for the price");
+            if (string.IsNullOrEmpty(args.Title))
+                context.AddError("Empty or null Title is an invalid search term");
+        }
+        else if (context.Arguments is MovieQueryArgsWithValidator args2)
+        {
+            if (string.IsNullOrEmpty(args2.Genre))
+                context.AddError("Genre is required");
+            if (string.IsNullOrEmpty(args2.Title))
+                context.AddError("Empty or null Title is an invalid search term");
         }
         return System.Threading.Tasks.Task.CompletedTask;
     }

--- a/src/tests/EntityGraphQL.Tests/ValidationTests.cs
+++ b/src/tests/EntityGraphQL.Tests/ValidationTests.cs
@@ -117,10 +117,13 @@ public class ValidationTests
         .Add(AddPerson)
         .AddValidator(context =>
         {
-            if (context.Arguments is PersonArgs args)
+            foreach (var arg in context.Arguments)
             {
-                if (args.Name == "Luke")
-                    context.AddError("Name can't be Luke");
+                if (arg is PersonArgs args)
+                {
+                    if (args.Name == "Luke")
+                        context.AddError("Name can't be Luke");
+                }
             }
         });
         var gql = new QueryRequest
@@ -264,12 +267,15 @@ public class ValidationTests
             "Get a list of Movies")
             .AddValidator((context) =>
             {
-                if (context.Arguments is MovieQueryArgs args)
+                foreach (var arg in context.Arguments)
                 {
-                    if (args.Price == 150)
-                        context.AddError("You can't use 150 for the price");
-                    if (string.IsNullOrEmpty(args.Title))
-                        context.AddError("Empty or null Title is an invalid search term");
+                    if (arg is MovieQueryArgs args)
+                    {
+                        if (args.Price == 150)
+                            context.AddError("You can't use 150 for the price");
+                        if (string.IsNullOrEmpty(args.Title))
+                            context.AddError("Empty or null Title is an invalid search term");
+                    }
                 }
             });
         var gql = new QueryRequest
@@ -300,12 +306,15 @@ public class ValidationTests
                 // pretend await
                 await System.Threading.Tasks.Task.Run(() =>
                 {
-                    if (context.Arguments is MovieQueryArgs args)
+                    foreach (var arg in context.Arguments)
                     {
-                        if (args.Price == 150)
-                            context.AddError("You can't use 150 for the price");
-                        if (string.IsNullOrEmpty(args.Title))
-                            context.AddError("Empty or null Title is an invalid search term");
+                        if (arg is MovieQueryArgs args)
+                        {
+                            if (args.Price == 150)
+                                context.AddError("You can't use 150 for the price");
+                            if (string.IsNullOrEmpty(args.Title))
+                                context.AddError("Empty or null Title is an invalid search term");
+                        }
                     }
                 });
             });
@@ -358,16 +367,18 @@ internal class PersonValidator : IArgumentValidator
 {
     public System.Threading.Tasks.Task ValidateAsync(ArgumentValidatorContext context)
     {
-        // reusing for tests - but you could too
-        if (context.Arguments is PersonArgs args)
+        foreach (var arg in context.Arguments)
         {
-            if (args.Name == "Luke")
-                context.AddError("Name can't be Luke");
-        }
-        else if (context.Arguments is PersonArgsWithValidator args2)
-        {
-            if (args2.Name == "Luke")
-                context.AddError("Name can't be Luke");
+            if (arg is PersonArgs args)
+            {
+                if (args.Name == "Luke")
+                    context.AddError("Name can't be Luke");
+            }
+            else if (arg is PersonArgsWithValidator args2)
+            {
+                if (args2.Name == "Luke")
+                    context.AddError("Name can't be Luke");
+            }
         }
         return System.Threading.Tasks.Task.CompletedTask;
     }
@@ -377,20 +388,22 @@ internal class MovieValidator : IArgumentValidator
 {
     public System.Threading.Tasks.Task ValidateAsync(ArgumentValidatorContext context)
     {
-        // should always be true 
-        if (context.Arguments is MovieQueryArgs args)
+        foreach (var arg in context.Arguments)
         {
-            if (args.Price == 150)
-                context.AddError("You can't use 150 for the price");
-            if (string.IsNullOrEmpty(args.Title))
-                context.AddError("Empty or null Title is an invalid search term");
-        }
-        else if (context.Arguments is MovieQueryArgsWithValidator args2)
-        {
-            if (string.IsNullOrEmpty(args2.Genre))
-                context.AddError("Genre is required");
-            if (string.IsNullOrEmpty(args2.Title))
-                context.AddError("Empty or null Title is an invalid search term");
+            if (arg is MovieQueryArgs args)
+            {
+                if (args.Price == 150)
+                    context.AddError("You can't use 150 for the price");
+                if (string.IsNullOrEmpty(args.Title))
+                    context.AddError("Empty or null Title is an invalid search term");
+            }
+            else if (arg is MovieQueryArgsWithValidator args2)
+            {
+                if (string.IsNullOrEmpty(args2.Genre))
+                    context.AddError("Genre is required");
+                if (string.IsNullOrEmpty(args2.Title))
+                    context.AddError("Empty or null Title is an invalid search term");
+            }
         }
         return System.Threading.Tasks.Task.CompletedTask;
     }


### PR DESCRIPTION
Previously if `AutoCreateInputTypes` was enabled we didn't know if a parameter should be a GraphQL argument or an injected service unless you used `[GraphQLArguments]`. But this meant you couldn't have complex types as parameters in the method and have them reflected in the schema (`[GraphQLArguments]` flattens the arguments in the schema). This has been refactored to be predictable. 

`AutoCreateInputTypes` now defaults to `true` and you will have to add some attributes to your parameters or classes.

`[GraphQLInputType]` will include the parameter as an argument and use the type as an input type. `[GraphQLArguments]` will flatten the properties of that parameter type into many arguments in the schema.

When looking for a methods parameters, EntityGraphQL will

1. First all scalar / non-complex types will be added at arguments in the schema.

2. If parameter type or enum type is already in the schema it will be added at an argument.

2. Any argument or type with `GraphQLInputTypeAttribute` or `GraphQLArgumentsAttribute` found will be added as schema arguments.

3. If no attributes are found it will assume they are services and not add them to the schema. *I.e. Label your arguments with the attributes or add them to the schema beforehand.*

`AutoCreateInputTypes` now only controls if the type of the argument should be added to the schema.