### PR TITLE
Fix ArgumentException when an entity has indexer property

### DIFF
--- a/src/EntityGraphQL/Schema/SchemaBuilder.cs
+++ b/src/EntityGraphQL/Schema/SchemaBuilder.cs
@@ -297,6 +297,12 @@ namespace EntityGraphQL.Schema
             if (isInputType && GraphQLIgnoreAttribute.ShouldIgnoreMemberFromInput(prop))
                 return false;
 
+            if (prop is PropertyInfo propertyInfo &&
+                propertyInfo.GetIndexParameters().Length > 0)
+            {
+                return false;
+            }
+
             return true;
         }
 


### PR DESCRIPTION
First of all, thanks for the library! I've just started exporing it and everything is working smoothly so far. Well, almost everything, that's why I'm submitting the PR.

Some of the entities in the database context I've been experimenting with use [NpgsqlTsVector](https://www.npgsql.org/doc/api/NpgsqlTypes.NpgsqlTsVector.html) type that causes `SchemaBuilder` to fail with `ArgumentException` (Incorrect number of arguments supplied for call to method 'Lexeme get_Item(Int32)' (Parameter 'property')).

This happens when it tries to build an expression for the indexer property because such properties need an addition argument. Given that such properties are, in fact, methods, I think they should be discarded altogether.