### PR TITLE
fix conversion of non-nullable/nullable types

### DIFF
--- a/src/EntityGraphQL/Compiler/EntityQuery/EntityQueryNodeVisitor.cs
+++ b/src/EntityGraphQL/Compiler/EntityQuery/EntityQueryNodeVisitor.cs
@@ -226,9 +226,9 @@ namespace EntityGraphQL.Compiler.EntityQuery
         private static Expression ConvertLeftOrRight(ExpressionType op, Expression left, Expression right)
         {
             if (left.Type.IsNullableType() && !right.Type.IsNullableType())
-                right = Expression.Convert(right, left.Type);
+                right = Expression.Convert(right, right.Type.GetNullableType());
             else if (right.Type.IsNullableType() && !left.Type.IsNullableType())
-                left = Expression.Convert(left, right.Type);
+                left = Expression.Convert(left, left.Type.GetNullableType());
 
             else if (left.Type == typeof(int) && (right.Type == typeof(uint) || right.Type == typeof(short) || right.Type == typeof(long) || right.Type == typeof(ushort) || right.Type == typeof(ulong)))
                 right = Expression.Convert(right, left.Type);
@@ -257,6 +257,11 @@ namespace EntityGraphQL.Compiler.EntityQuery
                 else // default try to make types match
                     left = Expression.Convert(left, right.Type);
             }
+
+            if (left.Type.IsNullableType() && !right.Type.IsNullableType())
+                right = Expression.Convert(right, left.Type);
+            else if (right.Type.IsNullableType() && !left.Type.IsNullableType())
+                left = Expression.Convert(left, right.Type);
 
             return Expression.MakeBinary(op, left, right);
         }

--- a/src/EntityGraphQL/Extensions/TypeExtensions.cs
+++ b/src/EntityGraphQL/Extensions/TypeExtensions.cs
@@ -23,6 +23,21 @@ namespace EntityGraphQL.Extensions
             return source;
         }
 
+        /// <summary>
+        /// Return the Type wrapped as a Nullable<>
+        /// </summary>
+        /// <param name="source"></param>
+        /// <returns></returns>
+        public static Type GetNullableType(this Type source)
+        {
+            var type = Nullable.GetUnderlyingType(source) ?? source;
+            if (type.IsValueType)
+                return typeof(Nullable<>).MakeGenericType(type);
+            else
+                return type;
+        }
+
+
         public static Type GetNonNullableOrEnumerableType(this Type source)
         {
             return source.GetNonNullableType().GetEnumerableOrArrayType() ?? source.GetNonNullableType();


### PR DESCRIPTION
After upgrading to .NET 8, queries with a DateTime filter stopped working.

For example:
```
{
  activities(filter: "createdAt > \"2023-07-27T13:52:56.00\"") { 
    totalItems
  }
}
```

Would produce this error:
```
{
  "error": {
    "errors": [
      {
        "message": "No coercion operator is defined between types 'System.String' and 'System.Nullable`1[System.DateTime]'."
      }
    ]
  }
}
```

`ConvertLeftOrRight` was trying to convert a non-nullable string straight into a nullable DateTime.
I altered this to instead change the non-nullable type into a **nullable version of the same type**, which allows the rest of the conversions to take place correctly.