### PR TITLE
Fix #337 - Description attribute accidentally updating name instead of description

### DIFF
--- a/src/EntityGraphQL/Schema/ArgType.cs
+++ b/src/EntityGraphQL/Schema/ArgType.cs
@@ -96,7 +96,7 @@ namespace EntityGraphQL.Schema
             if (memberInfo?.GetCustomAttribute<DescriptionAttribute>() is DescriptionAttribute descAttr)
             {
                 if (!string.IsNullOrEmpty(descAttr.Description))
-                    arg.Name = descAttr.Description;
+                    arg.Description = descAttr.Description;
             }
 
             if (memberInfo?.GetCustomAttribute<GraphQLFieldAttribute>() is GraphQLFieldAttribute gqlFieldAttr)

--- a/src/tests/EntityGraphQL.Tests/MutationTests/MutationTests.cs
+++ b/src/tests/EntityGraphQL.Tests/MutationTests/MutationTests.cs
@@ -988,6 +988,29 @@ namespace EntityGraphQL.Tests
             IEnumerable<string> result = (IEnumerable<string>)results.Data["listOfGuidArgs"];
             Assert.True(new List<string> { "cc3e20f9-9dbb-4ded-8072-6ab3cf0c94da" }.All(i => result.Contains(i)));
         }
+        
+        
+        [Fact]
+        public void TestDescriptionAttribute()
+        {
+            var schemaProvider = SchemaBuilder.FromObject<TestDataContext>();
+            schemaProvider.AddMutationsFrom<PeopleMutations>();
+            var gql = new QueryRequest
+            {
+                Query = @"mutation Mutate($x: Int!) {
+                    descriptionArgs(x: $x)
+                }",
+                Variables = new QueryVariables {
+                    {"x", 3 }
+                }
+            };
+
+            var testSchema = new TestDataContext();
+            var results = schemaProvider.ExecuteRequestWithContext(gql, testSchema, null, null);
+            Assert.Null(results.Errors);
+            var result = (int)results.Data["descriptionArgs"];
+            Assert.Equal(3, result);
+        }
 
         [Fact]
         public void ConstOnMutationArgOrInpoutTypeNotAdded()

--- a/src/tests/EntityGraphQL.Tests/MutationTests/PeopleMutations.cs
+++ b/src/tests/EntityGraphQL.Tests/MutationTests/PeopleMutations.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using EntityGraphQL.Schema;
 using System.Linq.Expressions;
 using System;
+using System.ComponentModel;
 using System.Threading.Tasks;
 using System.ComponentModel.DataAnnotations;
 
@@ -262,6 +263,12 @@ namespace EntityGraphQL.Tests
                 throw new ArgumentException("Ids can not be empty GUID values");
             return args.Ids.Select(g => g.ToString()).ToArray();
         }
+        
+        [GraphQLMutation]
+        static public int DescriptionArgs(DescriptionArgs args)
+        {
+            return args.X;
+        }
     }
 
     public class NestedInputObject
@@ -364,5 +371,12 @@ namespace EntityGraphQL.Tests
     public class ListOfGuidArgs
     {
         public List<Guid> Ids { get; set; }
+    }
+    
+    [GraphQLArguments]
+    public class DescriptionArgs
+    {
+        [Description("The x parameter")]
+        public int X { get; set; }
     }
 }


### PR DESCRIPTION
Annotating a mutation argument with [Description("some description")] now sets the argument's description rather than the name