### PR TITLE
make error variable values more distinctive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 5.2.1
+
+## Fixes
+
+- #355 - make error variable values more distinctive
+
 # 5.2.0
 
 Check release notes for the 5.2.0-beta1 and beta2 below.

--- a/src/EntityGraphQL/Compiler/EntityQuery/EntityQueryNodeVisitor.cs
+++ b/src/EntityGraphQL/Compiler/EntityQuery/EntityQueryNodeVisitor.cs
@@ -158,7 +158,7 @@ namespace EntityGraphQL.Compiler.EntityQuery
                         return Expression.Default(enumType.TypeDotnet);
                     }
 
-                    throw new EntityGraphQLCompilerException($"Field {field} not found on type {schemaType.Name}");
+                    throw new EntityGraphQLCompilerException($"Field '{field}' not found on type '{schemaType.Name}'");
                 }
 
                 return enumOrConstantValue;

--- a/src/EntityGraphQL/Compiler/QueryWalkerHelper.cs
+++ b/src/EntityGraphQL/Compiler/QueryWalkerHelper.cs
@@ -82,11 +82,11 @@ namespace EntityGraphQL.Compiler
             foreach (var item in (List<ObjectFieldNode>)argumentValue.Value!)
             {
                 if (!schemaType.HasField(item.Name.Value, null))
-                    throw new EntityGraphQLCompilerException($"Field {item.Name.Value} not found of type {schemaType.Name}");
+                    throw new EntityGraphQLCompilerException($"Field '{item.Name.Value}' not found of type '{schemaType.Name}'");
                 var schemaField = schemaType.GetField(item.Name.Value, null);
 
                 if (schemaField.ResolveExpression == null)
-                    throw new EntityGraphQLCompilerException($"Field {item.Name.Value} on type {schemaType.Name} has no resolve expression");
+                    throw new EntityGraphQLCompilerException($"Field '{item.Name.Value}' on type '{schemaType.Name}' has no resolve expression");
 
                 var nameFromType = ((MemberExpression)schemaField.ResolveExpression).Member.Name;
                 var prop = argType.GetProperty(nameFromType);
@@ -95,7 +95,7 @@ namespace EntityGraphQL.Compiler
                 {
                     var field = argType.GetField(nameFromType);
                     if (field == null)
-                        throw new EntityGraphQLCompilerException($"Field {item.Name.Value} not found on object argument");
+                        throw new EntityGraphQLCompilerException($"Field '{item.Name.Value}' not found on object argument");
                     field.SetValue(obj, ProcessArgumentValue(schema, item.Value, argName, field.FieldType));
                 }
                 else

--- a/src/EntityGraphQL/Schema/BaseSchemaTypeWithFields.cs
+++ b/src/EntityGraphQL/Schema/BaseSchemaTypeWithFields.cs
@@ -136,7 +136,7 @@ namespace EntityGraphQL.Schema
         public IField AddField(IField field)
         {
             if (FieldsByName.ContainsKey(field.Name))
-                throw new EntityQuerySchemaException($"Field {field.Name} already exists on type {this.Name}. Use ReplaceField() if this is intended.");
+                throw new EntityQuerySchemaException($"Field '{field.Name}' already exists on type '{this.Name}'. Use ReplaceField() if this is intended.");
 
             OnAddField(field);
 

--- a/src/EntityGraphQL/Schema/Field.cs
+++ b/src/EntityGraphQL/Schema/Field.cs
@@ -172,7 +172,7 @@ namespace EntityGraphQL.Schema
             // check if we are taking args from elsewhere (extensions do this)
             if (UseArgumentsFromField != null && compileContext != null)
             {
-                newArgParam = compileContext.GetConstantParameterForField(UseArgumentsFromField) ?? throw new EntityGraphQLCompilerException($"Could not find arguments for field {UseArgumentsFromField.Name} in compile context.");
+                newArgParam = compileContext.GetConstantParameterForField(UseArgumentsFromField) ?? throw new EntityGraphQLCompilerException($"Could not find arguments for field '{UseArgumentsFromField.Name}' in compile context.");
                 argumentValue = compileContext.ConstantParameters[newArgParam];
             }
             else if (newArgParam != null)
@@ -210,7 +210,7 @@ namespace EntityGraphQL.Schema
                 returnType = ((MethodCallExpression)fieldExpression.Body).Type;
 
             if (typeof(Task).IsAssignableFrom(returnType))
-                throw new EntityGraphQLCompilerException($"Field {Name} is returning a Task please resolve your async method with .GetAwaiter().GetResult()");
+                throw new EntityGraphQLCompilerException($"Field '{Name}' is returning a Task please resolve your async method with .GetAwaiter().GetResult()");
 
             ReturnType = SchemaBuilder.MakeGraphQlType(Schema, returnType, null);
         }

--- a/src/EntityGraphQL/Schema/SchemaBuilder.cs
+++ b/src/EntityGraphQL/Schema/SchemaBuilder.cs
@@ -103,7 +103,7 @@ namespace EntityGraphQL.Schema
         private static Field? MakeFieldWithIdArgumentIfExists(ISchemaProvider schema, ISchemaType schemaType, Type contextType, Field fieldProp, SchemaBuilderOptions options)
         {
             if (fieldProp.ResolveExpression == null)
-                throw new ArgumentException($"Field {fieldProp.Name} does not have a resolve function. This is required for AutoCreateIdArguments to work.");
+                throw new ArgumentException($"Field '{fieldProp.Name}' does not have a resolve function. This is required for AutoCreateIdArguments to work.");
             if (!fieldProp.ResolveExpression.Type.IsEnumerableOrArray())
                 return null;
             var returnSchemaType = fieldProp.ReturnType.SchemaType;
@@ -112,7 +112,7 @@ namespace EntityGraphQL.Schema
                 return null;
 
             if (idFieldDef.ResolveExpression == null)
-                throw new ArgumentException($"Field {idFieldDef.Name} does not have a resolve function. This is required for AutoCreateIdArguments to work.");
+                throw new ArgumentException($"Field '{idFieldDef.Name}' does not have a resolve function. This is required for AutoCreateIdArguments to work.");
 
             // We need to build an anonymous type with id = RequiredField<idFieldDef.Resolve.Type>()
             // Resulting lambda is (a, p) => a.Where(b => b.Id == p.Id).First()

--- a/src/EntityGraphQL/Schema/SchemaType.cs
+++ b/src/EntityGraphQL/Schema/SchemaType.cs
@@ -86,13 +86,13 @@ namespace EntityGraphQL.Schema
                 throw new InvalidOperationException("Unions cannot contain fields");
 
             if (FieldsByName.ContainsKey(field.Name))
-                throw new EntityQuerySchemaException($"Field {field.Name} already exists on type {Name}. Use ReplaceField() if this is intended.");
+                throw new EntityQuerySchemaException($"Field '{field.Name}' already exists on type '{Name}'. Use ReplaceField() if this is intended.");
 
             if (field.Arguments.Any() && (GqlType == GqlTypes.InputObject || GqlType == GqlTypes.Enum))
-                throw new EntityQuerySchemaException($"Field {field.Name} on type {Name} has arguments but is a GraphQL {GqlType} type and can not have arguments.");
+                throw new EntityQuerySchemaException($"Field '{field.Name}' on type '{Name}' has arguments but is a GraphQL '{GqlType}' type and can not have arguments.");
 
             if (GqlType == GqlTypes.Scalar)
-                throw new EntityQuerySchemaException($"Cannot add field {field.Name} to type {Name}, as {Name} is a scalar type and can not have fields.");
+                throw new EntityQuerySchemaException($"Cannot add field '{field.Name}' to type '{Name}', as '{Name}' is a scalar type and can not have fields.");
 
             FieldsByName.Add(field.Name, field);
             return field;

--- a/src/tests/EntityGraphQL.Tests/EntityQuery/EntityQueryCompilerTests.cs
+++ b/src/tests/EntityGraphQL.Tests/EntityQuery/EntityQueryCompilerTests.cs
@@ -70,7 +70,7 @@ namespace EntityGraphQL.Compiler.EntityQuery.Tests
         public void FailsIdentityNotThere()
         {
             var ex = Assert.Throws<EntityGraphQLCompilerException>(() => EntityQueryCompiler.Compile("wrongField", SchemaBuilder.FromObject<TestSchema>()));
-            Assert.Equal("Field wrongField not found on type Query", ex.Message);
+            Assert.Equal("Field 'wrongField' not found on type 'Query'", ex.Message);
         }
         [Fact]
         public void CompilesIdentityCallFullPath()

--- a/src/tests/EntityGraphQL.Tests/MutationTests/MutationTests.cs
+++ b/src/tests/EntityGraphQL.Tests/MutationTests/MutationTests.cs
@@ -1125,7 +1125,7 @@ namespace EntityGraphQL.Tests
             schema.AddInputType<InputObject>("InputObject", "Using an object in the arguments");
 
             var ex = Assert.Throws<EntityQuerySchemaException>(() => schema.Type<InputObject>().AddField("invalid", new { id = (int?)null }, (ctx, args) => 8, "Invalid field"));
-            Assert.Equal($"Field invalid on type InputObject has arguments but is a GraphQL {nameof(GqlTypes.InputObject)} type and can not have arguments.", ex.Message);
+            Assert.Equal($"Field 'invalid' on type 'InputObject' has arguments but is a GraphQL '{nameof(GqlTypes.InputObject)}' type and can not have arguments.", ex.Message);
         }
     }
 }

--- a/src/tests/EntityGraphQL.Tests/QueryTests/QueryTests.cs
+++ b/src/tests/EntityGraphQL.Tests/QueryTests/QueryTests.cs
@@ -313,7 +313,7 @@ query {
             var schema = SchemaBuilder.FromObject<TestDataContext>();
 
             var ex = Assert.Throws<EntityQuerySchemaException>(() => schema.Type<Gender>().AddField("invalid", new { id = (int?)null }, (ctx, args) => 8, "Invalid field"));
-            Assert.Equal("Field invalid on type Gender has arguments but is a GraphQL Enum type and can not have arguments.", ex.Message);
+            Assert.Equal("Field 'invalid' on type 'Gender' has arguments but is a GraphQL 'Enum' type and can not have arguments.", ex.Message);
         }
         [Fact]
         public void TestNoFieldsOnScalar()
@@ -321,7 +321,7 @@ query {
             var schema = SchemaBuilder.FromObject<TestDataContext>();
 
             var ex = Assert.Throws<EntityQuerySchemaException>(() => schema.Type<string>().AddField("invalid", (ctx) => 8, "Invalid field"));
-            Assert.Equal("Cannot add field invalid to type String, as String is a scalar type and can not have fields.", ex.Message);
+            Assert.Equal("Cannot add field 'invalid' to type 'String', as 'String' is a scalar type and can not have fields.", ex.Message);
         }
 
 

--- a/src/tests/EntityGraphQL.Tests/SchemaTests/SchemaBuilderTests.cs
+++ b/src/tests/EntityGraphQL.Tests/SchemaTests/SchemaBuilderTests.cs
@@ -98,7 +98,7 @@ namespace EntityGraphQL.Tests
             var schemaProvider = SchemaBuilder.FromObject<TestSchema>();
             // user(id: ID) already created
             var ex = Assert.Throws<EntityQuerySchemaException>(() => schemaProvider.Query().AddField("people", new { monkey = ArgumentHelper.Required<int>() }, (ctx, param) => ctx.People.Where(u => u.Id == param.monkey).FirstOrDefault(), "Return a user by ID"));
-            Assert.Equal("Field people already exists on type Query. Use ReplaceField() if this is intended.", ex.Message);
+            Assert.Equal("Field 'people' already exists on type 'Query'. Use ReplaceField() if this is intended.", ex.Message);
         }
 
         [Fact]


### PR DESCRIPTION
I noticed that some error messages returned are harder to quickly grasp. i think this should make them more readable. should i do it for all exceptions all variables or is this enough for now?