### PR TITLE
Change AddGraphQLValidator service lifetime to Scoped

### DIFF
--- a/docs/docs/validation.md
+++ b/docs/docs/validation.md
@@ -41,7 +41,7 @@ This service needs to be registered in your service provider. You can always imp
 services.AddGraphQLValidator(); // with EntityGraphQL.AspNet
 
 // Or without / or you own implementation
-services.AddTransient<IGraphQLValidator, GraphQLValidator>();
+services.AddScoped<IGraphQLValidator, GraphQLValidator>();
 
 // your mutation
 public class MovieMutations

--- a/src/EntityGraphQL.AspNet/Extensions/EntityGraphQLAspNetServiceCollectionExtensions.cs
+++ b/src/EntityGraphQL.AspNet/Extensions/EntityGraphQLAspNetServiceCollectionExtensions.cs
@@ -65,7 +65,7 @@ namespace EntityGraphQL.AspNet
         /// <returns></returns>
         public static IServiceCollection AddGraphQLValidator(this IServiceCollection serviceCollection)
         {
-            serviceCollection.TryAddTransient<IGraphQLValidator, GraphQLValidator>();
+            serviceCollection.TryAddScoped<IGraphQLValidator, GraphQLValidator>();
             return serviceCollection;
         }
     }


### PR DESCRIPTION
When GraphQLValidator is added with `Transient` lifetime, a new instance gets created whenever GetService is called.
This causes the system to never report any errors that are added to the validator.

Adding the validator service with a `Scoped` lifetime means the validator lives through the entire request and any errors that were added can be returned in the response.

[ServiceLifetime docs](https://learn.microsoft.com/en-us/dotnet/api/microsoft.extensions.dependencyinjection.servicelifetime)