### PR TITLE
support building sort type from schema fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ public class PersonArgConstructor
 ## Fixes
 
 - Fix issue where a subscription execution had access to a disposed `IServiceProvider`
+- `Broadcaster` is thread safe when removing observers
 
 # 5.3.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,9 @@ public class PersonArgConstructor
 
 - Fix issue where a subscription execution had access to a disposed `IServiceProvider`
 - `Broadcaster` is thread safe when removing observers
+- Fixes in the implementation of the [GraphQL over Websockets](https://github.com/enisdenjo/graphql-ws/blob/master/PROTOCOL.md)
+  - ID is now a `string` as it does not specify that it must be a `Guid`
+  - Better errors on invalid messages
 
 # 5.3.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - #367 - Remove Antlr dependency for generating the filter expression parser. Replaced with Parlot, a dotnet only solution to remove a barrier for contributors. This also results in the filter (FilterExpression field extension) expressions being compiled up to twice as fast.
 - #334 - add `isAny([])` method to the filter expression language
+- `Broadcaster` exposes its properties and methods are virtual allowing you to extend its functionality instead of writing your own fully
 - #222 - EntityGraphQL can now build a argument objects via their constructor. The parameter names need to match the field names. E.g.
 
 ```cs
@@ -24,6 +25,10 @@ public class PersonArgConstructor
     public string Name { get; }
 }
 ```
+
+## Fixes
+
+- Fix issue where a subscription execution had access to a disposed `IServiceProvider`
 
 # 5.3.0
 

--- a/src/EntityGraphQL.AspNet/EntityGraphQL.AspNet.csproj
+++ b/src/EntityGraphQL.AspNet/EntityGraphQL.AspNet.csproj
@@ -4,6 +4,7 @@
     <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
     <AssemblyName>EntityGraphQL.AspNet</AssemblyName>
     <PackageId>EntityGraphQL.AspNet</PackageId>
+    <LangVersion>12</LangVersion>
     <PackageVersion>5.4.0</PackageVersion>
     <Description>Contains ASP.NET extensions and middleware for EntityGraphQL</Description>
     <Authors>Luke Murray</Authors>

--- a/src/EntityGraphQL.AspNet/Extensions/EntityGraphQLWebApplicationExtensions.cs
+++ b/src/EntityGraphQL.AspNet/Extensions/EntityGraphQLWebApplicationExtensions.cs
@@ -1,18 +1,19 @@
 using System.Net.WebSockets;
-using EntityGraphQL.Schema;
 using EntityGraphQL.AspNet.WebSockets;
+using EntityGraphQL.Schema;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 
-namespace EntityGraphQL.AspNet
-{
-    public static class EntityGraphQLWebApplicationExtensions
-    {
-        public static IApplicationBuilder UseGraphQLWebSockets<TQueryType>(this IApplicationBuilder app, string path = "/subscriptions", ExecutionOptions? options = null)
-        {
-            path = path.TrimEnd('/');
+namespace EntityGraphQL.AspNet;
 
-            app.Use(async (context, next) =>
+public static class EntityGraphQLWebApplicationExtensions
+{
+    public static IApplicationBuilder UseGraphQLWebSockets<TQueryType>(this IApplicationBuilder app, string path = "/subscriptions", ExecutionOptions? options = null)
+    {
+        path = path.TrimEnd('/');
+
+        app.Use(
+            async (context, next) =>
             {
                 if (context.Request.Path == path)
                 {
@@ -21,9 +22,7 @@ namespace EntityGraphQL.AspNet
                         using var webSocket = await context.WebSockets.AcceptWebSocketAsync("graphql-transport-ws");
                         if (!context.WebSockets.WebSocketRequestedProtocols.Contains(webSocket.SubProtocol!))
                         {
-                            await webSocket.CloseAsync(WebSocketCloseStatus.ProtocolError,
-                                "Server only supports the graphql-ws protocol",
-                                context.RequestAborted);
+                            await webSocket.CloseAsync(WebSocketCloseStatus.ProtocolError, "Server only supports the graphql-ws protocol", context.RequestAborted);
 
                             context.Response.StatusCode = StatusCodes.Status400BadRequest;
                             return;
@@ -38,9 +37,9 @@ namespace EntityGraphQL.AspNet
                 {
                     await next(context);
                 }
-            });
+            }
+        );
 
-            return app;
-        }
+        return app;
     }
 }

--- a/src/EntityGraphQL.AspNet/WebSockets/GraphQLWSMessage.cs
+++ b/src/EntityGraphQL.AspNet/WebSockets/GraphQLWSMessage.cs
@@ -1,29 +1,29 @@
 using System;
 using System.Collections.Generic;
 
-namespace EntityGraphQL.AspNet.WebSockets
+namespace EntityGraphQL.AspNet.WebSockets;
+
+public class BaseGraphQLWSResponse
 {
-    public class TypeOnlyGraphQLWSResponse
-    {
-        public string? Type { get; set; }
-    }
+    public string Type { get; set; } = string.Empty;
+}
 
-    public class WithIdGraphQLWSResponse : TypeOnlyGraphQLWSResponse
-    {
-        public Guid? Id { get; set; }
-    }
-    public class GraphQLWSRequest : WithIdGraphQLWSResponse
-    {
-        public QueryRequest? Payload { get; set; }
-    }
+public class BaseWithIdGraphQLWSResponse : BaseGraphQLWSResponse
+{
+    public string? Id { get; set; }
+}
 
-    public class GraphQLWSResponse : WithIdGraphQLWSResponse
-    {
-        public QueryResult? Payload { get; set; }
-    }
+public class GraphQLWSRequest : BaseWithIdGraphQLWSResponse
+{
+    public QueryRequest? Payload { get; set; }
+}
 
-    public class GraphQLWSError : WithIdGraphQLWSResponse
-    {
-        public List<GraphQLError>? Payload { get; set; }
-    }
+public class GraphQLWSResponse : BaseWithIdGraphQLWSResponse
+{
+    public QueryResult? Payload { get; set; }
+}
+
+public class GraphQLWSError : BaseWithIdGraphQLWSResponse
+{
+    public List<GraphQLError>? Payload { get; set; }
 }

--- a/src/EntityGraphQL.AspNet/WebSockets/GraphQLWebSocketServer.cs
+++ b/src/EntityGraphQL.AspNet/WebSockets/GraphQLWebSocketServer.cs
@@ -1,232 +1,240 @@
 using System;
-using System.Linq;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Net.WebSockets;
 using System.Text;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using EntityGraphQL.Schema;
+using EntityGraphQL.Subscriptions;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
-using EntityGraphQL.Subscriptions;
 
-namespace EntityGraphQL.AspNet.WebSockets
+namespace EntityGraphQL.AspNet.WebSockets;
+
+/// <summary>
+/// Implementation of the GraphQL over WebSocket protocol - https://github.com/enisdenjo/graphql-ws/blob/master/PROTOCOL.md.
+/// </summary>
+/// <typeparam name="TQueryType"></typeparam>
+public class GraphQLWebSocketServer<TQueryType> : IGraphQLWebSocketServer
 {
     /// <summary>
-    /// Implementation of the GraphQL over WebSocket protocol - https://github.com/enisdenjo/graphql-ws/blob/master/PROTOCOL.md.
+    /// These are the subscriptions/clients that are currently active with this server.
     /// </summary>
-    /// <typeparam name="TQueryType"></typeparam>
-    public class GraphQLWebSocketServer<TQueryType> : IGraphQLWebSocketServer
+    private readonly Dictionary<Guid, IDisposable> subscriptions = new();
+    private readonly WebSocket webSocket;
+    private readonly ExecutionOptions options;
+    private bool initialised;
+    private readonly JsonSerializerOptions jsonOptions = new() { IncludeFields = true, PropertyNamingPolicy = JsonNamingPolicy.CamelCase, };
+
+    public HttpContext Context { get; }
+
+    public GraphQLWebSocketServer(WebSocket webSocket, HttpContext context, ExecutionOptions? options = null)
     {
-        /// <summary>
-        /// These are the subscriptions/clients that are currently active with this server.
-        /// </summary>
-        private readonly Dictionary<Guid, IDisposable> subscriptions = new();
-        private readonly WebSocket webSocket;
-        private readonly HttpContext context;
-        private readonly ExecutionOptions options;
-        private bool initialised;
-        private readonly JsonSerializerOptions jsonOptions = new()
-        {
-            IncludeFields = true,
-            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-        };
+        this.webSocket = webSocket;
+        this.Context = context;
+        this.options = options ?? new ExecutionOptions();
+    }
 
-        public GraphQLWebSocketServer(WebSocket webSocket, HttpContext context, ExecutionOptions? options = null)
+    public async Task HandleAsync()
+    {
+        while (!webSocket.CloseStatus.HasValue && webSocket.State == WebSocketState.Open)
         {
-            this.webSocket = webSocket;
-            this.context = context;
-            this.options = options ?? new ExecutionOptions();
-        }
-
-        public async Task HandleAsync()
-        {
-            while (!webSocket.CloseStatus.HasValue)
+            using var memoryStream = new MemoryStream();
+            WebSocketReceiveResult? receiveResult = null;
+            do
             {
-                using var memoryStream = new MemoryStream();
-                WebSocketReceiveResult? receiveResult = null;
-                do
+                var buffer = new byte[1024 * 4];
+                var segment = new ArraySegment<byte>(buffer);
+                receiveResult = await webSocket.ReceiveAsync(segment, CancellationToken.None);
+
+                if (receiveResult.CloseStatus.HasValue)
                 {
-                    var buffer = new byte[1024 * 4];
-                    var segment = new ArraySegment<byte>(buffer);
-                    receiveResult = await webSocket.ReceiveAsync(segment, CancellationToken.None);
-
-                    if (receiveResult.CloseStatus.HasValue)
-                    {
-                        await CloseConnectionAsync(receiveResult.CloseStatus.Value, receiveResult.CloseStatusDescription);
-                        break;
-                    }
-
-                    if (receiveResult.Count == 0)
-                        continue;
-
-                    await memoryStream.WriteAsync(segment.AsMemory(segment.Offset, receiveResult.Count), CancellationToken.None);
-                } while (!receiveResult.EndOfMessage);
-
-                if (!webSocket.CloseStatus.HasValue)
-                {
-                    var message = Encoding.UTF8.GetString(memoryStream.ToArray());
-                    await HandleMessageAsync(JsonSerializer.Deserialize<GraphQLWSRequest>(message, jsonOptions)!);
-                }
-            }
-
-            await CloseConnectionAsync(webSocket.CloseStatus.Value, webSocket.CloseStatusDescription);
-        }
-
-        private async Task HandleMessageAsync(GraphQLWSRequest graphQLWSMessage)
-        {
-            switch (graphQLWSMessage.Type)
-            {
-                case GraphQLWSMessageType.ConnectionInit:
-                    {
-                        if (initialised)
-                            await CloseConnectionAsync((WebSocketCloseStatus)4429, "Too many initialisation requests");
-                        else
-                        {
-                            initialised = true;
-                            await SendSimpleResponseAsync(GraphQLWSMessageType.ConnectionAck);
-                        }
-                        break;
-                    }
-                case GraphQLWSMessageType.Ping: await SendSimpleResponseAsync(GraphQLWSMessageType.Pong); break;
-                case GraphQLWSMessageType.Subscribe: await HandleSubscribeAsync(graphQLWSMessage); break;
-                case GraphQLWSMessageType.Complete: CompleteSubscription(graphQLWSMessage.Id!.Value); break;
-                case GraphQLWSMessageType.Pong: break; // can come to us but we don't care
-                default:
-                    await CloseConnectionAsync(WebSocketCloseStatus.InvalidMessageType, $"Unknown message type: {graphQLWSMessage.Type}");
+                    await CloseConnectionAsync(receiveResult.CloseStatus.Value, receiveResult.CloseStatusDescription);
                     break;
+                }
+
+                if (receiveResult.Count == 0)
+                    continue;
+
+                await memoryStream.WriteAsync(segment.AsMemory(segment.Offset, receiveResult.Count), CancellationToken.None);
+            } while (!receiveResult.EndOfMessage);
+
+            if (!webSocket.CloseStatus.HasValue)
+            {
+                var message = Encoding.UTF8.GetString(memoryStream.ToArray());
+                await HandleMessageAsync(JsonSerializer.Deserialize<GraphQLWSRequest>(message, jsonOptions)!);
             }
         }
 
-        private async Task HandleSubscribeAsync(GraphQLWSRequest graphQLWSMessage)
+        await CloseConnectionAsync(webSocket.CloseStatus, webSocket.CloseStatusDescription);
+    }
+
+    private async Task HandleMessageAsync(GraphQLWSRequest graphQLWSMessage)
+    {
+        switch (graphQLWSMessage.Type)
         {
-            if (!initialised)
+            case GraphQLWSMessageType.ConnectionInit:
             {
-                await CloseConnectionAsync((WebSocketCloseStatus)4401, "Unauthorized");
+                if (initialised)
+                    await CloseConnectionAsync((WebSocketCloseStatus)4429, "Too many initialisation requests");
+                else
+                {
+                    initialised = true;
+                    await SendSimpleResponseAsync(GraphQLWSMessageType.ConnectionAck);
+                }
+                break;
+            }
+            case GraphQLWSMessageType.Ping:
+                await SendSimpleResponseAsync(GraphQLWSMessageType.Pong);
+                break;
+            case GraphQLWSMessageType.Subscribe:
+                await HandleSubscribeAsync(graphQLWSMessage);
+                break;
+            case GraphQLWSMessageType.Complete:
+                CompleteSubscription(graphQLWSMessage.Id!.Value);
+                break;
+            case GraphQLWSMessageType.Pong:
+                break; // can come to us but we don't care
+            default:
+                await CloseConnectionAsync(WebSocketCloseStatus.InvalidMessageType, $"Unknown message type: {graphQLWSMessage.Type}");
+                break;
+        }
+    }
+
+    private async Task HandleSubscribeAsync(GraphQLWSRequest graphQLWSMessage)
+    {
+        if (!initialised)
+        {
+            await CloseConnectionAsync((WebSocketCloseStatus)4401, "Unauthorized");
+            return;
+        }
+
+        if (!graphQLWSMessage.Id.HasValue)
+            await CloseConnectionAsync((WebSocketCloseStatus)4400, "Invalid subscribe message, missing id field.");
+        else if (graphQLWSMessage.Payload == null)
+            await CloseConnectionAsync((WebSocketCloseStatus)4400, "Invalid subscribe message, missing payload field.");
+        else
+        {
+            var schema = Context.RequestServices.GetService<SchemaProvider<TQueryType>>();
+            if (schema == null)
+            {
+                await CloseConnectionAsync(
+                    (WebSocketCloseStatus)4400,
+                    $"No SchemaProvider<{typeof(TQueryType).Name}> found in the service collection. Make sure you set up your Startup.ConfigureServices() to call AddGraphQLSchema<{typeof(TQueryType).Name}>()."
+                );
                 return;
             }
 
-            if (!graphQLWSMessage.Id.HasValue)
-                await CloseConnectionAsync((WebSocketCloseStatus)4400, "Invalid subscribe message, missing id field.");
-            else if (graphQLWSMessage.Payload == null)
-                await CloseConnectionAsync((WebSocketCloseStatus)4400, "Invalid subscribe message, missing payload field.");
+            var schemaContext = Context.RequestServices.GetService<TQueryType>();
+            if (schemaContext == null)
+                await CloseConnectionAsync(
+                    (WebSocketCloseStatus)4400,
+                    $"No schema context was found in the service collection. Make sure the {typeof(TQueryType).Name} used with MapGraphQL<{typeof(TQueryType).Name}>() is registered in the service collection."
+                );
+            else if (subscriptions.ContainsKey(graphQLWSMessage.Id.Value))
+                await CloseConnectionAsync((WebSocketCloseStatus)4409, $"Subscriber for {graphQLWSMessage.Id.Value} already exists");
             else
             {
-                var schema = context.RequestServices.GetService<SchemaProvider<TQueryType>>();
-                if (schema == null)
+                var request = graphQLWSMessage.Payload;
+                // executing this sets up the observers etc. We don't return any data until we have an event
+                var result = await schema.ExecuteRequestWithContextAsync(request, schemaContext, Context.RequestServices, Context.User, options)!;
+                if (result.Errors != null)
                 {
-                    await CloseConnectionAsync((WebSocketCloseStatus)4400, $"No SchemaProvider<{typeof(TQueryType).Name}> found in the service collection. Make sure you set up your Startup.ConfigureServices() to call AddGraphQLSchema<{typeof(TQueryType).Name}>().");
-                    return;
+                    await SendErrorAsync(graphQLWSMessage.Id!.Value, result.Errors);
                 }
-
-                var schemaContext = context.RequestServices.GetService<TQueryType>();
-                if (schemaContext == null)
-                    await CloseConnectionAsync((WebSocketCloseStatus)4400, $"No schema context was found in the service collection. Make sure the {typeof(TQueryType).Name} used with MapGraphQL<{typeof(TQueryType).Name}>() is registered in the service collection.");
-                else if (subscriptions.ContainsKey(graphQLWSMessage.Id.Value))
-                    await CloseConnectionAsync((WebSocketCloseStatus)4409, $"Subscriber for {graphQLWSMessage.Id.Value} already exists");
+                // No error and a successful subscribe operation
+                if (result.Data?.Values.First() is GraphQLSubscribeResult subscribeResult)
+                {
+                    var websocketSubscription = (IDisposable)
+                        Activator.CreateInstance(
+                            typeof(WebSocketSubscription<,>).MakeGenericType(typeof(TQueryType), subscribeResult!.EventType),
+                            graphQLWSMessage.Id!.Value,
+                            subscribeResult!.GetObservable(),
+                            this,
+                            subscribeResult!.SubscriptionStatement,
+                            subscribeResult!.Field
+                        )!;
+                    subscriptions.Add(graphQLWSMessage.Id!.Value, websocketSubscription);
+                }
                 else
                 {
-                    var request = graphQLWSMessage.Payload;
-                    // executing this sets up the observers etc. We don't return any data until we have an event
-                    var result = await schema.ExecuteRequestWithContextAsync(request, schemaContext, context.RequestServices, context.User, options)!;
-                    if (result.Errors != null)
+                    // Assume it is a query or mutation over websockets
+                    if (result.Errors == null)
                     {
-                        await SendErrorAsync(graphQLWSMessage.Id!.Value, result.Errors);
+                        await SendNextAsync(graphQLWSMessage.Id!.Value, result);
                     }
-                    // No error and a successful subscribe operation
-                    if (result.Data?.Values.First() is GraphQLSubscribeResult subscribeResult)
-                    {
-                        var websocketSubscription = (IDisposable)Activator.CreateInstance(typeof(WebSocketSubscription<,>).MakeGenericType(typeof(TQueryType), subscribeResult!.EventType), graphQLWSMessage.Id!.Value, subscribeResult!.GetObservable(), this, subscribeResult!.SubscriptionStatement, subscribeResult!.Field)!;
-                        subscriptions.Add(graphQLWSMessage.Id!.Value, websocketSubscription);
-                    }
-                    else
-                    {
-                        // Assume it is a query or mutation over websockets
-                        if (result.Errors == null)
-                        {
-                            await SendNextAsync(graphQLWSMessage.Id!.Value, result);
-                        }
-                        // send complete after next or error above
-                        await SendAsync(new WithIdGraphQLWSResponse
-                        {
-                            Type = GraphQLWSMessageType.Complete,
-                            Id = graphQLWSMessage.Id!.Value,
-                        });
-                    }
+                    // send complete after next or error above
+                    await SendAsync(new WithIdGraphQLWSResponse { Type = GraphQLWSMessageType.Complete, Id = graphQLWSMessage.Id!.Value, });
                 }
             }
         }
+    }
 
-        public async Task SendErrorAsync(Guid id, Exception exception)
-        {
-            await SendErrorAsync(id, new List<GraphQLError> { new GraphQLError(exception.Message, null) });
-        }
-        public Task SendErrorAsync(Guid id, IEnumerable<GraphQLError> errors)
-        {
-            return SendAsync(new GraphQLWSError
+    public async Task SendErrorAsync(Guid id, Exception exception)
+    {
+        await SendErrorAsync(id, new List<GraphQLError> { new GraphQLError(exception.Message, null) });
+    }
+
+    public Task SendErrorAsync(Guid id, IEnumerable<GraphQLError> errors)
+    {
+        return SendAsync(
+            new GraphQLWSError
             {
                 Id = id,
                 Type = GraphQLWSMessageType.Error,
                 Payload = errors.ToList(),
-            });
-        }
-
-        public void CompleteSubscription(Guid id)
-        {
-            subscriptions.TryGetValue(id, out var subscription);
-            if (subscription != null)
-            {
-                subscription.Dispose();
-                subscriptions.Remove(id);
             }
-        }
+        );
+    }
 
-        public async Task SendNextAsync(Guid id, QueryResult result)
+    public void CompleteSubscription(Guid id)
+    {
+        subscriptions.TryGetValue(id, out var subscription);
+        if (subscription != null)
         {
-            await SendAsync(new GraphQLWSResponse
+            subscription.Dispose();
+            subscriptions.Remove(id);
+        }
+    }
+
+    public async Task SendNextAsync(Guid id, QueryResult result)
+    {
+        await SendAsync(
+            new GraphQLWSResponse
             {
                 Id = id,
                 Type = GraphQLWSMessageType.Next,
                 Payload = result,
-            });
-        }
-
-        private async Task SendSimpleResponseAsync(string type)
-        {
-            await SendAsync(new TypeOnlyGraphQLWSResponse
-            {
-                Type = type
-            });
-        }
-
-        private Task SendAsync(object graphQLWSMessage)
-        {
-            var json = JsonSerializer.Serialize(graphQLWSMessage, jsonOptions);
-            var buffer = Encoding.UTF8.GetBytes(json);
-            var segment = new ArraySegment<byte>(buffer);
-            return webSocket.SendAsync(segment, WebSocketMessageType.Text, true, CancellationToken.None);
-        }
-
-        private async Task CloseConnectionAsync(WebSocketCloseStatus closeStatus, string? closeStatusDescription)
-        {
-            if (webSocket.State != WebSocketState.Closed &&
-                webSocket.State != WebSocketState.CloseSent &&
-                webSocket.State != WebSocketState.Aborted)
-            {
-                await webSocket.CloseAsync(closeStatus, closeStatusDescription, CancellationToken.None);
             }
-
-            foreach (var subscription in subscriptions.Values)
-                subscription.Dispose();
-        }
+        );
     }
 
-    public interface IGraphQLWebSocketServer
+    private async Task SendSimpleResponseAsync(string type)
     {
-        void CompleteSubscription(Guid id);
-        Task SendErrorAsync(Guid id, Exception exception);
-        Task SendNextAsync(Guid id, QueryResult result);
+        await SendAsync(new TypeOnlyGraphQLWSResponse { Type = type });
+    }
+
+    private Task SendAsync(object graphQLWSMessage)
+    {
+        if (webSocket.State != WebSocketState.Open)
+            return Task.CompletedTask;
+        var json = JsonSerializer.Serialize(graphQLWSMessage, jsonOptions);
+        var buffer = Encoding.UTF8.GetBytes(json);
+        var segment = new ArraySegment<byte>(buffer);
+        return webSocket.SendAsync(segment, WebSocketMessageType.Text, true, CancellationToken.None);
+    }
+
+    private async Task CloseConnectionAsync(WebSocketCloseStatus? closeStatus, string? closeStatusDescription)
+    {
+        if (webSocket.State != WebSocketState.Closed && webSocket.State != WebSocketState.CloseSent && webSocket.State != WebSocketState.Aborted)
+        {
+            await webSocket.CloseAsync(closeStatus ?? WebSocketCloseStatus.NormalClosure, closeStatusDescription, CancellationToken.None);
+        }
+
+        foreach (var subscription in subscriptions.Values)
+            subscription.Dispose();
     }
 }

--- a/src/EntityGraphQL.AspNet/WebSockets/IGraphQLWebSocketServer.cs
+++ b/src/EntityGraphQL.AspNet/WebSockets/IGraphQLWebSocketServer.cs
@@ -1,0 +1,13 @@
+using System;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+
+namespace EntityGraphQL.AspNet.WebSockets;
+
+public interface IGraphQLWebSocketServer
+{
+    public HttpContext Context { get; }
+    void CompleteSubscription(Guid id);
+    Task SendErrorAsync(Guid id, Exception exception);
+    Task SendNextAsync(Guid id, QueryResult result);
+}

--- a/src/EntityGraphQL.AspNet/WebSockets/IGraphQLWebSocketServer.cs
+++ b/src/EntityGraphQL.AspNet/WebSockets/IGraphQLWebSocketServer.cs
@@ -7,7 +7,7 @@ namespace EntityGraphQL.AspNet.WebSockets;
 public interface IGraphQLWebSocketServer
 {
     public HttpContext Context { get; }
-    void CompleteSubscription(Guid id);
-    Task SendErrorAsync(Guid id, Exception exception);
-    Task SendNextAsync(Guid id, QueryResult result);
+    Task CompleteSubscriptionAsync(string id);
+    Task SendErrorAsync(string id, Exception exception);
+    Task SendNextAsync(string id, QueryResult result);
 }

--- a/src/EntityGraphQL.AspNet/WebSockets/WebSocketSubscription.cs
+++ b/src/EntityGraphQL.AspNet/WebSockets/WebSocketSubscription.cs
@@ -2,62 +2,61 @@ using System;
 using System.Collections.Generic;
 using EntityGraphQL.Compiler;
 
-namespace EntityGraphQL.AspNet.WebSockets
+namespace EntityGraphQL.AspNet.WebSockets;
+
+/// <summary>
+/// Ties the GraphQL subscription to the WebSocket connection.
+/// </summary>
+/// <typeparam name="TEventType"></typeparam>
+public sealed class WebSocketSubscription<TQueryContext, TEventType> : IDisposable, IObserver<TEventType>
 {
-    /// <summary>
-    /// Ties the GraphQL subscription to the WebSocket connection.
-    /// </summary>
-    /// <typeparam name="TEventType"></typeparam>
-    public sealed class WebSocketSubscription<TQueryContext, TEventType> : IDisposable, IObserver<TEventType>
+    private readonly Guid id;
+    private readonly IObservable<TEventType> observable;
+    private readonly IGraphQLWebSocketServer server;
+    private readonly IDisposable subscription;
+    private readonly GraphQLSubscriptionStatement subscriptionStatement;
+    private readonly GraphQLSubscriptionField subscriptionNode;
+
+    public WebSocketSubscription(Guid id, object observable, IGraphQLWebSocketServer server, GraphQLSubscriptionStatement subscriptionStatement, GraphQLSubscriptionField node)
     {
-        private readonly Guid id;
-        private readonly IObservable<TEventType> observable;
-        private readonly IGraphQLWebSocketServer server;
-        private readonly IDisposable subscription;
-        private readonly GraphQLSubscriptionStatement subscriptionStatement;
-        private readonly GraphQLSubscriptionField subscriptionNode;
+        this.id = id;
+        if (observable is not IObservable<TEventType>)
+            throw new ArgumentException($"{nameof(observable)} must be of type {nameof(IObservable<TEventType>)}");
+        this.observable = (IObservable<TEventType>)observable;
+        this.server = server;
+        this.subscriptionStatement = subscriptionStatement;
+        this.subscriptionNode = node;
 
-        public WebSocketSubscription(Guid id, object observable, IGraphQLWebSocketServer server, GraphQLSubscriptionStatement subscriptionStatement, GraphQLSubscriptionField node)
+        this.subscription = this.observable.Subscribe(this);
+    }
+
+    public void OnNext(TEventType value)
+    {
+        try
         {
-            this.id = id;
-            if (observable is not IObservable<TEventType>)
-                throw new ArgumentException($"{nameof(observable)} must be of type {nameof(IObservable<TEventType>)}");
-            this.observable = (IObservable<TEventType>)observable;
-            this.server = server;
-            this.subscriptionStatement = subscriptionStatement;
-            this.subscriptionNode = node;
-
-            this.subscription = this.observable.Subscribe(this);
+            var data = subscriptionStatement.ExecuteSubscriptionEvent<TQueryContext, TEventType>(subscriptionNode, value, server.Context.RequestServices);
+            var result = new QueryResult();
+            result.SetData(new Dictionary<string, object?> { { subscriptionNode.Name, data } });
+            server.SendNextAsync(id, result).GetAwaiter().GetResult();
         }
-
-        public void OnNext(TEventType value)
+        catch (Exception ex)
         {
-            try
-            {
-                var data = subscriptionStatement.ExecuteSubscriptionEvent<TQueryContext, TEventType>(subscriptionNode, value, server.Context.RequestServices);
-                var result = new QueryResult();
-                result.SetData(new Dictionary<string, object?> { { subscriptionNode.Name, data } });
-                server.SendNextAsync(id, result).GetAwaiter().GetResult();
-            }
-            catch (Exception ex)
-            {
-                OnError(ex);
-            }
+            OnError(ex);
         }
+    }
 
-        public void OnError(Exception error)
-        {
-            server.SendErrorAsync(id, error).GetAwaiter().GetResult();
-        }
+    public void OnError(Exception error)
+    {
+        server.SendErrorAsync(id, error).GetAwaiter().GetResult();
+    }
 
-        public void OnCompleted()
-        {
-            server.CompleteSubscription(id);
-        }
+    public void OnCompleted()
+    {
+        server.CompleteSubscription(id);
+    }
 
-        public void Dispose()
-        {
-            subscription.Dispose();
-        }
+    public void Dispose()
+    {
+        subscription.Dispose();
     }
 }

--- a/src/EntityGraphQL.AspNet/WebSockets/WebSocketSubscription.cs
+++ b/src/EntityGraphQL.AspNet/WebSockets/WebSocketSubscription.cs
@@ -8,7 +8,7 @@ namespace EntityGraphQL.AspNet.WebSockets
     /// Ties the GraphQL subscription to the WebSocket connection.
     /// </summary>
     /// <typeparam name="TEventType"></typeparam>
-    internal sealed class WebSocketSubscription<TQueryContext, TEventType> : IDisposable, IObserver<TEventType>
+    public sealed class WebSocketSubscription<TQueryContext, TEventType> : IDisposable, IObserver<TEventType>
     {
         private readonly Guid id;
         private readonly IObservable<TEventType> observable;
@@ -34,7 +34,7 @@ namespace EntityGraphQL.AspNet.WebSockets
         {
             try
             {
-                var data = subscriptionStatement.ExecuteSubscriptionEvent<TQueryContext, TEventType>(subscriptionNode, value);
+                var data = subscriptionStatement.ExecuteSubscriptionEvent<TQueryContext, TEventType>(subscriptionNode, value, server.Context.RequestServices);
                 var result = new QueryResult();
                 result.SetData(new Dictionary<string, object?> { { subscriptionNode.Name, data } });
                 server.SendNextAsync(id, result).GetAwaiter().GetResult();

--- a/src/EntityGraphQL/Compiler/GqlNodes/ExecutableGraphQLStatement.cs
+++ b/src/EntityGraphQL/Compiler/GqlNodes/ExecutableGraphQLStatement.cs
@@ -10,305 +10,384 @@ using EntityGraphQL.Extensions;
 using EntityGraphQL.Schema;
 using Microsoft.Extensions.DependencyInjection;
 
-namespace EntityGraphQL.Compiler
+namespace EntityGraphQL.Compiler;
+
+/// <summary>
+/// Base class for document statements that we "execute" - Query and Mutation. Execution runs the expression and gets the data result
+/// A fragment is just a definition
+/// </summary>
+public abstract class ExecutableGraphQLStatement : IGraphQLNode
 {
+    public Expression? NextFieldContext { get; }
+    public IGraphQLNode? ParentNode { get; }
+    public ParameterExpression? RootParameter { get; }
+
     /// <summary>
-    /// Base class for document statements that we "execute" - Query and Mutation. Execution runs the expression and gets the data result
-    /// A fragment is just a definition
+    /// Variables that are expected to be passed in to execute this query
     /// </summary>
-    public abstract class ExecutableGraphQLStatement : IGraphQLNode
+    protected Dictionary<string, ArgType> OpDefinedVariables { get; set; } = new();
+    public ISchemaProvider Schema { get; protected set; }
+
+    public ParameterExpression? OpVariableParameter { get; }
+
+    public IField? Field { get; }
+    public bool HasServices
     {
-        public Expression? NextFieldContext { get; }
-        public IGraphQLNode? ParentNode { get; }
-        public ParameterExpression? RootParameter { get; }
-        /// <summary>
-        /// Variables that are expected to be passed in to execute this query
-        /// </summary>
-        protected Dictionary<string, ArgType> OpDefinedVariables { get; set; } = new();
-        public ISchemaProvider Schema { get; protected set; }
+        get => Field?.Services.Count > 0;
+    }
 
-        public ParameterExpression? OpVariableParameter { get; }
+    public IReadOnlyDictionary<string, object> Arguments { get; }
 
-        public IField? Field { get; }
-        public bool HasServices { get => Field?.Services.Count > 0; }
+    public string? Name { get; }
 
-        public IReadOnlyDictionary<string, object> Arguments { get; }
+    public List<BaseGraphQLField> QueryFields { get; } = [];
+    protected List<GraphQLDirective> Directives { get; } = [];
 
-        public string? Name { get; }
+    /// <summary>
+    /// This represents the operation type node which is not a root field
+    /// </summary>
+    public bool IsRootField => false;
 
-        public List<BaseGraphQLField> QueryFields { get; } = [];
-        protected List<GraphQLDirective> Directives { get; } = [];
-        /// <summary>
-        /// This represents the operation type node which is not a root field
-        /// </summary>
-        public bool IsRootField => false;
-
-        public ExecutableGraphQLStatement(ISchemaProvider schema, string? name, Expression nodeExpression, ParameterExpression rootParameter, Dictionary<string, ArgType> opVariables)
+    public ExecutableGraphQLStatement(ISchemaProvider schema, string? name, Expression nodeExpression, ParameterExpression rootParameter, Dictionary<string, ArgType> opVariables)
+    {
+        Name = name;
+        NextFieldContext = nodeExpression;
+        RootParameter = rootParameter;
+        OpDefinedVariables = opVariables;
+        this.Schema = schema;
+        Arguments = new Dictionary<string, object>();
+        if (OpDefinedVariables.Count > 0)
         {
-            Name = name;
-            NextFieldContext = nodeExpression;
-            RootParameter = rootParameter;
-            OpDefinedVariables = opVariables;
-            this.Schema = schema;
-            Arguments = new Dictionary<string, object>();
-            if (OpDefinedVariables.Count > 0)
+            var variableType = LinqRuntimeTypeBuilder.GetDynamicType(OpDefinedVariables.ToDictionary(f => f.Key, f => f.Value.RawType), "docVars");
+            OpVariableParameter = Expression.Parameter(variableType, "docVars");
+        }
+    }
+
+    public virtual async Task<ConcurrentDictionary<string, object?>> ExecuteAsync<TContext>(
+        TContext? context,
+        IServiceProvider? serviceProvider,
+        List<GraphQLFragmentStatement> fragments,
+        Func<string, string> fieldNamer,
+        ExecutionOptions options,
+        QueryVariables? variables
+    )
+    {
+        if (context == null && serviceProvider == null)
+            throw new EntityGraphQLCompilerException("Either context or serviceProvider must be provided.");
+
+        // build separate expression for all root level nodes in the op e.g. op is
+        // query Op1 {
+        //      people { name id }
+        //      movies { released name }
+        // }
+        // people & movies will be the 2 fields that will be 2 separate expressions
+        var result = new ConcurrentDictionary<string, object?>();
+
+        object? docVariables = BuildDocumentVariables(ref variables);
+
+        foreach (var fieldNode in QueryFields)
+        {
+            try
             {
-                var variableType = LinqRuntimeTypeBuilder.GetDynamicType(OpDefinedVariables.ToDictionary(f => f.Key, f => f.Value.RawType), "docVars");
-                OpVariableParameter = Expression.Parameter(variableType, "docVars");
+#if DEBUG
+                Stopwatch? timer = null;
+                if (options.IncludeDebugInfo)
+                {
+                    timer = new Stopwatch();
+                    timer.Start();
+                }
+#endif
+                var contextToUse = GetContextToUse(context, serviceProvider!, fieldNode)!;
+
+                (var data, var didExecute) = await CompileAndExecuteNodeAsync(new CompileContext(options, null), contextToUse, serviceProvider, fragments, fieldNode, docVariables);
+#if DEBUG
+                if (options.IncludeDebugInfo)
+                {
+                    timer?.Stop();
+                    result[$"__{fieldNode.Name}_timeMs"] = timer?.ElapsedMilliseconds;
+                }
+#endif
+
+                if (didExecute)
+                    result[fieldNode.Name] = data;
+            }
+            catch (EntityGraphQLValidationException)
+            {
+                throw;
+            }
+            catch (EntityGraphQLFieldException)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                throw new EntityGraphQLFieldException(fieldNode.Name, ex);
             }
         }
+        return result;
+    }
 
-        public virtual async Task<ConcurrentDictionary<string, object?>> ExecuteAsync<TContext>(TContext? context, IServiceProvider? serviceProvider, List<GraphQLFragmentStatement> fragments, Func<string, string> fieldNamer, ExecutionOptions options, QueryVariables? variables)
+    protected static TContext GetContextToUse<TContext>(TContext? context, IServiceProvider serviceProvider, BaseGraphQLField fieldNode)
+    {
+        if (context == null)
+            return serviceProvider.GetService<TContext>()!
+                ?? throw new EntityGraphQLCompilerException($"Could not find service of type {typeof(TContext).Name} to execute field {fieldNode.Name}");
+
+        return context;
+    }
+
+    protected object? BuildDocumentVariables(ref QueryVariables? variables)
+    {
+        // inject document level variables - letting the query be cached and passing in different variables
+        object? variablesToUse = null;
+
+        if (OpDefinedVariables.Count > 0 && OpVariableParameter != null)
         {
-            if (context == null && serviceProvider == null)
-                throw new EntityGraphQLCompilerException("Either context or serviceProvider must be provided.");
-
-            // build separate expression for all root level nodes in the op e.g. op is
-            // query Op1 {
-            //      people { name id }
-            //      movies { released name }
-            // }
-            // people & movies will be the 2 fields that will be 2 separate expressions
-            var result = new ConcurrentDictionary<string, object?>();
-
-            object? docVariables = BuildDocumentVariables(ref variables);
-
-            foreach (var fieldNode in QueryFields)
+            variables ??= new QueryVariables();
+            variablesToUse = Activator.CreateInstance(OpVariableParameter.Type);
+            foreach (var (name, argType) in OpDefinedVariables)
             {
                 try
                 {
-#if DEBUG
-                    Stopwatch? timer = null;
-                    if (options.IncludeDebugInfo)
-                    {
-                        timer = new Stopwatch();
-                        timer.Start();
-                    }
-#endif
-                    var contextToUse = GetContextToUse(context, serviceProvider!, fieldNode)!;
-
-                    (var data, var didExecute) = await CompileAndExecuteNodeAsync(new CompileContext(options, null), contextToUse, serviceProvider, fragments, fieldNode, docVariables);
-#if DEBUG
-                    if (options.IncludeDebugInfo)
-                    {
-                        timer?.Stop();
-                        result[$"__{fieldNode.Name}_timeMs"] = timer?.ElapsedMilliseconds;
-                    }
-#endif
-
-                    if (didExecute)
-                        result[fieldNode.Name] = data;
+                    var argValue = ExpressionUtil.ChangeType(variables.GetValueOrDefault(name) ?? argType.DefaultValue, argType.RawType, Schema, null);
+                    if (argValue == null && argType.IsRequired)
+                        throw new EntityGraphQLCompilerException(
+                            $"Supplied variable '{name}' is null while the variable definition is non-null. Please update query document or supply a non-null value."
+                        );
+                    OpVariableParameter.Type.GetField(name)!.SetValue(variablesToUse, argValue);
                 }
-                catch (EntityGraphQLValidationException)
-                {
-                    throw;
-                }
-                catch (EntityGraphQLFieldException)
+                catch (EntityGraphQLCompilerException)
                 {
                     throw;
                 }
                 catch (Exception ex)
                 {
-                    throw new EntityGraphQLFieldException(fieldNode.Name, ex);
+                    throw new EntityGraphQLCompilerException($"Supplied variable '{name}' can not be applied to defined variable type '{argType.Type}'", ex);
                 }
             }
-            return result;
         }
 
-        protected static TContext GetContextToUse<TContext>(TContext? context, IServiceProvider serviceProvider, BaseGraphQLField fieldNode)
+        return variablesToUse;
+    }
+
+    protected async Task<(object? result, bool didExecute)> CompileAndExecuteNodeAsync(
+        CompileContext compileContext,
+        object context,
+        IServiceProvider? serviceProvider,
+        List<GraphQLFragmentStatement> fragments,
+        BaseGraphQLField node,
+        object? docVariables
+    )
+    {
+        object? runningContext = context;
+
+        var replacer = new ParameterReplacer();
+        // For root/top level fields we need to first select the whole graph without fields that require services
+        // so that EF Core 3.1+ can run and optimise the query against the DB
+        // We then select the full graph from that context
+
+        if (node.RootParameter == null)
+            throw new EntityGraphQLCompilerException($"Root parameter not set for {node.Name}");
+
+        Expression? expression = null;
+        var contextParam = node.RootParameter;
+
+        if (node.HasServicesAtOrBelow(fragments) && compileContext.ExecutionOptions.ExecuteServiceFieldsSeparately == true)
         {
-            if (context == null)
-                return serviceProvider.GetService<TContext>()! ?? throw new EntityGraphQLCompilerException($"Could not find service of type {typeof(TContext).Name} to execute field {fieldNode.Name}");
-
-            return context;
-        }
-
-        protected object? BuildDocumentVariables(ref QueryVariables? variables)
-        {
-            // inject document level variables - letting the query be cached and passing in different variables
-            object? variablesToUse = null;
-
-            if (OpDefinedVariables.Count > 0 && OpVariableParameter != null)
+            // build this first as NodeExpression may modify ConstantParameters
+            // this is without fields that require services
+            expression = node.GetNodeExpression(
+                compileContext,
+                serviceProvider,
+                fragments,
+                OpVariableParameter,
+                docVariables,
+                contextParam,
+                withoutServiceFields: true,
+                null,
+                null,
+                false,
+                replacer
+            );
+            if (expression != null)
             {
-                variables ??= new QueryVariables();
-                variablesToUse = Activator.CreateInstance(OpVariableParameter.Type);
-                foreach (var (name, argType) in OpDefinedVariables)
+                // execute expression now and get a result that we will then perform a full select over
+                // This part is happening via EntityFramework if you use it
+                (runningContext, _) = await ExecuteExpressionAsync(expression, runningContext!, contextParam, serviceProvider, replacer, compileContext, node, false);
+                if (runningContext == null)
+                    return (null, true);
+
+                // the full selection is now on the anonymous type returned by the selection without fields. We don't know the type until now
+                var newContextType = Expression.Parameter(runningContext.GetType(), "ctx_no_srv");
+
+                // core context data is fetched. Now fetch all the bulk resolvers
+                var bulkData = ResolveBulkLoaders(compileContext, serviceProvider, node, runningContext, replacer, newContextType);
+
+                // new context
+                compileContext = new(compileContext.ExecutionOptions, bulkData);
+
+                // we now know the selection type without services and need to build the full select on that type
+                // need to rebuild the full query
+                expression = node.GetNodeExpression(
+                    compileContext,
+                    serviceProvider,
+                    fragments,
+                    OpVariableParameter,
+                    docVariables,
+                    newContextType,
+                    false,
+                    replacementNextFieldContext: newContextType,
+                    null,
+                    contextChanged: true,
+                    replacer
+                );
+                contextParam = newContextType;
+            }
+        }
+
+        if (expression == null)
+        {
+            // just do things normally
+            expression = node.GetNodeExpression(
+                compileContext,
+                serviceProvider,
+                fragments,
+                OpVariableParameter,
+                docVariables,
+                contextParam,
+                false,
+                null,
+                null,
+                contextChanged: false,
+                replacer
+            );
+        }
+
+        var data = await ExecuteExpressionAsync(expression, runningContext, contextParam, serviceProvider, replacer, compileContext, node, true);
+        return data;
+    }
+
+    private static Dictionary<string, object> ResolveBulkLoaders(
+        CompileContext compileContext,
+        IServiceProvider? serviceProvider,
+        BaseGraphQLField node,
+        object? runningContext,
+        ParameterReplacer replacer,
+        ParameterExpression newContextType
+    )
+    {
+        var bulkData = new Dictionary<string, object>();
+        if (compileContext.BulkResolvers?.Count > 0)
+        {
+            foreach (var bulkResolver in compileContext.BulkResolvers)
+            {
+                // rebuild list expression on new context
+                var toReplace = node.Field!.ResolveExpression!;
+                var listExpression = replacer.Replace(bulkResolver.ListExpression, toReplace, newContextType);
+                var newParam = Expression.Parameter(listExpression.Type.GetEnumerableOrArrayType()!, "bulkList");
+                // replace the data selection expression with the new context
+                var expReplacer = new ExpressionReplacer(bulkResolver.ExtractedFields, newParam, false, false, null);
+                var selection = expReplacer.Replace(bulkResolver.DataSelection.Body);
+                var selectionLambda = Expression.Lambda(selection, newParam);
+                selection = ExpressionUtil.MakeCallOnEnumerable(nameof(Enumerable.Select), [newParam.Type, selection.Type], listExpression, selectionLambda);
+
+                var bulkDataArgs = Expression.Lambda(selection, newContextType).Compile().DynamicInvoke([runningContext]);
+                var parameters = new List<ParameterExpression> { bulkResolver.FieldExpression.Parameters.First() };
+                var allArgs = new List<object?> { bulkDataArgs };
+                var bulkLoader = GraphQLHelper.InjectServices(serviceProvider!, compileContext.Services, allArgs, bulkResolver.FieldExpression.Body, parameters, replacer);
+                if (compileContext.ConstantParameters.Any())
                 {
-                    try
-                    {
-                        var argValue = ExpressionUtil.ChangeType(variables.GetValueOrDefault(name) ?? argType.DefaultValue, argType.RawType, Schema, null);
-                        if (argValue == null && argType.IsRequired)
-                            throw new EntityGraphQLCompilerException($"Supplied variable '{name}' is null while the variable definition is non-null. Please update query document or supply a non-null value.");
-                        OpVariableParameter.Type.GetField(name)!.SetValue(variablesToUse, argValue);
-                    }
-                    catch (EntityGraphQLCompilerException)
-                    {
-                        throw;
-                    }
-                    catch (Exception ex)
-                    {
-                        throw new EntityGraphQLCompilerException($"Supplied variable '{name}' can not be applied to defined variable type '{argType.Type}'", ex);
-                    }
+                    parameters.AddRange(compileContext.ConstantParameters.Keys);
+                    allArgs.AddRange(compileContext.ConstantParameters.Values);
                 }
-            }
 
-            return variablesToUse;
+                var dataLoaded = Expression.Lambda(bulkLoader, parameters).Compile().DynamicInvoke([.. allArgs])!;
+                bulkData[bulkResolver.Name] = dataLoaded;
+            }
         }
 
-        protected async Task<(object? result, bool didExecute)> CompileAndExecuteNodeAsync(CompileContext compileContext, object context, IServiceProvider? serviceProvider, List<GraphQLFragmentStatement> fragments, BaseGraphQLField node, object? docVariables)
+        return bulkData;
+    }
+
+    private static async Task<(object? result, bool didExecute)> ExecuteExpressionAsync(
+        Expression? expression,
+        object context,
+        ParameterExpression contextParam,
+        IServiceProvider? serviceProvider,
+        ParameterReplacer replacer,
+        CompileContext compileContext,
+        BaseGraphQLField node,
+        bool isFinal
+    )
+    {
+        // they had a query with a directive that was skipped, resulting in an empty query?
+        if (expression == null)
+            return (null, false);
+
+        var allArgs = new List<object?> { context };
+
+        var parameters = new List<ParameterExpression> { contextParam };
+
+        // this is the full requested graph
+        // inject dependencies into the fullSelection
+        if (serviceProvider != null)
         {
-            object? runningContext = context;
-
-            var replacer = new ParameterReplacer();
-            // For root/top level fields we need to first select the whole graph without fields that require services
-            // so that EF Core 3.1+ can run and optimise the query against the DB
-            // We then select the full graph from that context
-
-            if (node.RootParameter == null)
-                throw new EntityGraphQLCompilerException($"Root parameter not set for {node.Name}");
-
-            Expression? expression = null;
-            var contextParam = node.RootParameter;
-
-            if (node.HasServicesAtOrBelow(fragments) && compileContext.ExecutionOptions.ExecuteServiceFieldsSeparately == true)
-            {
-                // build this first as NodeExpression may modify ConstantParameters
-                // this is without fields that require services
-                expression = node.GetNodeExpression(compileContext, serviceProvider, fragments, OpVariableParameter, docVariables, contextParam, withoutServiceFields: true, null, null, false, replacer);
-                if (expression != null)
-                {
-                    // execute expression now and get a result that we will then perform a full select over
-                    // This part is happening via EntityFramework if you use it
-                    (runningContext, _) = await ExecuteExpressionAsync(expression, runningContext!, contextParam, serviceProvider, replacer, compileContext, node, false);
-                    if (runningContext == null)
-                        return (null, true);
-
-                    // the full selection is now on the anonymous type returned by the selection without fields. We don't know the type until now
-                    var newContextType = Expression.Parameter(runningContext.GetType(), "ctx_no_srv");
-
-                    // core context data is fetched. Now fetch all the bulk resolvers
-                    var bulkData = ResolveBulkLoaders(compileContext, serviceProvider, node, runningContext, replacer, newContextType);
-
-                    // new context
-                    compileContext = new(compileContext.ExecutionOptions, bulkData);
-
-                    // we now know the selection type without services and need to build the full select on that type
-                    // need to rebuild the full query
-                    expression = node.GetNodeExpression(compileContext, serviceProvider, fragments, OpVariableParameter, docVariables, newContextType, false, replacementNextFieldContext: newContextType, null, contextChanged: true, replacer);
-                    contextParam = newContextType;
-                }
-            }
-
-            if (expression == null)
-            {
-                // just do things normally
-                expression = node.GetNodeExpression(compileContext, serviceProvider, fragments, OpVariableParameter, docVariables, contextParam, false, null, null, contextChanged: false, replacer);
-            }
-
-            var data = await ExecuteExpressionAsync(expression, runningContext, contextParam, serviceProvider, replacer, compileContext, node, true);
-            return data;
+            expression = GraphQLHelper.InjectServices(serviceProvider, compileContext.Services, allArgs, expression, parameters, replacer);
         }
 
-        private static Dictionary<string, object> ResolveBulkLoaders(CompileContext compileContext, IServiceProvider? serviceProvider, BaseGraphQLField node, object? runningContext, ParameterReplacer replacer, ParameterExpression newContextType)
+        if (compileContext.ConstantParameters.Any())
         {
-            var bulkData = new Dictionary<string, object>();
-            if (compileContext.BulkResolvers?.Count > 0)
-            {
-                foreach (var bulkResolver in compileContext.BulkResolvers)
-                {
-                    // rebuild list expression on new context
-                    var toReplace = node.Field!.ResolveExpression!;
-                    var listExpression = replacer.Replace(bulkResolver.ListExpression, toReplace, newContextType);
-                    var newParam = Expression.Parameter(listExpression.Type.GetEnumerableOrArrayType()!, "bulkList");
-                    // replace the data selection expression with the new context
-                    var expReplacer = new ExpressionReplacer(bulkResolver.ExtractedFields, newParam, false, false, null);
-                    var selection = expReplacer.Replace(bulkResolver.DataSelection.Body);
-                    var selectionLambda = Expression.Lambda(selection, newParam);
-                    selection = ExpressionUtil.MakeCallOnEnumerable(nameof(Enumerable.Select), [newParam.Type, selection.Type], listExpression, selectionLambda);
-
-                    var bulkDataArgs = Expression.Lambda(selection, newContextType).Compile().DynamicInvoke([runningContext]);
-                    var parameters = new List<ParameterExpression> { bulkResolver.FieldExpression.Parameters.First() };
-                    var allArgs = new List<object?> { bulkDataArgs };
-                    var bulkLoader = GraphQLHelper.InjectServices(serviceProvider!, compileContext.Services, allArgs, bulkResolver.FieldExpression.Body, parameters, replacer);
-                    if (compileContext.ConstantParameters.Any())
-                    {
-                        parameters.AddRange(compileContext.ConstantParameters.Keys);
-                        allArgs.AddRange(compileContext.ConstantParameters.Values);
-                    }
-
-                    var dataLoaded = Expression.Lambda(bulkLoader, parameters).Compile().DynamicInvoke([.. allArgs])!;
-                    bulkData[bulkResolver.Name] = dataLoaded;
-                }
-            }
-
-            return bulkData;
+            parameters.AddRange(compileContext.ConstantParameters.Keys);
+            allArgs.AddRange(compileContext.ConstantParameters.Values);
         }
 
-        private static async Task<(object? result, bool didExecute)> ExecuteExpressionAsync(Expression? expression, object context, ParameterExpression contextParam, IServiceProvider? serviceProvider, ParameterReplacer replacer, CompileContext compileContext, BaseGraphQLField node, bool isFinal)
+        // evaluate everything using ToList(). But handle null result
+        if (expression.Type.IsEnumerableOrArray() && !expression.Type.IsDictionary())
         {
-            // they had a query with a directive that was skipped, resulting in an empty query?
-            if (expression == null)
-                return (null, false);
+            var returnType = typeof(List<>).MakeGenericType(expression.Type.GetEnumerableOrArrayType()!);
+            expression = Expression.Call(
+                typeof(EnumerableExtensions),
+                nameof(EnumerableExtensions.ToListWithNullCheck),
+                new[] { expression.Type.GetEnumerableOrArrayType()! },
+                expression,
+                Expression.Constant(node.Field!.ReturnType.TypeNotNullable)
+            );
+        }
 
-            var allArgs = new List<object?> { context };
+        if (compileContext.BulkData != null)
+        {
+            parameters.Add(compileContext.BulkParameter!);
+            allArgs.Add(compileContext.BulkData);
+        }
 
-            var parameters = new List<ParameterExpression> { contextParam };
+        if (compileContext.ExecutionOptions.BeforeExecuting != null)
+        {
+            expression = compileContext.ExecutionOptions.BeforeExecuting.Invoke(expression, isFinal);
+        }
 
-            // this is the full requested graph
-            // inject dependencies into the fullSelection
-            if (serviceProvider != null)
-            {
-                expression = GraphQLHelper.InjectServices(serviceProvider, compileContext.Services, allArgs, expression, parameters, replacer);
-            }
-
-            if (compileContext.ConstantParameters.Any())
-            {
-                parameters.AddRange(compileContext.ConstantParameters.Keys);
-                allArgs.AddRange(compileContext.ConstantParameters.Values);
-            }
-
-            // evaluate everything using ToList(). But handle null result
-            if (expression.Type.IsEnumerableOrArray() && !expression.Type.IsDictionary())
-            {
-                var returnType = typeof(List<>).MakeGenericType(expression.Type.GetEnumerableOrArrayType()!);
-                expression = Expression.Call(typeof(EnumerableExtensions), nameof(EnumerableExtensions.ToListWithNullCheck), new[] { expression.Type.GetEnumerableOrArrayType()! }, expression, Expression.Constant(node.Field!.ReturnType.TypeNotNullable));
-            }
-
-            if (compileContext.BulkData != null)
-            {
-                parameters.Add(compileContext.BulkParameter!);
-                allArgs.Add(compileContext.BulkData);
-            }
-
-            if (compileContext.ExecutionOptions.BeforeExecuting != null)
-            {
-                expression = compileContext.ExecutionOptions.BeforeExecuting.Invoke(expression, isFinal);
-            }
-
-            var lambdaExpression = Expression.Lambda(expression, parameters.ToArray());
+        var lambdaExpression = Expression.Lambda(expression, parameters.ToArray());
 
 #if DEBUG
-            if (compileContext.ExecutionOptions.NoExecution)
-                return (null, false);
+        if (compileContext.ExecutionOptions.NoExecution)
+            return (null, false);
 #endif
-            object? res = null;
-            if (lambdaExpression.ReturnType.IsGenericType && lambdaExpression.ReturnType.GetGenericTypeDefinition() == typeof(Task<>))
-                res = await (dynamic?)lambdaExpression.Compile().DynamicInvoke(allArgs.ToArray());
-            else
-                res = lambdaExpression.Compile().DynamicInvoke(allArgs.ToArray());
+        object? res = null;
+        if (lambdaExpression.ReturnType.IsGenericType && lambdaExpression.ReturnType.GetGenericTypeDefinition() == typeof(Task<>))
+            res = await (dynamic?)lambdaExpression.Compile().DynamicInvoke(allArgs.ToArray());
+        else
+            res = lambdaExpression.Compile().DynamicInvoke(allArgs.ToArray());
 
-            return (res, true);
-        }
+        return (res, true);
+    }
 
-        public virtual void AddField(BaseGraphQLField field)
-        {
-            field.IsRootField = true;
-            QueryFields.Add(field);
-        }
+    public virtual void AddField(BaseGraphQLField field)
+    {
+        field.IsRootField = true;
+        QueryFields.Add(field);
+    }
 
-        public void AddDirectives(IEnumerable<GraphQLDirective> graphQLDirectives)
-        {
-            Directives.AddRange(graphQLDirectives);
-        }
+    public void AddDirectives(IEnumerable<GraphQLDirective> graphQLDirectives)
+    {
+        Directives.AddRange(graphQLDirectives);
     }
 }

--- a/src/EntityGraphQL/Compiler/GqlNodes/GraphQLDocument.cs
+++ b/src/EntityGraphQL/Compiler/GqlNodes/GraphQLDocument.cs
@@ -6,107 +6,123 @@ using System.Threading.Tasks;
 using EntityGraphQL.Schema;
 using Microsoft.Extensions.DependencyInjection;
 
-namespace EntityGraphQL.Compiler
+namespace EntityGraphQL.Compiler;
+
+/// <summary>
+/// Top level result of parsing a GraphQL document.
+/// Contains a list of top level operations defined in the query document. They can either be queries or mutations.
+/// Also contains a list of fragments defined in the query document
+/// e.g.
+/// {
+///     query Op1 {
+///         people { name id }
+///         movies { name released }
+///     }
+///     query Op2 {
+///         ...
+///     }
+///     mutation ...
+///     fragment ...
+/// }
+/// </summary>
+public class GraphQLDocument : IGraphQLNode
 {
+    public Expression? NextFieldContext { get; }
+    public IGraphQLNode? ParentNode { get; }
+    public ParameterExpression? RootParameter { get; }
+    public List<BaseGraphQLField> QueryFields { get; } = [];
+
     /// <summary>
-    /// Top level result of parsing a GraphQL document.
-    /// Contains a list of top level operations defined in the query document. They can either be queries or mutations.
-    /// Also contains a list of fragments defined in the query document
-    /// e.g.
-    /// {
-    ///     query Op1 {
-    ///         people { name id }
-    ///         movies { name released }
-    ///     }
-    ///     query Op2 {
-    ///         ...
-    ///     }
-    ///     mutation ...
-    ///     fragment ...
-    /// }
+    /// A list of GraphQL operations. These could be mutations or queries
     /// </summary>
-    public class GraphQLDocument : IGraphQLNode
+    /// <value></value>
+    public List<ExecutableGraphQLStatement> Operations { get; }
+    public List<GraphQLFragmentStatement> Fragments { get; set; }
+
+    /// <summary>
+    /// This is the top level document node. Not a root field
+    /// </summary>
+    public bool IsRootField => false;
+
+    public GraphQLDocument(ISchemaProvider schema)
     {
-        public Expression? NextFieldContext { get; }
-        public IGraphQLNode? ParentNode { get; }
-        public ParameterExpression? RootParameter { get; }
-        public List<BaseGraphQLField> QueryFields { get; } = [];
+        Schema = schema;
+        Operations = new List<ExecutableGraphQLStatement>();
+        Fragments = new List<GraphQLFragmentStatement>();
+        Arguments = new Dictionary<string, object>();
+    }
 
-        /// <summary>
-        /// A list of GraphQL operations. These could be mutations or queries
-        /// </summary>
-        /// <value></value>
-        public List<ExecutableGraphQLStatement> Operations { get; }
-        public List<GraphQLFragmentStatement> Fragments { get; set; }
-        /// <summary>
-        /// This is the top level document node. Not a root field
-        /// </summary>
-        public bool IsRootField => false;
-        public GraphQLDocument(ISchemaProvider schema)
-        {
-            Schema = schema;
-            Operations = new List<ExecutableGraphQLStatement>();
-            Fragments = new List<GraphQLFragmentStatement>();
-            Arguments = new Dictionary<string, object>();
-        }
+    public string Name
+    {
+        get => "Query Request Root";
+    }
 
-        public string Name
-        {
-            get => "Query Request Root";
-        }
+    public IField? Field { get; }
+    public bool HasServices
+    {
+        get => Field?.Services.Count > 0;
+    }
 
-        public IField? Field { get; }
-        public bool HasServices { get => Field?.Services.Count > 0; }
+    public IReadOnlyDictionary<string, object> Arguments { get; }
 
-        public IReadOnlyDictionary<string, object> Arguments { get; }
+    public ISchemaProvider Schema { get; }
 
-        public ISchemaProvider Schema { get; }
+    public QueryResult ExecuteQuery<TContext>(
+        TContext context,
+        IServiceProvider? services,
+        QueryVariables? variables,
+        string? operationName = null,
+        ExecutionOptions? options = null
+    )
+    {
+        return ExecuteQueryAsync(context, services, variables, operationName, options).GetAwaiter().GetResult();
+    }
 
-        public QueryResult ExecuteQuery<TContext>(TContext context, IServiceProvider? services, QueryVariables? variables, string? operationName = null, ExecutionOptions? options = null)
-        {
-            return ExecuteQueryAsync(context, services, variables, operationName, options).GetAwaiter().GetResult();
-        }
+    /// <summary>
+    /// Executes the compiled GraphQL document adding data results into QueryResult.
+    /// If no OperationName is supplied the first operation in the query document is executed
+    /// </summary>
+    /// <param name="overwriteContext">Instance of the context type of the schema. If provided this is used wherever the context is needed.
+    /// If not supplied the context is fetched from serviceProvider allowing you to control the scope</param>
+    /// <param name="serviceProvider">Service provider used for DI</param>
+    /// <param name="variables">Variables passed in the request</param>
+    /// <param name="operationName">Optional name of operation to execute. If null the first operation will be executed</param>
+    /// <param name="options">Options for execution.</param>
+    /// <returns></returns>
+    public async Task<QueryResult> ExecuteQueryAsync<TContext>(
+        TContext? overwriteContext,
+        IServiceProvider? serviceProvider,
+        QueryVariables? variables,
+        string? operationName,
+        ExecutionOptions? options = null
+    )
+    {
+        // check operation names
+        if (Operations.Count > 1 && Operations.Any(o => string.IsNullOrEmpty(o.Name)))
+            throw new EntityGraphQLExecutionException("An operation name must be defined for all operations if there are multiple operations in the request");
 
-        /// <summary>
-        /// Executes the compiled GraphQL document adding data results into QueryResult.
-        /// If no OperationName is supplied the first operation in the query document is executed
-        /// </summary>
-        /// <param name="overwriteContext">Instance of the context type of the schema. If provided this is used whereever the context is needed.
-        /// If not supplied the context is fetched from serviceProvider allowing you to control the scope</param>
-        /// <param name="serviceProvider">Service provider used for DI</param>
-        /// <param name="variables">Variables passed in the request</param>
-        /// <param name="operationName">Optional name of operation to execute. If null the first operation will be executed</param>
-        /// <param name="options">Options for execution.</param>
-        /// <returns></returns>
-        public async Task<QueryResult> ExecuteQueryAsync<TContext>(TContext? overwriteContext, IServiceProvider? serviceProvider, QueryVariables? variables, string? operationName, ExecutionOptions? options = null)
-        {
-            // check operation names
-            if (Operations.Count > 1 && Operations.Any(o => string.IsNullOrEmpty(o.Name)))
-                throw new EntityGraphQLExecutionException("An operation name must be defined for all operations if there are multiple operations in the request");
+        var result = new QueryResult();
+        IGraphQLValidator? validator = serviceProvider?.GetService<IGraphQLValidator>();
+        var op = string.IsNullOrEmpty(operationName) ? Operations.First() : Operations.First(o => o.Name == operationName);
 
-            var result = new QueryResult();
-            IGraphQLValidator? validator = serviceProvider?.GetService<IGraphQLValidator>();
-            var op = string.IsNullOrEmpty(operationName) ? Operations.First() : Operations.First(o => o.Name == operationName);
+        // execute the selected operation
+        options ??= new ExecutionOptions(); // defaults
 
-            // execute the selected operation
-            options ??= new ExecutionOptions(); // defaults
+        result.SetData(await op.ExecuteAsync(overwriteContext, serviceProvider, Fragments, Schema.SchemaFieldNamer, options, variables));
 
-            result.SetData(await op.ExecuteAsync(overwriteContext, serviceProvider, Fragments, Schema.SchemaFieldNamer, options, variables));
+        if (validator?.Errors.Count > 0)
+            result.AddErrors(validator.Errors);
 
-            if (validator?.Errors.Count > 0)
-                result.AddErrors(validator.Errors);
+        return result;
+    }
 
-            return result;
-        }
+    public void AddField(BaseGraphQLField field)
+    {
+        throw new NotImplementedException();
+    }
 
-        public void AddField(BaseGraphQLField field)
-        {
-            throw new NotImplementedException();
-        }
-
-        public void AddDirectives(IEnumerable<GraphQLDirective> graphQLDirectives)
-        {
-            throw new NotImplementedException();
-        }
+    public void AddDirectives(IEnumerable<GraphQLDirective> graphQLDirectives)
+    {
+        throw new NotImplementedException();
     }
 }

--- a/src/EntityGraphQL/Compiler/GqlNodes/GraphQLMutationField.cs
+++ b/src/EntityGraphQL/Compiler/GqlNodes/GraphQLMutationField.cs
@@ -5,38 +5,75 @@ using System.Threading.Tasks;
 using EntityGraphQL.Compiler.Util;
 using EntityGraphQL.Schema;
 
-namespace EntityGraphQL.Compiler
+namespace EntityGraphQL.Compiler;
+
+public class GraphQLMutationField : BaseGraphQLQueryField
 {
-    public class GraphQLMutationField : BaseGraphQLQueryField
+    public MutationField MutationField { get; set; }
+
+    public BaseGraphQLQueryField? ResultSelection { get; set; }
+
+    public GraphQLMutationField(
+        ISchemaProvider schema,
+        string name,
+        MutationField mutationField,
+        Dictionary<string, object>? args,
+        Expression nextFieldContext,
+        ParameterExpression rootParameter,
+        IGraphQLNode parentNode
+    )
+        : base(schema, mutationField, name, nextFieldContext, rootParameter, parentNode, args)
     {
-        public MutationField MutationField { get; set; }
+        this.MutationField = mutationField;
+    }
 
-        public BaseGraphQLQueryField? ResultSelection { get; set; }
-
-        public GraphQLMutationField(ISchemaProvider schema, string name, MutationField mutationField, Dictionary<string, object>? args, Expression nextFieldContext, ParameterExpression rootParameter, IGraphQLNode parentNode)
-            : base(schema, mutationField, name, nextFieldContext, rootParameter, parentNode, args)
+    public Task<object?> ExecuteMutationAsync<TContext>(
+        TContext context,
+        IServiceProvider? serviceProvider,
+        ParameterExpression? variableParameter,
+        object? variablesToUse,
+        ExecutionOptions executionOptions
+    )
+    {
+        try
         {
-            this.MutationField = mutationField;
+            return MutationField.CallAsync(context, Arguments, serviceProvider, variableParameter, variablesToUse, executionOptions);
         }
-
-        public Task<object?> ExecuteMutationAsync<TContext>(TContext context, IServiceProvider? serviceProvider, ParameterExpression? variableParameter, object? variablesToUse, ExecutionOptions executionOptions)
+        catch (EntityQuerySchemaException e)
         {
-            try
-            {
-                return MutationField.CallAsync(context, Arguments, serviceProvider, variableParameter, variablesToUse, executionOptions);
-            }
-            catch (EntityQuerySchemaException e)
-            {
-                throw new EntityQuerySchemaException($"Error applying mutation: {e.Message}", e);
-            }
+            throw new EntityQuerySchemaException($"Error applying mutation: {e.Message}", e);
         }
+    }
 
-        protected override Expression? GetFieldExpression(CompileContext compileContext, IServiceProvider? serviceProvider, List<GraphQLFragmentStatement> fragments, ParameterExpression? docParam, object? docVariables, ParameterExpression schemaContext, bool withoutServiceFields, Expression? replacementNextFieldContext, List<Type>? possibleNextContextTypes, bool contextChanged, ParameterReplacer replacer)
-        {
-            if (ResultSelection == null)
-                throw new EntityGraphQLCompilerException($"Mutation {Name} should have a result selection");
+    protected override Expression? GetFieldExpression(
+        CompileContext compileContext,
+        IServiceProvider? serviceProvider,
+        List<GraphQLFragmentStatement> fragments,
+        ParameterExpression? docParam,
+        object? docVariables,
+        ParameterExpression schemaContext,
+        bool withoutServiceFields,
+        Expression? replacementNextFieldContext,
+        List<Type>? possibleNextContextTypes,
+        bool contextChanged,
+        ParameterReplacer replacer
+    )
+    {
+        if (ResultSelection == null)
+            throw new EntityGraphQLCompilerException($"Mutation {Name} should have a result selection");
 
-            return ResultSelection.GetNodeExpression(compileContext, serviceProvider, fragments, docParam, docVariables, schemaContext, withoutServiceFields, replacementNextFieldContext, possibleNextContextTypes, contextChanged, replacer);
-        }
+        return ResultSelection.GetNodeExpression(
+            compileContext,
+            serviceProvider,
+            fragments,
+            docParam,
+            docVariables,
+            schemaContext,
+            withoutServiceFields,
+            replacementNextFieldContext,
+            possibleNextContextTypes,
+            contextChanged,
+            replacer
+        );
     }
 }

--- a/src/EntityGraphQL/Compiler/GqlNodes/GraphQLMutationStatement.cs
+++ b/src/EntityGraphQL/Compiler/GqlNodes/GraphQLMutationStatement.cs
@@ -10,193 +10,227 @@ using EntityGraphQL.Directives;
 using EntityGraphQL.Extensions;
 using EntityGraphQL.Schema;
 
-namespace EntityGraphQL.Compiler
+namespace EntityGraphQL.Compiler;
+
+/// <summary>
+/// Represents a GraphQL mutation statement and knows how to execute the mutation fields.
+/// </summary>
+public class GraphQLMutationStatement : ExecutableGraphQLStatement
 {
-    /// <summary>
-    /// Represents a GraphQL mutation statement and knows how to execute the mutation fields.
-    /// </summary>
-    public class GraphQLMutationStatement : ExecutableGraphQLStatement
+    public GraphQLMutationStatement(ISchemaProvider schema, string? name, Expression nodeExpression, ParameterExpression rootParameter, Dictionary<string, ArgType> variables)
+        : base(schema, name, nodeExpression, rootParameter, variables) { }
+
+    public override async Task<ConcurrentDictionary<string, object?>> ExecuteAsync<TContext>(
+        TContext? context,
+        IServiceProvider? serviceProvider,
+        List<GraphQLFragmentStatement> fragments,
+        Func<string, string> fieldNamer,
+        ExecutionOptions options,
+        QueryVariables? variables
+    )
+        where TContext : default
     {
-        public GraphQLMutationStatement(ISchemaProvider schema, string? name, Expression nodeExpression, ParameterExpression rootParameter, Dictionary<string, ArgType> variables)
-            : base(schema, name, nodeExpression, rootParameter, variables)
+        if (context == null && serviceProvider == null)
+            throw new EntityGraphQLCompilerException("Either context or serviceProvider must be provided.");
+
+        var result = new ConcurrentDictionary<string, object?>();
+        // pass to directives
+        foreach (var directive in Directives)
         {
-        }
-
-        public override async Task<ConcurrentDictionary<string, object?>> ExecuteAsync<TContext>(TContext? context, IServiceProvider? serviceProvider, List<GraphQLFragmentStatement> fragments, Func<string, string> fieldNamer, ExecutionOptions options, QueryVariables? variables) where TContext : default
-        {
-            if (context == null && serviceProvider == null)
-                throw new EntityGraphQLCompilerException("Either context or serviceProvider must be provided.");
-
-            var result = new ConcurrentDictionary<string, object?>();
-            // pass to directives
-            foreach (var directive in Directives)
-            {
-                if (directive.VisitNode(ExecutableDirectiveLocation.MUTATION, Schema, this, Arguments, null, null) == null)
-                    return result;
-            }
-
-            // Mutation fields don't directly have services to collect. This is handled after the mutation is executed.
-            // When we are building/executing the selection on the mutation result services are handled
-            CompileContext compileContext = new(options, null);
-            foreach (var field in QueryFields)
-            {
-                try
-                {
-                    object? docVariables = BuildDocumentVariables(ref variables);
-                    foreach (var node in field.Expand(compileContext, fragments, false, NextFieldContext!, OpVariableParameter, docVariables).Cast<GraphQLMutationField>())
-                    {
-#if DEBUG
-                        Stopwatch? timer = null;
-                        if (options.IncludeDebugInfo)
-                        {
-                            timer = new Stopwatch();
-                            timer.Start();
-                        }
-#endif
-
-                        var contextToUse = GetContextToUse(context, serviceProvider!, field)!;
-
-                        var data = await ExecuteAsync(compileContext, node, contextToUse, serviceProvider, fragments, options, docVariables);
-#if DEBUG
-                        if (options.IncludeDebugInfo)
-                        {
-                            timer?.Stop();
-                            result[$"__{node.Name}_timeMs"] = timer?.ElapsedMilliseconds;
-                        }
-#endif
-                        result[node.Name] = data;
-                    }
-                }
-                catch (EntityGraphQLValidationException)
-                {
-                    throw;
-                }
-                catch (EntityGraphQLFieldException)
-                {
-                    throw;
-                }
-                catch (Exception ex)
-                {
-                    throw new EntityGraphQLFieldException(field.Name, ex);
-                }
-            }
-            return result;
-        }
-
-        /// <summary>
-        /// Execute the current mutation
-        /// </summary>
-        /// <param name="node">The mutation field to execute</param>
-        /// <param name="context">The context instance that will be used</param>
-        /// <param name="validator">Error validator, passed to mutations</param>
-        /// <param name="serviceProvider">A service provider to look up any dependencies</param>
-        /// <param name="fragments"></param>
-        /// <param name="options">Execution options</param>
-        /// <param name="docVariables">Resolved values of variables pass in request</param>
-        /// <typeparam name="TContext"></typeparam>
-        /// <returns></returns>
-        private async Task<object?> ExecuteAsync<TContext>(CompileContext compileContext, GraphQLMutationField node, TContext context, IServiceProvider? serviceProvider, List<GraphQLFragmentStatement> fragments, ExecutionOptions options, object? docVariables)
-        {
-            if (context == null)
-                return null;
-            // run the mutation to get the context for the query select
-            var result = await node.ExecuteMutationAsync(context, serviceProvider, OpVariableParameter, docVariables, options);
-
-            if (result == null || // result is null and don't need to do anything more
-                node.ResultSelection == null) // mutation must return a scalar type
+            if (directive.VisitNode(ExecutableDirectiveLocation.MUTATION, Schema, this, Arguments, null, null) == null)
                 return result;
-            return await MakeSelectionFromResultAsync(compileContext, node, node.ResultSelection!, context, serviceProvider, fragments, docVariables, result);
         }
 
-        protected async Task<object?> MakeSelectionFromResultAsync<TContext>(CompileContext compileContext, BaseGraphQLQueryField node, BaseGraphQLQueryField selection, TContext context, IServiceProvider? serviceProvider, List<GraphQLFragmentStatement> fragments, object? docVariables, object? result)
+        // Mutation fields don't directly have services to collect. This is handled after the mutation is executed.
+        // When we are building/executing the selection on the mutation result services are handled
+        CompileContext compileContext = new(options, null);
+        foreach (var field in QueryFields)
         {
-            var resultExp = selection;
-
-            if (result is LambdaExpression mutationLambda)
+            try
             {
-                // If they have returned an Expression, we need to join the select Expression with the
-                // expression they returned which gives us the full Expression executable over the whole
-                // GraphQL schema
-
-                // this will typically be similar to
-                // db => db.Entity.Where(filter) or db => db.Entity.First(filter)
-                // i.e. they'll be returning a list of items or a specific item
-                // We want to take the field selection from the GraphQL query and add a LINQ Select() onto the expression
-
-                var mutationContextParam = mutationLambda.Parameters.First();
-                var mutationContextExpression = mutationLambda.Body;
-
-                if (!mutationContextExpression.Type.IsEnumerableOrArray())
+                object? docVariables = BuildDocumentVariables(ref variables);
+                foreach (var node in field.Expand(compileContext, fragments, false, NextFieldContext!, OpVariableParameter, docVariables).Cast<GraphQLMutationField>())
                 {
-                    var listExp = ExpressionUtil.FindEnumerable(mutationContextExpression);
-                    if (listExp.Item1 != null && mutationContextExpression.NodeType == ExpressionType.Call)
+#if DEBUG
+                    Stopwatch? timer = null;
+                    if (options.IncludeDebugInfo)
                     {
-                        // yes we can
-                        // rebuild the Expression so we keep any ConstantParameters
-                        var item1 = listExp.Item1;
-                        var collectionNode = new GraphQLListSelectionField(Schema, null, resultExp.Name ?? "unknown", resultExp!.RootParameter, resultExp.RootParameter, item1, node, null);
-                        foreach (var queryField in resultExp.QueryFields)
-                        {
-                            collectionNode.AddField(queryField);
-                        }
-                        var newNode = new GraphQLCollectionToSingleField(Schema, collectionNode, (GraphQLObjectProjectionField)resultExp, listExp.Item2!);
-                        resultExp = newNode;
+                        timer = new Stopwatch();
+                        timer.Start();
                     }
-                    else
+#endif
+
+                    var contextToUse = GetContextToUse(context, serviceProvider!, field)!;
+
+                    var data = await ExecuteAsync(compileContext, node, contextToUse, serviceProvider, fragments, options, docVariables);
+#if DEBUG
+                    if (options.IncludeDebugInfo)
                     {
-                        var newNode = new GraphQLObjectProjectionField((GraphQLObjectProjectionField)resultExp, ((LambdaExpression)result).Body);
-                        foreach (var queryField in resultExp.QueryFields)
-                        {
-                            newNode.AddField(queryField);
-                        }
-                        resultExp = newNode;
-                        SetupConstants(mutationContextExpression, compileContext, resultExp.RootParameter!);
+                        timer?.Stop();
+                        result[$"__{node.Name}_timeMs"] = timer?.ElapsedMilliseconds;
                     }
+#endif
+                    result[node.Name] = data;
+                }
+            }
+            catch (EntityGraphQLValidationException)
+            {
+                throw;
+            }
+            catch (EntityGraphQLFieldException)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                throw new EntityGraphQLFieldException(field.Name, ex);
+            }
+        }
+        return result;
+    }
+
+    /// <summary>
+    /// Execute the current mutation
+    /// </summary>
+    /// <param name="node">The mutation field to execute</param>
+    /// <param name="context">The context instance that will be used</param>
+    /// <param name="validator">Error validator, passed to mutations</param>
+    /// <param name="serviceProvider">A service provider to look up any dependencies</param>
+    /// <param name="fragments"></param>
+    /// <param name="options">Execution options</param>
+    /// <param name="docVariables">Resolved values of variables pass in request</param>
+    /// <typeparam name="TContext"></typeparam>
+    /// <returns></returns>
+    private async Task<object?> ExecuteAsync<TContext>(
+        CompileContext compileContext,
+        GraphQLMutationField node,
+        TContext context,
+        IServiceProvider? serviceProvider,
+        List<GraphQLFragmentStatement> fragments,
+        ExecutionOptions options,
+        object? docVariables
+    )
+    {
+        if (context == null)
+            return null;
+        // run the mutation to get the context for the query select
+        var result = await node.ExecuteMutationAsync(context, serviceProvider, OpVariableParameter, docVariables, options);
+
+        if (
+            result == null
+            || // result is null and don't need to do anything more
+            node.ResultSelection == null
+        ) // mutation must return a scalar type
+            return result;
+        return await MakeSelectionFromResultAsync(compileContext, node, node.ResultSelection!, context, serviceProvider, fragments, docVariables, result);
+    }
+
+    protected async Task<object?> MakeSelectionFromResultAsync<TContext>(
+        CompileContext compileContext,
+        BaseGraphQLQueryField node,
+        BaseGraphQLQueryField selection,
+        TContext context,
+        IServiceProvider? serviceProvider,
+        List<GraphQLFragmentStatement> fragments,
+        object? docVariables,
+        object? result
+    )
+    {
+        var resultExp = selection;
+
+        if (result is LambdaExpression mutationLambda)
+        {
+            // If they have returned an Expression, we need to join the select Expression with the
+            // expression they returned which gives us the full Expression executable over the whole
+            // GraphQL schema
+
+            // this will typically be similar to
+            // db => db.Entity.Where(filter) or db => db.Entity.First(filter)
+            // i.e. they'll be returning a list of items or a specific item
+            // We want to take the field selection from the GraphQL query and add a LINQ Select() onto the expression
+
+            var mutationContextParam = mutationLambda.Parameters.First();
+            var mutationContextExpression = mutationLambda.Body;
+
+            if (!mutationContextExpression.Type.IsEnumerableOrArray())
+            {
+                var listExp = ExpressionUtil.FindEnumerable(mutationContextExpression);
+                if (listExp.Item1 != null && mutationContextExpression.NodeType == ExpressionType.Call)
+                {
+                    // yes we can
+                    // rebuild the Expression so we keep any ConstantParameters
+                    var item1 = listExp.Item1;
+                    var collectionNode = new GraphQLListSelectionField(
+                        Schema,
+                        null,
+                        resultExp.Name ?? "unknown",
+                        resultExp!.RootParameter,
+                        resultExp.RootParameter,
+                        item1,
+                        node,
+                        null
+                    );
+                    foreach (var queryField in resultExp.QueryFields)
+                    {
+                        collectionNode.AddField(queryField);
+                    }
+                    var newNode = new GraphQLCollectionToSingleField(Schema, collectionNode, (GraphQLObjectProjectionField)resultExp, listExp.Item2!);
+                    resultExp = newNode;
                 }
                 else
                 {
-                    // we now know the context as it is dynamically returned in a mutation
-                    if (resultExp is GraphQLListSelectionField listField)
+                    var newNode = new GraphQLObjectProjectionField((GraphQLObjectProjectionField)resultExp, ((LambdaExpression)result).Body);
+                    foreach (var queryField in resultExp.QueryFields)
                     {
-                        listField.ListExpression = mutationContextExpression;
+                        newNode.AddField(queryField);
                     }
+                    resultExp = newNode;
                     SetupConstants(mutationContextExpression, compileContext, resultExp.RootParameter!);
                 }
-                resultExp.IsRootField = node.IsRootField;
-                resultExp.RootParameter = mutationContextParam;
-
-                (result, _) = await CompileAndExecuteNodeAsync(compileContext, context!, serviceProvider, fragments, resultExp, docVariables);
-                return result;
             }
-            // we now know the context as it is dynamically returned in a mutation
-            if (resultExp is GraphQLListSelectionField field)
+            else
             {
-                var contextParam = Expression.Parameter(result!.GetType());
-                resultExp.RootParameter = contextParam;
-                field.ListExpression = contextParam;
+                // we now know the context as it is dynamically returned in a mutation
+                if (resultExp is GraphQLListSelectionField listField)
+                {
+                    listField.ListExpression = mutationContextExpression;
+                }
+                SetupConstants(mutationContextExpression, compileContext, resultExp.RootParameter!);
             }
+            resultExp.IsRootField = node.IsRootField;
+            resultExp.RootParameter = mutationContextParam;
 
-            // run the query select against the object they have returned directly from the mutation
-            (result, _) = await CompileAndExecuteNodeAsync(compileContext, result!, serviceProvider, fragments, resultExp, docVariables);
+            (result, _) = await CompileAndExecuteNodeAsync(compileContext, context!, serviceProvider, fragments, resultExp, docVariables);
             return result;
         }
-
-        private static void SetupConstants(Expression mutationContextExpression, CompileContext compileContext, ParameterExpression rootParameter)
+        // we now know the context as it is dynamically returned in a mutation
+        if (resultExp is GraphQLListSelectionField field)
         {
-            // if they just return a constant I.e the entity they just updated. It comes as a member access constant
-            if (mutationContextExpression.NodeType == ExpressionType.MemberAccess)
+            var contextParam = Expression.Parameter(result!.GetType());
+            resultExp.RootParameter = contextParam;
+            field.ListExpression = contextParam;
+        }
+
+        // run the query select against the object they have returned directly from the mutation
+        (result, _) = await CompileAndExecuteNodeAsync(compileContext, result!, serviceProvider, fragments, resultExp, docVariables);
+        return result;
+    }
+
+    private static void SetupConstants(Expression mutationContextExpression, CompileContext compileContext, ParameterExpression rootParameter)
+    {
+        // if they just return a constant I.e the entity they just updated. It comes as a member access constant
+        if (mutationContextExpression.NodeType == ExpressionType.MemberAccess)
+        {
+            var me = (MemberExpression)mutationContextExpression;
+            if (me.Expression!.NodeType == ExpressionType.Constant)
             {
-                var me = (MemberExpression)mutationContextExpression;
-                if (me.Expression!.NodeType == ExpressionType.Constant)
-                {
-                    compileContext.AddConstant(null, rootParameter, Expression.Lambda(me).Compile().DynamicInvoke());
-                }
+                compileContext.AddConstant(null, rootParameter, Expression.Lambda(me).Compile().DynamicInvoke());
             }
-            else if (mutationContextExpression.NodeType == ExpressionType.Constant)
-            {
-                var ce = (ConstantExpression)mutationContextExpression;
-                compileContext.AddConstant(null, rootParameter, ce.Value);
-            }
+        }
+        else if (mutationContextExpression.NodeType == ExpressionType.Constant)
+        {
+            var ce = (ConstantExpression)mutationContextExpression;
+            compileContext.AddConstant(null, rootParameter, ce.Value);
         }
     }
 }

--- a/src/EntityGraphQL/Compiler/GqlNodes/GraphQLQueryStatement.cs
+++ b/src/EntityGraphQL/Compiler/GqlNodes/GraphQLQueryStatement.cs
@@ -6,25 +6,30 @@ using System.Threading.Tasks;
 using EntityGraphQL.Directives;
 using EntityGraphQL.Schema;
 
-namespace EntityGraphQL.Compiler
-{
-    public class GraphQLQueryStatement : ExecutableGraphQLStatement
-    {
-        public GraphQLQueryStatement(ISchemaProvider schema, string? name, Expression nodeExpression, ParameterExpression rootParameter, Dictionary<string, ArgType> variables)
-            : base(schema, name, nodeExpression, rootParameter, variables)
-        {
-        }
+namespace EntityGraphQL.Compiler;
 
-        public override Task<ConcurrentDictionary<string, object?>> ExecuteAsync<TContext>(TContext? context, IServiceProvider? serviceProvider, List<GraphQLFragmentStatement> fragments, Func<string, string> fieldNamer, ExecutionOptions options, QueryVariables? variables) where TContext : default
+public class GraphQLQueryStatement : ExecutableGraphQLStatement
+{
+    public GraphQLQueryStatement(ISchemaProvider schema, string? name, Expression nodeExpression, ParameterExpression rootParameter, Dictionary<string, ArgType> variables)
+        : base(schema, name, nodeExpression, rootParameter, variables) { }
+
+    public override Task<ConcurrentDictionary<string, object?>> ExecuteAsync<TContext>(
+        TContext? context,
+        IServiceProvider? serviceProvider,
+        List<GraphQLFragmentStatement> fragments,
+        Func<string, string> fieldNamer,
+        ExecutionOptions options,
+        QueryVariables? variables
+    )
+        where TContext : default
+    {
+        var result = new ConcurrentDictionary<string, object?>();
+        // pass to directives
+        foreach (var directive in Directives)
         {
-            var result = new ConcurrentDictionary<string, object?>();
-            // pass to directives
-            foreach (var directive in Directives)
-            {
-                if (directive.VisitNode(ExecutableDirectiveLocation.QUERY, Schema, this, Arguments, null, null) == null)
-                    return Task.FromResult(result);
-            }
-            return base.ExecuteAsync(context, serviceProvider, fragments, fieldNamer, options, variables);
+            if (directive.VisitNode(ExecutableDirectiveLocation.QUERY, Schema, this, Arguments, null, null) == null)
+                return Task.FromResult(result);
         }
+        return base.ExecuteAsync(context, serviceProvider, fragments, fieldNamer, options, variables);
     }
 }

--- a/src/EntityGraphQL/Compiler/GqlNodes/GraphQLSubscriptionField.cs
+++ b/src/EntityGraphQL/Compiler/GqlNodes/GraphQLSubscriptionField.cs
@@ -5,38 +5,75 @@ using System.Threading.Tasks;
 using EntityGraphQL.Compiler.Util;
 using EntityGraphQL.Schema;
 
-namespace EntityGraphQL.Compiler
+namespace EntityGraphQL.Compiler;
+
+public class GraphQLSubscriptionField : BaseGraphQLQueryField
 {
-    public class GraphQLSubscriptionField : BaseGraphQLQueryField
+    public SubscriptionField SubscriptionField { get; set; }
+
+    public BaseGraphQLQueryField? ResultSelection { get; set; }
+
+    public GraphQLSubscriptionField(
+        ISchemaProvider schema,
+        string name,
+        SubscriptionField subscriptionField,
+        Dictionary<string, object>? args,
+        Expression nextFieldContext,
+        ParameterExpression rootParameter,
+        IGraphQLNode parentNode
+    )
+        : base(schema, subscriptionField, name, nextFieldContext, rootParameter, parentNode, args)
     {
-        public SubscriptionField SubscriptionField { get; set; }
+        this.SubscriptionField = subscriptionField;
+    }
 
-        public BaseGraphQLQueryField? ResultSelection { get; set; }
-
-        public GraphQLSubscriptionField(ISchemaProvider schema, string name, SubscriptionField subscriptionField, Dictionary<string, object>? args, Expression nextFieldContext, ParameterExpression rootParameter, IGraphQLNode parentNode)
-            : base(schema, subscriptionField, name, nextFieldContext, rootParameter, parentNode, args)
+    public Task<object?> ExecuteSubscriptionAsync<TContext>(
+        TContext context,
+        IServiceProvider? serviceProvider,
+        ParameterExpression? variableParameter,
+        object? variablesToUse,
+        ExecutionOptions executionOptions
+    )
+    {
+        try
         {
-            this.SubscriptionField = subscriptionField;
+            return SubscriptionField.CallAsync(context, Arguments, serviceProvider, variableParameter, variablesToUse, executionOptions);
         }
-
-        public Task<object?> ExecuteSubscriptionAsync<TContext>(TContext context, IServiceProvider? serviceProvider, ParameterExpression? variableParameter, object? variablesToUse, ExecutionOptions executionOptions)
+        catch (EntityQuerySchemaException e)
         {
-            try
-            {
-                return SubscriptionField.CallAsync(context, Arguments, serviceProvider, variableParameter, variablesToUse, executionOptions);
-            }
-            catch (EntityQuerySchemaException e)
-            {
-                throw new EntityQuerySchemaException($"Error registering subscription: {e.Message}", e);
-            }
+            throw new EntityQuerySchemaException($"Error registering subscription: {e.Message}", e);
         }
+    }
 
-        protected override Expression? GetFieldExpression(CompileContext compileContext, IServiceProvider? serviceProvider, List<GraphQLFragmentStatement> fragments, ParameterExpression? docParam, object? docVariables, ParameterExpression schemaContext, bool withoutServiceFields, Expression? replacementNextFieldContext, List<Type>? possibleNextContextTypes, bool contextChanged, ParameterReplacer replacer)
-        {
-            if (ResultSelection == null)
-                throw new EntityGraphQLCompilerException($"Subscription {Name} should have a result selection");
+    protected override Expression? GetFieldExpression(
+        CompileContext compileContext,
+        IServiceProvider? serviceProvider,
+        List<GraphQLFragmentStatement> fragments,
+        ParameterExpression? docParam,
+        object? docVariables,
+        ParameterExpression schemaContext,
+        bool withoutServiceFields,
+        Expression? replacementNextFieldContext,
+        List<Type>? possibleNextContextTypes,
+        bool contextChanged,
+        ParameterReplacer replacer
+    )
+    {
+        if (ResultSelection == null)
+            throw new EntityGraphQLCompilerException($"Subscription {Name} should have a result selection");
 
-            return ResultSelection.GetNodeExpression(compileContext, serviceProvider, fragments, docParam, docVariables, schemaContext, withoutServiceFields, replacementNextFieldContext, possibleNextContextTypes, contextChanged, replacer);
-        }
+        return ResultSelection.GetNodeExpression(
+            compileContext,
+            serviceProvider,
+            fragments,
+            docParam,
+            docVariables,
+            schemaContext,
+            withoutServiceFields,
+            replacementNextFieldContext,
+            possibleNextContextTypes,
+            contextChanged,
+            replacer
+        );
     }
 }

--- a/src/EntityGraphQL/Compiler/GqlNodes/GraphQLSubscriptionStatement.cs
+++ b/src/EntityGraphQL/Compiler/GqlNodes/GraphQLSubscriptionStatement.cs
@@ -11,119 +11,125 @@ using EntityGraphQL.Schema;
 using EntityGraphQL.Subscriptions;
 using Microsoft.Extensions.DependencyInjection;
 
-namespace EntityGraphQL.Compiler
+namespace EntityGraphQL.Compiler;
+
+/// <summary>
+/// Represents a GraphQL subscription statement and knows how to execute it.
+/// </summary>
+public class GraphQLSubscriptionStatement : GraphQLMutationStatement
 {
-    /// <summary>
-    /// Represents a GraphQL subscription statement and knows how to execute it.
-    /// </summary>
-    public class GraphQLSubscriptionStatement : GraphQLMutationStatement
+    private List<GraphQLFragmentStatement>? fragments;
+    private ExecutionOptions? options;
+    private object? docVariables;
+
+    public GraphQLSubscriptionStatement(ISchemaProvider schema, string? name, ParameterExpression rootParameter, Dictionary<string, ArgType> variables)
+        : base(schema, name, rootParameter, rootParameter, variables) { }
+
+    public override async Task<ConcurrentDictionary<string, object?>> ExecuteAsync<TContext>(
+        TContext? context,
+        IServiceProvider? serviceProvider,
+        List<GraphQLFragmentStatement> fragments,
+        Func<string, string> fieldNamer,
+        ExecutionOptions options,
+        QueryVariables? variables
+    )
+        where TContext : default
     {
-        private IServiceProvider? serviceProvider;
-        private List<GraphQLFragmentStatement>? fragments;
-        private ExecutionOptions? options;
-        private object? docVariables;
+        this.fragments = fragments;
+        this.options = options;
+        this.docVariables = BuildDocumentVariables(ref variables);
 
-        public GraphQLSubscriptionStatement(ISchemaProvider schema, string? name, ParameterExpression rootParameter, Dictionary<string, ArgType> variables)
-            : base(schema, name, rootParameter, rootParameter, variables)
+        var result = new ConcurrentDictionary<string, object?>();
+        // pass to directives
+        foreach (var directive in Directives)
         {
+            if (directive.VisitNode(ExecutableDirectiveLocation.SUBSCRIPTION, Schema, this, Arguments, null, null) == null)
+                return result;
         }
 
-        public override async Task<ConcurrentDictionary<string, object?>> ExecuteAsync<TContext>(TContext? context, IServiceProvider? serviceProvider, List<GraphQLFragmentStatement> fragments, Func<string, string> fieldNamer, ExecutionOptions options, QueryVariables? variables) where TContext : default
+        CompileContext compileContext = new(options, null);
+        foreach (var field in QueryFields)
         {
-            this.serviceProvider = serviceProvider;
-            this.fragments = fragments;
-            this.options = options;
-            this.docVariables = BuildDocumentVariables(ref variables);
-
-            var result = new ConcurrentDictionary<string, object?>();
-            // pass to directives
-            foreach (var directive in Directives)
+            try
             {
-                if (directive.VisitNode(ExecutableDirectiveLocation.SUBSCRIPTION, Schema, this, Arguments, null, null) == null)
-                    return result;
-            }
-
-            CompileContext compileContext = new(options, null);
-            foreach (var field in QueryFields)
-            {
-                try
+                foreach (var node in field.Expand(compileContext, fragments, false, NextFieldContext!, OpVariableParameter, docVariables).Cast<GraphQLSubscriptionField>())
                 {
-                    foreach (var node in field.Expand(compileContext, fragments, false, NextFieldContext!, OpVariableParameter, docVariables).Cast<GraphQLSubscriptionField>())
+#if DEBUG
+                    Stopwatch? timer = null;
+                    if (options.IncludeDebugInfo)
                     {
-#if DEBUG
-                        Stopwatch? timer = null;
-                        if (options.IncludeDebugInfo)
-                        {
-                            timer = new Stopwatch();
-                            timer.Start();
-                        }
-#endif
-                        var data = await ExecuteAsync(node, context, serviceProvider, docVariables, options);
-#if DEBUG
-                        if (options.IncludeDebugInfo)
-                        {
-                            timer?.Stop();
-                            result[$"__{node.Name}_timeMs"] = timer?.ElapsedMilliseconds;
-                        }
-#endif
-                        result[node.Name] = data;
+                        timer = new Stopwatch();
+                        timer.Start();
                     }
-                }
-                catch (EntityGraphQLValidationException)
-                {
-                    throw;
-                }
-                catch (EntityGraphQLFieldException)
-                {
-                    throw;
-                }
-                catch (Exception ex)
-                {
-                    throw new EntityGraphQLFieldException(field.Name, ex);
+#endif
+                    var data = await ExecuteAsync(node, context, serviceProvider, docVariables, options);
+#if DEBUG
+                    if (options.IncludeDebugInfo)
+                    {
+                        timer?.Stop();
+                        result[$"__{node.Name}_timeMs"] = timer?.ElapsedMilliseconds;
+                    }
+#endif
+                    result[node.Name] = data;
                 }
             }
-            return result;
+            catch (EntityGraphQLValidationException)
+            {
+                throw;
+            }
+            catch (EntityGraphQLFieldException)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                throw new EntityGraphQLFieldException(field.Name, ex);
+            }
         }
+        return result;
+    }
 
-        private async Task<object?> ExecuteAsync<TContext>(GraphQLSubscriptionField node, TContext context, IServiceProvider? serviceProvider, object? docVariables, ExecutionOptions executionOptions)
-        {
-            if (context == null)
-                return null;
-            // execute the subscription set up method. It returns in IObservable<T>
-            var result = await node.ExecuteSubscriptionAsync(context, serviceProvider, OpVariableParameter, docVariables, executionOptions);
+    private async Task<object?> ExecuteAsync<TContext>(
+        GraphQLSubscriptionField node,
+        TContext context,
+        IServiceProvider? serviceProvider,
+        object? docVariables,
+        ExecutionOptions executionOptions
+    )
+    {
+        if (context == null)
+            return null;
+        // execute the subscription set up method. It returns in IObservable<T>
+        var result = await node.ExecuteSubscriptionAsync(context, serviceProvider, OpVariableParameter, docVariables, executionOptions);
 
-            if (result == null || node.ResultSelection == null)
-                throw new EntityGraphQLExecutionException($"Subscription {node.Name} returned null. It must return an IObservable<T>");
+        if (result == null || node.ResultSelection == null)
+            throw new EntityGraphQLExecutionException($"Subscription {node.Name} returned null. It must return an IObservable<T>");
 
-            // result == IObservable<T> 
-            var returnType = result.GetType().GetGenericArgument(typeof(IObservable<>));
-            if (returnType == null)
-                throw new EntityGraphQLExecutionException($"Subscription {node.Name} return type does not implement IObservable<T>");
-            return new GraphQLSubscribeResult(returnType, result, this, node);
-        }
+        // result == IObservable<T>
+        var returnType = result.GetType().GetGenericArgument(typeof(IObservable<>));
+        if (returnType == null)
+            throw new EntityGraphQLExecutionException($"Subscription {node.Name} return type does not implement IObservable<T>");
+        return new GraphQLSubscribeResult(returnType, result, this, node);
+    }
 
-        public object? ExecuteSubscriptionEvent<TQueryContext, TType>(GraphQLSubscriptionField node, TType eventValue)
-        {
-            return ExecuteSubscriptionEventAsync<TQueryContext, TType>(node, eventValue).GetAwaiter().GetResult();
-        }
+    public object? ExecuteSubscriptionEvent<TQueryContext, TType>(GraphQLSubscriptionField node, TType eventValue, IServiceProvider serviceProvider)
+    {
+        return ExecuteSubscriptionEventAsync<TQueryContext, TType>(node, eventValue, serviceProvider).GetAwaiter().GetResult();
+    }
 
-        public Task<object?> ExecuteSubscriptionEventAsync<TQueryContext, TType>(GraphQLSubscriptionField node, TType eventValue)
-        {
-            if (serviceProvider == null)
-                throw new EntityGraphQLExecutionException($"serviceProvider cannot be null. Please provide a valid ServiceProvider when executing a subscription operation with the schema query context registered.");
+    public Task<object?> ExecuteSubscriptionEventAsync<TQueryContext, TType>(GraphQLSubscriptionField node, TType eventValue, IServiceProvider serviceProvider)
+    {
+        var context = (TQueryContext)serviceProvider.GetRequiredService(typeof(TQueryContext));
 
-            var context = (TQueryContext)serviceProvider!.GetRequiredService(typeof(TQueryContext));
+        var result = MakeSelectionFromResultAsync(new CompileContext(options!, null), node, node.ResultSelection!, context, serviceProvider, fragments!, docVariables, eventValue);
+        return result;
+    }
 
-            var result = MakeSelectionFromResultAsync(new CompileContext(options!, null), node, node.ResultSelection!, context, serviceProvider, fragments!, docVariables, eventValue);
-            return result;
-        }
-
-        public override void AddField(BaseGraphQLField field)
-        {
-            if (QueryFields.Count > 0)
-                throw new EntityGraphQLCompilerException($"Subscription operations may only have a single root field. Field '{field.Name}' should be used in another operation.");
-            field.IsRootField = true;
-            QueryFields.Add(field);
-        }
+    public override void AddField(BaseGraphQLField field)
+    {
+        if (QueryFields.Count > 0)
+            throw new EntityGraphQLCompilerException($"Subscription operations may only have a single root field. Field '{field.Name}' should be used in another operation.");
+        field.IsRootField = true;
+        QueryFields.Add(field);
     }
 }

--- a/src/EntityGraphQL/Compiler/GqlNodes/GraphQLSubscriptionStatement.cs
+++ b/src/EntityGraphQL/Compiler/GqlNodes/GraphQLSubscriptionStatement.cs
@@ -35,6 +35,9 @@ public class GraphQLSubscriptionStatement : GraphQLMutationStatement
     )
         where TContext : default
     {
+        if (context == null && serviceProvider == null)
+            throw new EntityGraphQLCompilerException("Either context or serviceProvider must be provided.");
+
         this.fragments = fragments;
         this.options = options;
         this.docVariables = BuildDocumentVariables(ref variables);
@@ -62,7 +65,8 @@ public class GraphQLSubscriptionStatement : GraphQLMutationStatement
                         timer.Start();
                     }
 #endif
-                    var data = await ExecuteAsync(node, context, serviceProvider, docVariables, options);
+                    var contextToUse = GetContextToUse(context, serviceProvider!, node)!;
+                    var data = await ExecuteAsync(node, contextToUse, serviceProvider, docVariables, options);
 #if DEBUG
                     if (options.IncludeDebugInfo)
                     {

--- a/src/EntityGraphQL/QueryRequest.cs
+++ b/src/EntityGraphQL/QueryRequest.cs
@@ -1,67 +1,91 @@
 using System.Collections.Generic;
 
-namespace EntityGraphQL
+namespace EntityGraphQL;
+
+/// <summary>
+/// A GraphQL request. The query, and any variables
+/// </summary>
+public class QueryRequest
 {
-    /// <summary>
-    /// A GraphQL request. The query, and any variables
-    /// </summary>
-    public class QueryRequest
-    {
-        // Name of the operation you want to run in the Query document (if it contains many)
-        public string? OperationName { get; set; }
-        /// <summary>
-        /// GraphQL query document
-        /// </summary>
-        /// <value></value>
-        public string? Query { get; set; }
-        /// <summary>
-        /// Variables values for the query.
-        /// It is a Dictionary<string, object?> type. Make sure that object is a resolved .NET type and 
-        /// not a JsonElement/JObject (e.g. turn objects into more dictionaries)
-        /// </summary>
-        public QueryVariables? Variables { get; set; }
-
-        public Dictionary<string, Dictionary<string, object>> Extensions { get; set; } = new Dictionary<string, Dictionary<string, object>>();
-    }
-
-    public class PersistedQueryExtension : Dictionary<string, object>
-    {
-        public PersistedQueryExtension()
-        {
-            Version = 1;
-        }
-        public string Sha256Hash { get => (string)this[nameof(Sha256Hash)]; set => this[nameof(Sha256Hash)] = value; }
-
-        public int Version { get => (int)this[nameof(Version)]; set => this[nameof(Version)] = value; }
-    }
+    // Name of the operation you want to run in the Query document (if it contains many)
+    public string? OperationName { get; set; }
 
     /// <summary>
-    /// Holds the variables passed along with a GraphQL query
+    /// GraphQL query document
     /// </summary>
-    public class QueryVariables : Dictionary<string, object?>
-    {
-        public object? GetValueFor(string varKey)
-        {
-            return ContainsKey(varKey) ? this[varKey] : null;
-        }
-    }
+    /// <value></value>
+    public string? Query { get; set; }
 
     /// <summary>
-    /// Describes any errors that might happen while resolving the query request
+    /// Variables values for the query.
+    /// It is a Dictionary<string, object?> type. Make sure that object is a resolved .NET type and
+    /// not a JsonElement/JObject (e.g. turn objects into more dictionaries)
     /// </summary>
-    public class GraphQLError : Dictionary<string, object>
+    public QueryVariables? Variables { get; set; }
+
+    public Dictionary<string, Dictionary<string, object>> Extensions { get; set; } = [];
+}
+
+public class QueryExtensions : Dictionary<string, Dictionary<string, object>>
+{
+    public QueryExtensions() { }
+
+    public QueryExtensions(IDictionary<string, Dictionary<string, object>> dictionary)
+        : base(dictionary) { }
+}
+
+public class PersistedQueryExtension : Dictionary<string, object>
+{
+    public PersistedQueryExtension()
     {
-        private static readonly string MessageKey = "message";
+        Version = 1;
+    }
 
-        public string Message { get => (string)this[MessageKey]; }
+    public string Sha256Hash
+    {
+        get => (string)this[nameof(Sha256Hash)];
+        set => this[nameof(Sha256Hash)] = value;
+    }
 
-        public Dictionary<string, object>? Extensions { get => (Dictionary<string, object>?)this.GetValueOrDefault(QueryResult.ExtensionsKey); }
+    public int Version
+    {
+        get => (int)this[nameof(Version)];
+        set => this[nameof(Version)] = value;
+    }
+}
 
-        public GraphQLError(string message, IDictionary<string, object>? extensions)
-        {
-            this[MessageKey] = message;
-            if (extensions != null)
-                this[QueryResult.ExtensionsKey] = new Dictionary<string, object>(extensions);
-        }
+/// <summary>
+/// Holds the variables passed along with a GraphQL query
+/// </summary>
+public class QueryVariables : Dictionary<string, object?>
+{
+    public object? GetValueFor(string varKey)
+    {
+        return ContainsKey(varKey) ? this[varKey] : null;
+    }
+}
+
+/// <summary>
+/// Describes any errors that might happen while resolving the query request
+/// </summary>
+public class GraphQLError : Dictionary<string, object>
+{
+    private static readonly string MessageKey = "message";
+
+    public string Message
+    {
+        get => (string)this[MessageKey];
+    }
+
+    public Dictionary<string, object>? Extensions
+    {
+        get => (Dictionary<string, object>?)this.GetValueOrDefault(QueryResult.ExtensionsKey);
+    }
+
+    public GraphQLError(string message, IDictionary<string, object>? extensions)
+    {
+        this[MessageKey] = message;
+        if (extensions != null)
+            this[QueryResult.ExtensionsKey] = new Dictionary<string, object>(extensions);
     }
 }

--- a/src/EntityGraphQL/Schema/FieldExtensions/Sorting/SortExtension.cs
+++ b/src/EntityGraphQL/Schema/FieldExtensions/Sorting/SortExtension.cs
@@ -19,14 +19,16 @@ namespace EntityGraphQL.Schema.FieldExtensions
         private readonly List<ISort> defaultSorts;
         private readonly ParameterExpression? fieldSelectionParam;
         private readonly Dictionary<string, Expression>? fieldSelectionExpressions;
+        private readonly bool useSchemaFields;
 
-        public SortExtension(LambdaExpression? fieldSelection, params ISort[] defaultSorts)
+        public SortExtension(LambdaExpression? fieldSelection, bool useSchemaFields, params ISort[] defaultSorts)
         {
             this.fieldSelectionType = fieldSelection?.ReturnType;
             this.defaultSorts = defaultSorts?.ToList() ?? [];
             this.fieldSelectionParam = fieldSelection?.Parameters.First();
             if (fieldSelection?.Body is NewExpression newExp)
                 this.fieldSelectionExpressions = newExp.Members?.Select((m, i) => new { m.Name, Expression = newExp.Arguments[i] }).ToDictionary(x => x.Name, x => x.Expression);
+            this.useSchemaFields = useSchemaFields;
         }
 
         public override void Configure(ISchemaProvider schema, IField field)
@@ -41,8 +43,7 @@ namespace EntityGraphQL.Schema.FieldExtensions
                 schema.AddEnum("SortDirectionEnum", typeof(SortDirection), "Sort direction enum");
             schemaReturnType = field.ReturnType.SchemaType;
             listType = field.ReturnType.TypeDotnet.GetEnumerableOrArrayType()!;
-            methodType = typeof(IQueryable).IsAssignableFrom(field.ReturnType.TypeDotnet) ?
-                typeof(Queryable) : typeof(Enumerable);
+            methodType = typeof(IQueryable).IsAssignableFrom(field.ReturnType.TypeDotnet) ? typeof(Queryable) : typeof(Enumerable);
 
             fieldNamer = schema.SchemaFieldNamer;
             var sortInputName = $"{field.FromType.Name}{field.Name.FirstCharToUpper()}SortInput".FirstCharToUpper();
@@ -83,21 +84,36 @@ namespace EntityGraphQL.Schema.FieldExtensions
 
         private Type MakeSortType(IField field)
         {
-            var typeWithSortFields = fieldSelectionType ?? listType!;
             // Build the field args
-            Dictionary<string, Type> fields = new();
+            Dictionary<string, Type> fields = [];
             var directionType = typeof(SortDirection?);
-            foreach (var prop in typeWithSortFields.GetProperties())
+
+            if (useSchemaFields)
             {
-                if (IsNotInputType(prop.PropertyType))
-                    continue;
-                fields.Add(prop.Name, directionType);
+                foreach (var schemaField in schemaReturnType!.GetFields())
+                {
+                    if (schemaField.Name.StartsWith("__", StringComparison.CurrentCulture))
+                        continue;
+                    if (IsNotInputType(schemaField.ReturnType.TypeDotnet))
+                        continue;
+                    fields.Add(schemaField.Name, directionType);
+                }
             }
-            foreach (var prop in typeWithSortFields.GetFields())
+            else
             {
-                if (IsNotInputType(prop.FieldType))
-                    continue;
-                fields.Add(prop.Name, directionType);
+                var typeWithSortFields = fieldSelectionType ?? listType!;
+                foreach (var prop in typeWithSortFields.GetProperties())
+                {
+                    if (IsNotInputType(prop.PropertyType))
+                        continue;
+                    fields.Add(prop.Name, directionType);
+                }
+                foreach (var prop in typeWithSortFields.GetFields())
+                {
+                    if (IsNotInputType(prop.FieldType))
+                        continue;
+                    fields.Add(prop.Name, directionType);
+                }
             }
             // build SortInput - need a unique name if they use sort on another field with the same name
             var argSortType = LinqRuntimeTypeBuilder.GetDynamicType(fields, field.Name);
@@ -109,7 +125,16 @@ namespace EntityGraphQL.Schema.FieldExtensions
             return type.IsEnumerableOrArray() || (type.IsClass && type != typeof(string));
         }
 
-        public override Expression? GetExpression(IField field, Expression expression, ParameterExpression? argumentParam, dynamic? arguments, Expression context, IGraphQLNode? parentNode, bool servicesPass, ParameterReplacer parameterReplacer)
+        public override Expression? GetExpression(
+            IField field,
+            Expression expression,
+            ParameterExpression? argumentParam,
+            dynamic? arguments,
+            Expression context,
+            IGraphQLNode? parentNode,
+            bool servicesPass,
+            ParameterReplacer parameterReplacer
+        )
         {
             // things are sorted already and the field shape has changed
             if (servicesPass)
@@ -143,19 +168,13 @@ namespace EntityGraphQL.Schema.FieldExtensions
                         }
                         else
                         {
-                            Expression sortField = listParam;
                             var schemaField = schemaReturnType!.GetField(fieldNamer!(fieldInfo.Name), null);
                             sortReturnType = schemaField.ReturnType.TypeDotnet;
-                            sortExpression = Expression.PropertyOrField(sortField, fieldInfo.Name);
+                            sortExpression = schemaField.ResolveExpression ?? Expression.PropertyOrField(listParam, fieldInfo.Name);
+                            listParam = schemaField.FieldParam!;
                         }
 
-                        expression = Expression.Call(
-                            methodType!,
-                            method,
-                            new Type[] { listType!, sortReturnType },
-                            expression,
-                            Expression.Lambda(sortExpression, listParam)
-                        );
+                        expression = Expression.Call(methodType!, method, [listType!, sortReturnType], expression, Expression.Lambda(sortExpression, listParam));
                         break;
                     }
                     sortMethod = "ThenBy";
@@ -168,12 +187,12 @@ namespace EntityGraphQL.Schema.FieldExtensions
                 {
                     var listParam = Expression.Parameter(listType!);
                     expression = Expression.Call(
-                            methodType!,
-                            defaultSort.Direction == SortDirection.ASC ? (thenBy ? "ThenBy" : "OrderBy") : (thenBy ? "ThenByDescending" : "OrderByDescending"),
-                            new Type[] { listType!, defaultSort.SortExpression.Body.Type },
-                            expression,
-                            parameterReplacer.Replace(defaultSort.SortExpression, defaultSort.SortExpression.Parameters.First(), listParam)
-                        );
+                        methodType!,
+                        defaultSort.Direction == SortDirection.ASC ? (thenBy ? "ThenBy" : "OrderBy") : (thenBy ? "ThenByDescending" : "OrderByDescending"),
+                        new Type[] { listType!, defaultSort.SortExpression.Body.Type },
+                        expression,
+                        parameterReplacer.Replace(defaultSort.SortExpression, defaultSort.SortExpression.Parameters.First(), listParam)
+                    );
                     thenBy = true;
                 }
             }

--- a/src/EntityGraphQL/Schema/FieldExtensions/Sorting/UseSortExtension.cs
+++ b/src/EntityGraphQL/Schema/FieldExtensions/Sorting/UseSortExtension.cs
@@ -15,9 +15,10 @@ namespace EntityGraphQL.Schema.FieldExtensions
         /// <returns></returns>
         public static IField UseSort<TElementType, TReturnType>(this IField field, Expression<Func<TElementType, TReturnType>> fieldSelection)
         {
-            field.AddExtension(new SortExtension(fieldSelection));
+            field.AddExtension(new SortExtension(fieldSelection, false));
             return field;
         }
+
         /// <summary>
         /// Update field to implement a sort argument that takes options to sort a collection
         /// Only call on a field that returns an IEnumerable
@@ -28,9 +29,14 @@ namespace EntityGraphQL.Schema.FieldExtensions
         /// <param name="defaultSort">Sort to use if no sort argument supplied in query</param>
         /// <param name="direction">Direction of the default sort</param>
         /// <returns></returns>
-        public static IField UseSort<TElementType, TReturnType>(this IField field, Expression<Func<TElementType, TReturnType>> fieldSelection, Expression<Func<TElementType, object>> defaultSort, SortDirection direction)
+        public static IField UseSort<TElementType, TReturnType>(
+            this IField field,
+            Expression<Func<TElementType, TReturnType>> fieldSelection,
+            Expression<Func<TElementType, object>> defaultSort,
+            SortDirection direction
+        )
         {
-            field.AddExtension(new SortExtension(fieldSelection, new Sort<TElementType>(defaultSort, direction)));
+            field.AddExtension(new SortExtension(fieldSelection, false, new Sort<TElementType>(defaultSort, direction)));
             return field;
         }
 
@@ -44,20 +50,29 @@ namespace EntityGraphQL.Schema.FieldExtensions
         /// <returns></returns>
         public static IField UseSort<TElementType>(this IField field, Expression<Func<TElementType, object>> defaultSort, SortDirection direction)
         {
-            field.AddExtension(new SortExtension(null, new Sort<TElementType>(defaultSort, direction)));
+            field.AddExtension(new SortExtension(null, false, new Sort<TElementType>(defaultSort, direction)));
             return field;
         }
 
-        public static IField UseSort<TElementType, TReturnType, TSort>(this IField field, Expression<Func<TElementType, TReturnType>> fieldSelection, params Sort<TElementType>[] defaultSorts)
+        public static IField UseSort<TElementType, TReturnType>(
+            this IField field,
+            Expression<Func<TElementType, TReturnType>> fieldSelection,
+            params Sort<TElementType>[] defaultSorts
+        )
         {
-            field.AddExtension(new SortExtension(fieldSelection, defaultSorts));
+            field.AddExtension(new SortExtension(fieldSelection, false, defaultSorts));
             return field;
         }
-
 
         public static IField UseSort<TElementType>(this IField field, params Sort<TElementType>[] defaultSorts)
         {
-            field.AddExtension(new SortExtension(null, defaultSorts));
+            field.AddExtension(new SortExtension(null, false, defaultSorts));
+            return field;
+        }
+
+        public static IField UseSort<TElementType>(this IField field, bool useSchemaFields, params Sort<TElementType>[] defaultSorts)
+        {
+            field.AddExtension(new SortExtension(null, useSchemaFields, defaultSorts));
             return field;
         }
 
@@ -66,10 +81,11 @@ namespace EntityGraphQL.Schema.FieldExtensions
         /// Only call on a field that returns an IEnumerable
         /// </summary>
         /// <param name="field"></param>
+        /// <param name="useSchemaFields">Use the schema fields for sorting. Will use the fields current in the schema only</param>
         /// <returns></returns>
-        public static IField UseSort(this IField field)
+        public static IField UseSort(this IField field, bool useSchemaFields = false)
         {
-            field.AddExtension(new SortExtension(null));
+            field.AddExtension(new SortExtension(null, useSchemaFields));
             return field;
         }
     }
@@ -88,6 +104,7 @@ namespace EntityGraphQL.Schema.FieldExtensions
     {
         public LambdaExpression SortExpression { get; set; }
         public SortDirection Direction { get; set; }
+
         public Sort(Expression<Func<TElementType, object>> sortExpression)
         {
             SortExpression = sortExpression;

--- a/src/EntityGraphQL/Schema/MethodField.cs
+++ b/src/EntityGraphQL/Schema/MethodField.cs
@@ -9,173 +9,211 @@ using EntityGraphQL.Compiler.Util;
 using EntityGraphQL.Extensions;
 using Microsoft.Extensions.DependencyInjection;
 
-namespace EntityGraphQL.Schema
+namespace EntityGraphQL.Schema;
+
+/// <summary>
+/// Represents a GraphQL field backed by a method in dotnet. This is used for "controller" type fields. e.g. Mutations and Subscriptions.
+/// This is not used for query fields.
+///
+/// The way we execute this field is different to a query field with is built inline to an expression.
+///
+/// A MethodField is the top level field in a mutation/subscription and maps to a dotnet method. The result is projected back into the query graph.
+/// </summary>
+public abstract class MethodField : BaseField
 {
-    /// <summary>
-    /// Respresents a GraphQL field backed by a method in dotnet. This is used for "controller" type fields. e.g. Mutations and Subscriptions.
-    /// This is not used for query fields.
-    /// 
-    /// The way we execute this field is different to a query field with is built inline to an expression.
-    /// 
-    /// A MethodField is the top level field in a mutation/subscription and maps to a dotnet method. The result is projected back into the query graph.
-    /// </summary>
-    public abstract class MethodField : BaseField
+    public override GraphQLQueryFieldType FieldType { get; }
+    protected MethodInfo Method { get; set; }
+    public bool IsAsync { get; protected set; }
+
+    public MethodField(
+        ISchemaProvider schema,
+        ISchemaType fromType,
+        string methodName,
+        GqlTypeInfo returnType,
+        MethodInfo method,
+        string description,
+        RequiredAuthorization requiredAuth,
+        bool isAsync,
+        SchemaBuilderOptions options
+    )
+        : base(schema, fromType, methodName, description, returnType)
     {
-        public override GraphQLQueryFieldType FieldType { get; }
-        protected MethodInfo Method { get; set; }
-        public bool IsAsync { get; protected set; }
-
-        public MethodField(ISchemaProvider schema, ISchemaType fromType, string methodName, GqlTypeInfo returnType, MethodInfo method, string description, RequiredAuthorization requiredAuth, bool isAsync, SchemaBuilderOptions options)
-            : base(schema, fromType, methodName, description, returnType)
+        Method = method;
+        RequiredAuthorization = requiredAuth;
+        IsAsync = isAsync;
+        Dictionary<string, Type> flattenedTypes;
+        foreach (var item in SchemaBuilder.GetGraphQlSchemaArgumentsFromMethod(schema, method, options, out flattenedTypes))
         {
-            Method = method;
-            RequiredAuthorization = requiredAuth;
-            IsAsync = isAsync;
-            Dictionary<string, Type> flattenedTypes;
-            foreach (var item in SchemaBuilder.GetGraphQlSchemaArgumentsFromMethod(schema, method, options, out flattenedTypes))
-            {
-                if (item.IsService)
-                    // services are not arguments in the schema
-                    // We do not add service to BaseField.Services as this MethodField is used for mutations/subscriptions
-                    // that make this method call then make a query on the result.
-                    // BaseField.Services are for fields in a query result
-                    // Services will be injected for us below in CallAsync
-                    continue;
+            if (item.IsService)
+                // services are not arguments in the schema
+                // We do not add service to BaseField.Services as this MethodField is used for mutations/subscriptions
+                // that make this method call then make a query on the result.
+                // BaseField.Services are for fields in a query result
+                // Services will be injected for us below in CallAsync
+                continue;
 
-                if (item.ShouldFlatten)
+            if (item.ShouldFlatten)
+            {
+                foreach (var f in item.FlattenArgs!)
                 {
-                    foreach (var f in item.FlattenArgs!)
-                    {
-                        Arguments.Add(f.ArgName, f.ArgType!);
-                    }
+                    Arguments.Add(f.ArgName, f.ArgType!);
                 }
-                else
-                    Arguments.Add(item.ArgName, item.ArgType!);
             }
-            ExpressionArgumentType = LinqRuntimeTypeBuilder.GetDynamicType(flattenedTypes, method.Name)!;
+            else
+                Arguments.Add(item.ArgName, item.ArgType!);
         }
+        ExpressionArgumentType = LinqRuntimeTypeBuilder.GetDynamicType(flattenedTypes, method.Name)!;
+    }
 
-        public virtual async Task<object?> CallAsync(object? context, IReadOnlyDictionary<string, object>? gqlRequestArgs, IServiceProvider? serviceProvider, ParameterExpression? variableParameter, object? docVariables, ExecutionOptions executionOptions)
+    public virtual async Task<object?> CallAsync(
+        object? context,
+        IReadOnlyDictionary<string, object>? gqlRequestArgs,
+        IServiceProvider? serviceProvider,
+        ParameterExpression? variableParameter,
+        object? docVariables,
+        ExecutionOptions executionOptions
+    )
+    {
+        if (context == null)
+            return null;
+
+        // args in the mutation method - may be arguments in the graphql schema, services injected
+        var allArgs = new List<object>();
+        var argsToValidate = new List<object>();
+        object? argInstance = null;
+        var validationErrors = new List<string>();
+
+        // add parameters and any DI services
+        foreach (var p in Method.GetParameters())
         {
-            if (context == null)
-                return null;
-
-            // args in the mutation method - may be arguments in the graphql schema, services injected
-            var allArgs = new List<object>();
-            var argsToValidate = new List<object>();
-            object? argInstance = null;
-            var validationErrors = new List<string>();
-
-            // add parameters and any DI services
-            foreach (var p in Method.GetParameters())
+            if (p.GetCustomAttribute<GraphQLArgumentsAttribute>() != null || p.ParameterType.GetTypeInfo().GetCustomAttribute<GraphQLArgumentsAttribute>() != null)
             {
-                if (p.GetCustomAttribute<GraphQLArgumentsAttribute>() != null || p.ParameterType.GetTypeInfo().GetCustomAttribute<GraphQLArgumentsAttribute>() != null)
+                // need to map GQL args to the GraphQLArguments object - p.ParameterType
+                argInstance = ArgumentUtil.BuildArgumentsObject(
+                    Schema,
+                    Name,
+                    this,
+                    gqlRequestArgs ?? new Dictionary<string, object>(),
+                    Arguments.Values,
+                    p.ParameterType,
+                    variableParameter,
+                    docVariables,
+                    validationErrors
+                )!;
+                allArgs.Add(argInstance);
+            }
+            else if (gqlRequestArgs != null && gqlRequestArgs.ContainsKey(p.Name!))
+            {
+                var argField = Arguments[p.Name!];
+                var value = ArgumentUtil.BuildArgumentFromMember(Schema, gqlRequestArgs, argField.Name, argField.RawType, argField.DefaultValue, validationErrors);
+                if (docVariables != null)
                 {
-                    // need to map GQL args to the GraphQLArguments object - p.ParameterType
-                    argInstance = ArgumentUtil.BuildArgumentsObject(Schema, Name, this, gqlRequestArgs ?? new Dictionary<string, object>(), Arguments.Values, p.ParameterType, variableParameter, docVariables, validationErrors)!;
-                    allArgs.Add(argInstance);
-                }
-                else if (gqlRequestArgs != null && gqlRequestArgs.ContainsKey(p.Name!))
-                {
-                    var argField = Arguments[p.Name!];
-                    var value = ArgumentUtil.BuildArgumentFromMember(Schema, gqlRequestArgs, argField.Name, argField.RawType, argField.DefaultValue, validationErrors);
-                    if (docVariables != null)
+                    if (value is Expression and not null)
                     {
-                        if (value is Expression and not null)
-                        {
-                            value = Expression.Lambda((Expression)value, variableParameter!).Compile().DynamicInvoke(new[] { docVariables });
-                        }
-                    }
-                    // this could be int to RequiredField<int>
-                    if (value != null && value.GetType() != argField.RawType)
-                    {
-                        value = ExpressionUtil.ChangeType(value, argField.RawType, Schema, executionOptions);
-                    }
-
-                    argField.Validate(value, p.Name!, validationErrors);
-
-                    allArgs.Add(value!);
-                    argsToValidate.Add(value!);
-                }
-                else if (p.ParameterType == context.GetType())
-                {
-                    allArgs.Add(context);
-                }
-                else if (serviceProvider != null)
-                {
-                    var service = serviceProvider.GetService(p.ParameterType) ?? throw new EntityGraphQLExecutionException($"Service {p.ParameterType.Name} not found for dependency injection for mutation {Method.Name}");
-                    allArgs.Add(service);
-                }
-                else
-                {
-                    var argField = Arguments[p.Name!];
-                    if (argField.DefaultValue != null)
-                    {
-                        allArgs.Add(argField.DefaultValue);
+                        value = Expression.Lambda((Expression)value, variableParameter!).Compile().DynamicInvoke(new[] { docVariables });
                     }
                 }
-            }
-
-            if (ArgumentValidators.Count > 0)
-            {
-                var validatorContext = new ArgumentValidatorContext(this, argInstance ?? argsToValidate, Method);
-                foreach (var argValidator in ArgumentValidators)
+                // this could be int to RequiredField<int>
+                if (value != null && value.GetType() != argField.RawType)
                 {
-                    argValidator(validatorContext);
+                    value = ExpressionUtil.ChangeType(value, argField.RawType, Schema, executionOptions);
                 }
-                if (validatorContext.Errors != null && validatorContext.Errors.Count > 0)
-                {
-                    validationErrors.AddRange(validatorContext.Errors);
-                }
-            }
 
-            if (validationErrors.Count > 0)
-            {
-                throw new EntityGraphQLValidationException(validationErrors);
-            }
+                argField.Validate(value, p.Name!, validationErrors);
 
-            object? instance = null;
-            // we create an instance _per request_ injecting any parameters to the constructor
-            // We kind of treat a mutation class like an asp.net controller
-            // and we do not want to register them in the service provider to avoid the same issues controllers would have
-            // with different lifetime objects
-            if (instance == null)
-            {
-                instance = serviceProvider != null ?
-                    ActivatorUtilities.CreateInstance(serviceProvider, Method.DeclaringType!) :
-                    Activator.CreateInstance(Method.DeclaringType!);
+                allArgs.Add(value!);
+                argsToValidate.Add(value!);
             }
-
-            object? result;
-            if (IsAsync)
+            else if (p.ParameterType == context.GetType())
             {
-                result = await (dynamic?)Method.Invoke(instance, allArgs.Count > 0 ? allArgs.ToArray() : null);
+                allArgs.Add(context);
+            }
+            else if (serviceProvider != null)
+            {
+                var service =
+                    serviceProvider.GetService(p.ParameterType)
+                    ?? throw new EntityGraphQLExecutionException($"Service {p.ParameterType.Name} not found for dependency injection for mutation {Method.Name}");
+                allArgs.Add(service);
             }
             else
             {
-                try
+                var argField = Arguments[p.Name!];
+                if (argField.DefaultValue != null)
                 {
-                    result = Method.Invoke(instance, allArgs.ToArray());
-                }
-                catch (TargetInvocationException ex)
-                {
-                    if (ex.InnerException != null)
-                        throw ex.InnerException;
-                    throw;
+                    allArgs.Add(argField.DefaultValue);
                 }
             }
-            return result;
         }
 
-        public override (Expression? expression, ParameterExpression? argumentParam) GetExpression(Expression fieldExpression, Expression? fieldContext, IGraphQLNode? parentNode, ParameterExpression? schemaContext, CompileContext? compileContext, IReadOnlyDictionary<string, object> args, ParameterExpression? docParam, object? docVariables, IEnumerable<GraphQLDirective> directives, bool contextChanged, ParameterReplacer replacer)
+        if (ArgumentValidators.Count > 0)
         {
-            var result = fieldExpression;
-
-            if (schemaContext != null && result != null)
+            var validatorContext = new ArgumentValidatorContext(this, argInstance ?? argsToValidate, Method);
+            foreach (var argValidator in ArgumentValidators)
             {
-                result = replacer.ReplaceByType(result, schemaContext.Type, schemaContext);
+                argValidator(validatorContext);
             }
-            return (result, null);
+            if (validatorContext.Errors != null && validatorContext.Errors.Count > 0)
+            {
+                validationErrors.AddRange(validatorContext.Errors);
+            }
         }
+
+        if (validationErrors.Count > 0)
+        {
+            throw new EntityGraphQLValidationException(validationErrors);
+        }
+
+        object? instance = null;
+        // we create an instance _per request_ injecting any parameters to the constructor
+        // We kind of treat a mutation class like an asp.net controller
+        // and we do not want to register them in the service provider to avoid the same issues controllers would have
+        // with different lifetime objects
+        if (instance == null)
+        {
+            instance = serviceProvider != null ? ActivatorUtilities.CreateInstance(serviceProvider, Method.DeclaringType!) : Activator.CreateInstance(Method.DeclaringType!);
+        }
+
+        object? result;
+        if (IsAsync)
+        {
+            result = await (dynamic?)Method.Invoke(instance, allArgs.Count > 0 ? allArgs.ToArray() : null);
+        }
+        else
+        {
+            try
+            {
+                result = Method.Invoke(instance, allArgs.ToArray());
+            }
+            catch (TargetInvocationException ex)
+            {
+                if (ex.InnerException != null)
+                    throw ex.InnerException;
+                throw;
+            }
+        }
+        return result;
+    }
+
+    public override (Expression? expression, ParameterExpression? argumentParam) GetExpression(
+        Expression fieldExpression,
+        Expression? fieldContext,
+        IGraphQLNode? parentNode,
+        ParameterExpression? schemaContext,
+        CompileContext? compileContext,
+        IReadOnlyDictionary<string, object> args,
+        ParameterExpression? docParam,
+        object? docVariables,
+        IEnumerable<GraphQLDirective> directives,
+        bool contextChanged,
+        ParameterReplacer replacer
+    )
+    {
+        var result = fieldExpression;
+
+        if (schemaContext != null && result != null)
+        {
+            result = replacer.ReplaceByType(result, schemaContext.Type, schemaContext);
+        }
+        return (result, null);
     }
 }

--- a/src/EntityGraphQL/Schema/SchemaProvider.cs
+++ b/src/EntityGraphQL/Schema/SchemaProvider.cs
@@ -12,1026 +12,1019 @@ using EntityGraphQL.Extensions;
 using EntityGraphQL.Schema.Directives;
 using Microsoft.Extensions.Logging;
 
-namespace EntityGraphQL.Schema
+namespace EntityGraphQL.Schema;
+
+/// <summary>
+/// Builds and holds your GraphQL schema definition.
+///
+/// The schema definition maps an external view of your data model to you internal dotnet model.
+/// This allows your internal model to change over time while not break your external API. You can create new versions when needed.
+/// </summary>
+/// <typeparam name="TContextType">Base Query object context. Ex. DbContext</typeparam>
+public class SchemaProvider<TContextType> : ISchemaProvider, IDisposable
 {
-    /// <summary>
-    /// Builds and holds your GraphQL schema definition.
-    ///
-    /// The schema definition maps an external view of your data model to you internal dotnet model.
-    /// This allows your internal model to change over time while not break your external API. You can create new versions when needed.
-    /// </summary>
-    /// <typeparam name="TContextType">Base Query object context. Ex. DbContext</typeparam>
-    public class SchemaProvider<TContextType> : ISchemaProvider, IDisposable
+    public Type QueryContextType
     {
-        public Type QueryContextType
-        {
-            get { return queryType.TypeDotnet; }
-        }
-        public Type MutationType
-        {
-            get { return mutationType.SchemaType.TypeDotnet; }
-        }
-        public Type SubscriptionType
-        {
-            get { return subscriptionType.SchemaType.TypeDotnet; }
-        }
-        public Func<string, string> SchemaFieldNamer { get; }
-        public IGqlAuthorizationService AuthorizationService { get; set; }
-        private readonly Dictionary<string, ISchemaType> schemaTypes = [];
-        private readonly Dictionary<string, IDirectiveProcessor> directives = [];
-        private readonly QueryCache queryCache;
+        get { return queryType.TypeDotnet; }
+    }
+    public Type MutationType
+    {
+        get { return mutationType.SchemaType.TypeDotnet; }
+    }
+    public Type SubscriptionType
+    {
+        get { return subscriptionType.SchemaType.TypeDotnet; }
+    }
+    public Func<string, string> SchemaFieldNamer { get; }
+    public IGqlAuthorizationService AuthorizationService { get; set; }
+    private readonly Dictionary<string, ISchemaType> schemaTypes = [];
+    private readonly Dictionary<string, IDirectiveProcessor> directives = [];
+    private readonly QueryCache queryCache;
 
-        public string QueryContextName
-        {
-            get => queryType.Name;
-        }
+    public string QueryContextName
+    {
+        get => queryType.Name;
+    }
 
-        private readonly SchemaType<TContextType> queryType;
-        private readonly ILogger<SchemaProvider<TContextType>>? logger;
-        private readonly GraphQLCompiler graphQLCompiler;
-        private readonly bool introspectionEnabled;
-        private readonly bool isDevelopment;
-        private readonly MutationType mutationType;
-        private readonly SubscriptionType subscriptionType;
-        private readonly Dictionary<Type, IExtensionAttributeHandler> attributeHandlers = new Dictionary<Type, IExtensionAttributeHandler>();
+    private readonly SchemaType<TContextType> queryType;
+    private readonly ILogger<SchemaProvider<TContextType>>? logger;
+    private readonly GraphQLCompiler graphQLCompiler;
+    private readonly bool introspectionEnabled;
+    private readonly bool isDevelopment;
+    private readonly MutationType mutationType;
+    private readonly SubscriptionType subscriptionType;
+    private readonly Dictionary<Type, IExtensionAttributeHandler> attributeHandlers = new Dictionary<Type, IExtensionAttributeHandler>();
 
-        public IDictionary<Type, ICustomTypeConverter> TypeConverters { get; } = new Dictionary<Type, ICustomTypeConverter>();
+    public IDictionary<Type, ICustomTypeConverter> TypeConverters { get; } = new Dictionary<Type, ICustomTypeConverter>();
 
-        public List<AllowedException> AllowedExceptions { get; } = new();
+    public List<AllowedException> AllowedExceptions { get; } = new();
 
-        // map some types to scalar types
-        private readonly Dictionary<Type, GqlTypeInfo> customTypeMappings;
-        private static readonly Action<ILogger, Exception> logErrorMessage = LoggerMessage.Define(LogLevel.Error, new EventId(1, "QueryRequest"), "Error executing QueryRequest");
+    // map some types to scalar types
+    private readonly Dictionary<Type, GqlTypeInfo> customTypeMappings;
+    private static readonly Action<ILogger, Exception> logErrorMessage = LoggerMessage.Define(LogLevel.Error, new EventId(1, "QueryRequest"), "Error executing QueryRequest");
 
-        public SchemaProvider()
-            : this(null, null) { }
+    public SchemaProvider()
+        : this(null, null) { }
 
-        /// <summary>
-        /// Create a new GraphQL Schema provider that defines all the types and fields etc.
-        /// </summary>
-        /// <param name="fieldNamer">A naming function for fields that will be used when using methods that automatically create field names e.g. SchemaType.AddAllFields()</param>
-        public SchemaProvider(
-            IGqlAuthorizationService? authorizationService = null,
-            Func<string, string>? fieldNamer = null,
-            ILogger<SchemaProvider<TContextType>>? logger = null,
-            bool introspectionEnabled = true,
-            bool isDevelopment = true
-        )
-        {
-            AuthorizationService = authorizationService ?? new RoleBasedAuthorization();
-            SchemaFieldNamer = fieldNamer ?? SchemaBuilderSchemaOptions.DefaultFieldNamer;
-            this.logger = logger;
-            this.graphQLCompiler = new GraphQLCompiler(this);
-            this.introspectionEnabled = introspectionEnabled;
-            this.isDevelopment = isDevelopment;
-            queryCache = new QueryCache();
+    /// <summary>
+    /// Create a new GraphQL Schema provider that defines all the types and fields etc.
+    /// </summary>
+    /// <param name="fieldNamer">A naming function for fields that will be used when using methods that automatically create field names e.g. SchemaType.AddAllFields()</param>
+    public SchemaProvider(
+        IGqlAuthorizationService? authorizationService = null,
+        Func<string, string>? fieldNamer = null,
+        ILogger<SchemaProvider<TContextType>>? logger = null,
+        bool introspectionEnabled = true,
+        bool isDevelopment = true
+    )
+    {
+        AuthorizationService = authorizationService ?? new RoleBasedAuthorization();
+        SchemaFieldNamer = fieldNamer ?? SchemaBuilderSchemaOptions.DefaultFieldNamer;
+        this.logger = logger;
+        this.graphQLCompiler = new GraphQLCompiler(this);
+        this.introspectionEnabled = introspectionEnabled;
+        this.isDevelopment = isDevelopment;
+        queryCache = new QueryCache();
 
-            // default GQL scalar types
-            AddScalarType<int>("Int", "Int scalar");
-            AddScalarType<double>("Float", "Float scalar");
-            AddScalarType<bool>("Boolean", "Boolean scalar");
-            AddScalarType<string>("String", "String scalar");
-            AddScalarType<Guid>("ID", "ID scalar");
-            AddScalarType<char>("Char", "Char scalar");
+        // default GQL scalar types
+        AddScalarType<int>("Int", "Int scalar");
+        AddScalarType<double>("Float", "Float scalar");
+        AddScalarType<bool>("Boolean", "Boolean scalar");
+        AddScalarType<string>("String", "String scalar");
+        AddScalarType<Guid>("ID", "ID scalar");
+        AddScalarType<char>("Char", "Char scalar");
 
-            // default custom scalar for DateTime
-            // TODO 6.0 - Rename Date to DateTime?
-            AddScalarType<DateTime>("Date", "Date with time scalar");
-            AddScalarType<DateTimeOffset>("DateTimeOffset", "DateTimeOffset scalar");
+        // default custom scalar for DateTime
+        // TODO 6.0 - Rename Date to DateTime?
+        AddScalarType<DateTime>("Date", "Date with time scalar");
+        AddScalarType<DateTimeOffset>("DateTimeOffset", "DateTimeOffset scalar");
 #if NET6_0_OR_GREATER
-            AddScalarType<DateOnly>("DateOnly", "Date value only scalar");
-            AddScalarType<TimeOnly>("TimeOnly", "Time value only scalar");
+        AddScalarType<DateOnly>("DateOnly", "Date value only scalar");
+        AddScalarType<TimeOnly>("TimeOnly", "Time value only scalar");
 #endif
 
-            customTypeMappings = new Dictionary<Type, GqlTypeInfo>
-            {
-                { typeof(sbyte), new GqlTypeInfo(() => Type("Int"), typeof(sbyte)) },
-                { typeof(short), new GqlTypeInfo(() => Type("Int"), typeof(short)) },
-                { typeof(ushort), new GqlTypeInfo(() => Type("Int"), typeof(ushort)) },
-                { typeof(long), new GqlTypeInfo(() => Type("Int"), typeof(long)) },
-                { typeof(ulong), new GqlTypeInfo(() => Type("Int"), typeof(ulong)) },
-                { typeof(byte), new GqlTypeInfo(() => Type("Int"), typeof(byte)) },
-                { typeof(uint), new GqlTypeInfo(() => Type("Int"), typeof(uint)) },
-                { typeof(float), new GqlTypeInfo(() => Type("Float"), typeof(float)) },
-                { typeof(decimal), new GqlTypeInfo(() => Type("Float"), typeof(decimal)) },
-                { typeof(byte[]), new GqlTypeInfo(() => Type("String"), typeof(byte[])) },
-            };
-
-            var queryContext = new SchemaType<TContextType>(this, "Query", null, null, GqlTypes.QueryObject);
-            this.queryType = queryContext;
-            schemaTypes.Add(queryContext.Name, queryContext);
-
-            // these types are added to the schema if a field is added to the type in ControllerType
-            this.mutationType = new MutationType(this, "Mutation", null, null);
-            this.subscriptionType = new SubscriptionType(this, "Subscription");
-
-            if (introspectionEnabled)
-            {
-                // add types first as fields from the other types may refer to these types
-                var typeElement = AddType<Models.TypeElement>("__Type", "Information about types");
-                AddType<Models.EnumValue>("__EnumValue", "Information about enums").AddAllFields();
-                AddType<Models.InputValue>(
-                        "__InputValue",
-                        "Arguments provided to Fields or Directives and the input fields of an InputObject are represented as Input Values which describe their type and optionally a default value."
-                    )
-                    .AddAllFields();
-                AddType<Models.Directive>("__Directive", "Information about directives").AddAllFields();
-                AddType<Models.Field>("__Field", "Information about fields").AddAllFields();
-                AddType<Models.Schema>(
-                        "__Schema",
-                        "A GraphQL Schema defines the capabilities of a GraphQL server. It exposes all available types and directives on the server, as well as the entry points for query, mutation, and subscription operations."
-                    )
-                    .AddAllFields();
-
-                // add these fields after the other types as the fields reference those types and by default would auto register under the wrong name
-                typeElement.AddAllFields();
-                typeElement.ReplaceField(
-                    "enumValues",
-                    new { includeDeprecated = false },
-                    (t, p) => t.EnumValues.Where(f => p.includeDeprecated ? f.IsDeprecated || !f.IsDeprecated : !f.IsDeprecated).ToList(),
-                    "Enum values available on type"
-                );
-
-                SetupIntrospectionTypesAndField();
-            }
-
-            var include = new IncludeDirectiveProcessor();
-            var skip = new SkipDirectiveProcessor();
-            directives.Add(include.Name, include);
-            directives.Add(skip.Name, skip);
-
-            AddAttributeHandler(new ObsoleteAttributeHandler());
-        }
-
-        /// <summary>
-        /// Add a custom type converter to convert query variables into the expected dotnet types. I.e. the incoming variables from
-        /// the request which may be strings or JSON into the dotnet types on the argument classes.
-        /// For example a string to DateTime converter.
-        ///
-        /// EntityGraphQL already handles Guid, DateTime, InputTypes from the schema, arrays/lists, System.Text.Json elements, float/double/decimal/int/short/uint/long/etc
-        /// </summary>
-        /// <param name="typeConverter"></param>
-        public void AddCustomTypeConverter(ICustomTypeConverter typeConverter)
+        customTypeMappings = new Dictionary<Type, GqlTypeInfo>
         {
-            TypeConverters.Add(typeConverter.Type, typeConverter);
-        }
+            { typeof(sbyte), new GqlTypeInfo(() => Type("Int"), typeof(sbyte)) },
+            { typeof(short), new GqlTypeInfo(() => Type("Int"), typeof(short)) },
+            { typeof(ushort), new GqlTypeInfo(() => Type("Int"), typeof(ushort)) },
+            { typeof(long), new GqlTypeInfo(() => Type("Int"), typeof(long)) },
+            { typeof(ulong), new GqlTypeInfo(() => Type("Int"), typeof(ulong)) },
+            { typeof(byte), new GqlTypeInfo(() => Type("Int"), typeof(byte)) },
+            { typeof(uint), new GqlTypeInfo(() => Type("Int"), typeof(uint)) },
+            { typeof(float), new GqlTypeInfo(() => Type("Float"), typeof(float)) },
+            { typeof(decimal), new GqlTypeInfo(() => Type("Float"), typeof(decimal)) },
+            { typeof(byte[]), new GqlTypeInfo(() => Type("String"), typeof(byte[])) },
+        };
 
-        private void SetupIntrospectionTypesAndField()
+        var queryContext = new SchemaType<TContextType>(this, "Query", null, null, GqlTypes.QueryObject);
+        this.queryType = queryContext;
+        schemaTypes.Add(queryContext.Name, queryContext);
+
+        // these types are added to the schema if a field is added to the type in ControllerType
+        this.mutationType = new MutationType(this, "Mutation", null, null);
+        this.subscriptionType = new SubscriptionType(this, "Subscription");
+
+        if (introspectionEnabled)
         {
-            if (!introspectionEnabled)
-                return;
-
-            // evaluate Fields lazily so we don't end up in endless loop
-            Type<Models.TypeElement>("__Type")
-                .ReplaceField(
-                    "fields",
-                    new { includeDeprecated = false },
-                    (t, p) => SchemaIntrospection.BuildFieldsForType(this, t.Name!).Where(f => p.includeDeprecated ? f.IsDeprecated || !f.IsDeprecated : !f.IsDeprecated).ToList(),
-                    "Fields available on type"
-                );
-
-            Query().ReplaceField("__schema", db => SchemaIntrospection.Make(this), "Introspection of the schema").Returns("__Schema");
-            Query()
-                .ReplaceField(
-                    "__type",
-                    new { name = ArgumentHelper.Required<string>() },
-                    (db, p) => SchemaIntrospection.Make(this).Types.Where(s => s.Name == p.name).First(),
-                    "Query a type by name"
+            // add types first as fields from the other types may refer to these types
+            var typeElement = AddType<Models.TypeElement>("__Type", "Information about types");
+            AddType<Models.EnumValue>("__EnumValue", "Information about enums").AddAllFields();
+            AddType<Models.InputValue>(
+                    "__InputValue",
+                    "Arguments provided to Fields or Directives and the input fields of an InputObject are represented as Input Values which describe their type and optionally a default value."
                 )
-                .Returns("__Type");
-        }
+                .AddAllFields();
+            AddType<Models.Directive>("__Directive", "Information about directives").AddAllFields();
+            AddType<Models.Field>("__Field", "Information about fields").AddAllFields();
+            AddType<Models.Schema>(
+                    "__Schema",
+                    "A GraphQL Schema defines the capabilities of a GraphQL server. It exposes all available types and directives on the server, as well as the entry points for query, mutation, and subscription operations."
+                )
+                .AddAllFields();
 
-        /// <summary>
-        /// Execute a query using this schema.
-        /// </summary>
-        /// <param name="gql">The GraphQL query document</param>
-        /// <param name="serviceProvider">A service provider used for looking up the context dependency and services in field selections and mutations</param>
-        /// <param name="user">Optional user/ClaimsPrincipal to check access for queries</param>
-        /// <param name="options"></param>
-        /// <returns></returns>
-        public QueryResult ExecuteRequest(QueryRequest gql, IServiceProvider serviceProvider, ClaimsPrincipal? user, ExecutionOptions? options = null)
-        {
-            return ExecuteRequestAsync(gql, serviceProvider, user, options).GetAwaiter().GetResult();
-        }
+            // add these fields after the other types as the fields reference those types and by default would auto register under the wrong name
+            typeElement.AddAllFields();
+            typeElement.ReplaceField(
+                "enumValues",
+                new { includeDeprecated = false },
+                (t, p) => t.EnumValues.Where(f => p.includeDeprecated ? f.IsDeprecated || !f.IsDeprecated : !f.IsDeprecated).ToList(),
+                "Enum values available on type"
+            );
 
-        /// <summary>
-        /// Execute a query using this schema.
-        /// </summary>
-        /// <param name="gql">The GraphQL query document</param>
-        /// <param name="serviceProvider">A service provider used for looking up the context dependency and services in field selections and mutations</param>
-        /// <param name="user">Optional user/ClaimsPrincipal to check access for queries</param>
-        /// <param name="options"></param>
-        /// <returns></returns>
-        public async Task<QueryResult> ExecuteRequestAsync(QueryRequest gql, IServiceProvider serviceProvider, ClaimsPrincipal? user, ExecutionOptions? options = null)
-        {
-            return await DoExecuteRequestAsync(gql, default, serviceProvider, user, options);
-        }
-
-        /// <summary>
-        /// Execute a query using this schema.
-        /// </summary>
-        /// <param name="gql">The query</param>
-        /// <param name="context">The context object. An instance of the context the schema was build from. This is used anywhere the context is required</param>
-        /// <param name="serviceProvider">A service provider used for looking up dependencies of field selections and mutations</param>
-        /// <param name="user">Optional user/ClaimsPrincipal to check access for queries</param>
-        /// <param name="options"></param>
-        /// <typeparam name="TContextType"></typeparam>
-        /// <returns></returns>
-        public QueryResult ExecuteRequestWithContext(
-            QueryRequest gql,
-            TContextType context,
-            IServiceProvider? serviceProvider,
-            ClaimsPrincipal? user,
-            ExecutionOptions? options = null
-        )
-        {
-            return ExecuteRequestWithContextAsync(gql, context, serviceProvider, user, options).GetAwaiter().GetResult();
-        }
-
-        /// <summary>
-        /// Execute a query using this schema.
-        /// </summary>
-        /// <param name="gql">The query</param>
-        /// <param name="context">The context object. An instance of the context the schema was build from. This is used anywhere the context is required</param>
-        /// <param name="serviceProvider">A service provider used for looking up dependencies of field selections and mutations</param>
-        /// <param name="user">Optional user/ClaimsPrincipal to check access for queries</param>
-        /// <param name="options"></param>
-        /// <typeparam name="TContextType"></typeparam>
-        /// <returns></returns>
-        public async Task<QueryResult> ExecuteRequestWithContextAsync(
-            QueryRequest gql,
-            TContextType context,
-            IServiceProvider? serviceProvider,
-            ClaimsPrincipal? user,
-            ExecutionOptions? options = null
-        )
-        {
-            return await DoExecuteRequestAsync(gql, context, serviceProvider, user, options);
-        }
-
-        private async Task<QueryResult> DoExecuteRequestAsync(
-            QueryRequest gql,
-            TContextType? overwriteContext,
-            IServiceProvider? serviceProvider,
-            ClaimsPrincipal? user,
-            ExecutionOptions? options
-        )
-        {
-            QueryResult result;
-            try
-            {
-                options ??= new ExecutionOptions();
-                GraphQLDocument? compiledQuery = null;
-                if (options.EnablePersistedQueries)
-                {
-                    var persistedQuery = (PersistedQueryExtension?)
-                        ExpressionUtil.ChangeType(gql.Extensions.GetValueOrDefault("persistedQuery"), typeof(PersistedQueryExtension), null, options);
-                    if (persistedQuery != null && persistedQuery.Version != 1)
-                        throw new EntityGraphQLExecutionException("PersistedQueryNotSupported");
-
-                    string? hash = persistedQuery?.Sha256Hash;
-
-                    if (hash == null && gql.Query == null)
-                        throw new EntityGraphQLExecutionException("Please provide a persisted query hash or a query string");
-
-                    if (hash != null)
-                    {
-                        compiledQuery = queryCache.GetCompiledQueryWithHash(hash);
-                        if (compiledQuery == null && gql.Query == null)
-                            throw new EntityGraphQLExecutionException("PersistedQueryNotFound");
-                        else if (compiledQuery == null)
-                        {
-                            compiledQuery = graphQLCompiler.Compile(gql, new QueryRequestContext(AuthorizationService, user));
-                            queryCache.AddCompiledQuery(hash, compiledQuery);
-                        }
-                    }
-                    else if (compiledQuery == null)
-                    {
-                        // if here they sent query with no hash
-                        // persisted queries will not auto cache it (only when you provide the hash) but is QueryCache is enabled we will cache it
-                        if (options.EnableQueryCache)
-                            compiledQuery = CompileQueryWithCache(gql, options, user);
-                        else
-                            compiledQuery = graphQLCompiler.Compile(gql, new QueryRequestContext(AuthorizationService, user));
-                    }
-                }
-                else if (options.EnableQueryCache)
-                {
-                    compiledQuery = CompileQueryWithCache(gql, options, user);
-                }
-                else
-                {
-                    // no cache
-                    if (gql.Query == null)
-                    {
-                        string? hash = (
-                            (PersistedQueryExtension?)ExpressionUtil.ChangeType(gql.Extensions.GetValueOrDefault("persistedQuery"), typeof(PersistedQueryExtension), null, options)
-                        )?.Sha256Hash;
-                        if (hash != null)
-                            throw new EntityGraphQLExecutionException("PersistedQueryNotSupported");
-
-                        throw new EntityGraphQLException("Query field must be set unless you are using persisted queries");
-                    }
-
-                    compiledQuery = graphQLCompiler.Compile(gql, new QueryRequestContext(AuthorizationService, user));
-                }
-
-                result = await compiledQuery.ExecuteQueryAsync(overwriteContext, serviceProvider, gql.Variables, gql.OperationName, options);
-            }
-            catch (Exception ex)
-            {
-                result = HandleException(ex);
-            }
-
-            return result;
-        }
-
-        private QueryResult HandleException(Exception exception)
-        {
-            if (logger != null)
-                logErrorMessage(logger, exception);
-
-            var result = new QueryResult();
-            foreach (var (errorMessage, extensions) in GenerateMessage(exception).Distinct())
-                result.AddError(errorMessage, extensions);
-            return result;
-        }
-
-        private IEnumerable<(string errorMessage, IDictionary<string, object>? extensions)> GenerateMessage(Exception exception)
-        {
-            switch (exception)
-            {
-                case EntityGraphQLValidationException validationException:
-                    return validationException.ValidationErrors.Select(v => (v, (IDictionary<string, object>?)null));
-                case AggregateException aggregateException:
-                    return aggregateException.InnerExceptions.SelectMany(GenerateMessage);
-                case EntityGraphQLException graphqlException:
-                    return new[] { (graphqlException.Message, (IDictionary<string, object>?)graphqlException.Extensions) };
-                case TargetInvocationException targetInvocationException:
-                    return GenerateMessage(targetInvocationException.InnerException!);
-                case EntityGraphQLFieldException fieldException:
-                    return GenerateMessage(fieldException.InnerException!).Select(f => ($"Field '{fieldException.FieldName}' - {f.errorMessage}", f.extensions));
-                default:
-                    if (isDevelopment || AllowedExceptions.Any(e => e.IsAllowed(exception)) || exception.GetType().GetCustomAttribute<AllowedExceptionAttribute>() != null)
-                        return new[] { (exception.Message, (IDictionary<string, object>?)null) };
-                    return new[] { ("Error occurred", (IDictionary<string, object>?)null) };
-            }
-        }
-
-        private GraphQLDocument CompileQueryWithCache(QueryRequest gql, ExecutionOptions executionOptions, ClaimsPrincipal? user)
-        {
-            GraphQLDocument? compiledQuery;
-            // try to get the compiled query from the cache
-            // cache the result
-            if (gql.Query == null)
-            {
-                string? phash = (
-                    (PersistedQueryExtension?)ExpressionUtil.ChangeType(gql.Extensions.GetValueOrDefault("persistedQuery"), typeof(PersistedQueryExtension), null, executionOptions)
-                )?.Sha256Hash;
-                if (phash != null)
-                    throw new EntityGraphQLExecutionException("PersistedQueryNotSupported");
-                throw new EntityGraphQLException("Query field must be set unless you are using persisted queries");
-            }
-
-            (compiledQuery, var hash) = queryCache.GetCompiledQuery(gql.Query, null);
-            if (compiledQuery == null)
-            {
-                compiledQuery = graphQLCompiler.Compile(gql, new QueryRequestContext(AuthorizationService, user));
-                queryCache.AddCompiledQuery(hash, compiledQuery);
-            }
-
-            return compiledQuery;
-        }
-
-        /// <summary>
-        /// Add a new Object type into the schema with TBaseType as its context.
-        /// </summary>
-        /// <param name="name">Name of the type</param>
-        /// <param name="description">description of the type</param>
-        /// <typeparam name="TBaseType"></typeparam>
-        /// <returns>The added type for further changes via chaining</returns>
-        public SchemaType<TBaseType> AddType<TBaseType>(string name, string? description)
-        {
-            var gqlType =
-                typeof(TBaseType).IsAbstract || typeof(TBaseType).IsInterface
-                    ? GqlTypes.Interface
-                    : typeof(TBaseType).IsEnum
-                        ? GqlTypes.Enum
-                        : GqlTypes.QueryObject;
-            var schemaType = new SchemaType<TBaseType>(this, name, description, null, gqlType);
-            FinishAddingType(typeof(TBaseType), schemaType);
-            return schemaType;
-        }
-
-        /// <summary>
-        /// Add a new Object type into the schema with contextType as its context
-        /// </summary>
-        /// <param name="contextType"></param>
-        /// <param name="name">Name of the type</param>
-        /// <param name="description">description of the type</param>
-        /// <returns>The added type for further changes via chaining</returns>
-        public ISchemaType AddType(Type contextType, string name, string? description = null)
-        {
-            var gqlType = contextType.IsAbstract || contextType.IsInterface ? GqlTypes.Interface : GqlTypes.QueryObject;
-            var newType = (ISchemaType)Activator.CreateInstance(typeof(SchemaType<>).MakeGenericType(contextType), this, contextType, name, description, null, gqlType, null)!;
-            FinishAddingType(contextType, newType);
-            return newType;
-        }
-
-        /// <summary>
-        /// Add a new Object type into the schema with TBaseType as its context
-        /// </summary>
-        /// <typeparam name="TBaseType"></typeparam>
-        /// <param name="name">Name of the type</param>
-        /// <param name="description">description of the type</param>
-        /// <param name="updateFunc">Callback called with the schema type where you can further update the type</param>
-        public SchemaType<TBaseType> AddType<TBaseType>(string name, string description, Action<SchemaType<TBaseType>> updateFunc)
-        {
-            var type = AddType<TBaseType>(name, description);
-            updateFunc(type);
-            return type;
-        }
-
-        /// <summary>
-        /// Adds a new Object type into the schema. The name defaults to the TBaseType name
-        /// </summary>
-        /// <param name="description">description of the type</param>
-        /// <typeparam name="TBaseType"></typeparam>
-        /// <returns>The added type for further changes via chaining</returns>
-        public SchemaType<TBaseType> AddType<TBaseType>(string description)
-        {
-            var name = SchemaBuilder.BuildTypeName(typeof(TBaseType));
-            return AddType<TBaseType>(name, description);
-        }
-
-        public ISchemaType AddType(ISchemaType schemaType)
-        {
-            FinishAddingType(schemaType.TypeDotnet, schemaType);
-            return schemaType;
-        }
-
-        private void FinishAddingType(Type contextType, ISchemaType tt)
-        {
-            tt.RequiredAuthorization = AuthorizationService.GetRequiredAuthFromType(contextType);
-            if (string.IsNullOrEmpty(tt.Description))
-            {
-                tt.Description = contextType.GetCustomAttribute<DescriptionAttribute>()?.Description;
-            }
-            schemaTypes.Add(tt.Name, tt);
-        }
-
-        /// <summary>
-        /// Remove TType from the schema
-        /// </summary>
-        /// <typeparam name="TType"></typeparam>
-        /// <returns>The SchemaProvider</returns>
-        public ISchemaProvider RemoveType<TType>()
-        {
-            return RemoveType(GetSchemaType(typeof(TType), false, null).Name);
-        }
-
-        /// <summary>
-        /// Remove TType from the schema
-        /// </summary>
-        /// <param name="schemaType"></param>
-        /// <returns>The SchemaProvider</returns>
-        public ISchemaProvider RemoveType(string schemaType)
-        {
-            schemaTypes.Remove(schemaType);
-            return this;
-        }
-
-        /// <summary>
-        /// Add a GraphQL Input Object type to the schema. Input types are objects used in arguments of fields or mutations
-        /// </summary>
-        /// <param name="name">Name of the type. Used as passed. Case sensitive</param>
-        /// <param name="description">Description of the input type</param>
-        /// <typeparam name="TBaseType"></typeparam>
-        /// <returns>The added type for further changes via chaining</returns>
-        public SchemaType<TBaseType> AddInputType<TBaseType>(string name, string? description = null)
-        {
-            return (SchemaType<TBaseType>)AddInputType(typeof(TBaseType), name, description);
-        }
-
-        /// <summary>
-        /// Add a GraphQL Input Object type to the schema. Input types are objects used in arguments of fields or mutations
-        /// </summary>
-        /// <param name="name">Name of the type. Used as passed. Case sensitive</param>
-        /// <param name="description">Description of the input type</param>
-        /// <returns>The added type for further changes via chaining</returns>
-        public ISchemaType AddInputType(Type type, string name, string? description = null)
-        {
-            var newType = (ISchemaType)Activator.CreateInstance(typeof(SchemaType<>).MakeGenericType(type), this, type, name, description, null, GqlTypes.InputObject, null)!;
-            FinishAddingType(type, newType);
-
-            return newType;
-        }
-
-        /// <summary>
-        /// Adds a new scalar type defined to the schema. Dotnet types of clrType will be treated as gqlTypeName
-        /// </summary>
-        /// <param name="clrType">Dotnet type to mapp to a scalar</param>
-        /// <param name="gqlTypeName">GraphQL scalar type name</param>
-        /// <param name="description">Description of the scalar type</param>
-        /// <returns>The added type for further changes via chaining</returns>
-        public ISchemaType AddScalarType(Type clrType, string gqlTypeName, string? description = null)
-        {
-            var schemaType = (ISchemaType)Activator.CreateInstance(typeof(SchemaType<>).MakeGenericType(clrType), this, gqlTypeName, description, null, GqlTypes.Scalar, null)!;
-            schemaTypes.Add(gqlTypeName, schemaType);
-            return schemaType;
-        }
-
-        /// <summary>
-        /// Adds a new scalar type defined to the schema. Dotnet types of TType will be treated as gqlTypeName
-        /// </summary>
-        /// <param name="clrType">Dotnet type to mapp to a scalar</param>
-        /// <param name="gqlTypeName">GraphQL scalar type name</param>
-        /// <param name="description">Description of the scalar type</param>
-        /// <returns>The added type for further changes via chaining</returns>
-        public SchemaType<TType> AddScalarType<TType>(string gqlTypeName, string? description = null)
-        {
-            var schemaType = new SchemaType<TType>(this, gqlTypeName, description, null, GqlTypes.Scalar);
-            schemaTypes.Add(gqlTypeName, schemaType);
-            return schemaType;
-        }
-
-        /// <summary>
-        /// Add any methods marked with GraphQLMutationAttribute in the given object to the schema. Method names are added as using fieldNamer
-        /// </summary>
-        /// <typeparam name="TType"></typeparam>
-        /// <param name="options">Options for the schema builder</param>
-        public void AddMutationsFrom<TType>(SchemaBuilderOptions? options = null)
-            where TType : class
-        {
-            mutationType.AddFrom<TType>(options);
-        }
-
-        /// <summary>
-        /// Search for a GraphQL type with the given name. Lookup is only done by name.
-        ///
-        /// Customer type mappings are not searched
-        ///
-        /// Use the Type<T>() methods for returning typed SchemaType<T>
-        /// </summary>
-        /// <param name="typeName"></param>
-        /// <returns>An ISchemaType if the type is found in the schema</returns>
-        /// <exception cref="EntityGraphQLCompilerException">If type name not found</exception>
-        public ISchemaType GetSchemaType(string typeName, QueryRequestContext? requestContext)
-        {
-            if (schemaTypes.TryGetValue(typeName, out var schemaType))
-                return SchemaProvider<TContextType>.CheckTypeAccess(schemaType, requestContext);
-
-            throw new EntityGraphQLCompilerException($"Type {typeName} not found in schema");
-        }
-
-        public ISchemaType GetSchemaType(Type dotnetType, QueryRequestContext? requestContext)
-        {
-            return GetSchemaType(dotnetType, false, requestContext);
-        }
-
-        /// <summary>
-        /// Search for a GraphQL type with the given name. Lookup is done by DotNet type first.
-        /// Then by the type name. Then the customTypeMappings are searched
-        ///
-        /// Use the Type<T>() methods for returning typed SchemaType<T>
-        /// </summary>
-        /// <param name="dotnetType"></param>
-        /// <param name="typeFilter">Used the filter the search as dotnet type may be shared across Input type and query
-        /// type with different names in the schema</param>
-        /// <returns></returns>
-        /// <exception cref="EntityGraphQLCompilerException"></exception>
-        public ISchemaType GetSchemaType(Type dotnetType, bool inputTypeScope, QueryRequestContext? requestContext)
-        {
-            if (TryGetSchemaType(dotnetType, inputTypeScope, out var schemaType, requestContext))
-                return schemaType!;
-            throw new EntityGraphQLCompilerException($"No schema type found for dotnet type '{dotnetType.Name}'. Make sure you add it or add a type mapping.");
-        }
-
-        public bool TryGetSchemaType(Type dotnetType, bool inputTypeScope, out ISchemaType? schemaType, QueryRequestContext? requestContext)
-        {
-            // look up by the actual type not the name
-            schemaType =
-                schemaTypes
-                    .Values.WhereWhen(t => t.GqlType == GqlTypes.Scalar || t.GqlType == GqlTypes.Enum || t.GqlType == GqlTypes.InputObject, inputTypeScope)
-                    .FirstOrDefault(t => t.TypeDotnet == dotnetType) ?? schemaTypes.GetValueOrDefault(dotnetType.Name);
-            if (inputTypeScope && schemaType?.GqlType.IsNotValidForInput() == true)
-            {
-                // chance the Type has an input type that inherits from it
-                schemaType = schemaTypes.Values.Where(t => dotnetType.IsAssignableFrom(t.TypeDotnet) && t.GqlType == GqlTypes.InputObject).FirstOrDefault();
-            }
-
-            if (schemaType == null && customTypeMappings.TryGetValue(dotnetType, out var typeInfo))
-            {
-                schemaType = typeInfo.SchemaType;
-            }
-            if (schemaType == null)
-                return false;
-            schemaType = SchemaProvider<TContextType>.CheckTypeAccess(schemaType, requestContext);
-            return true;
-        }
-
-        private static ISchemaType CheckTypeAccess(ISchemaType schemaType, QueryRequestContext? requestContext)
-        {
-            if (requestContext == null)
-                return schemaType;
-
-            if (requestContext.AuthorizationService != null && !requestContext.AuthorizationService.IsAuthorized(requestContext.User, schemaType.RequiredAuthorization))
-                throw new EntityGraphQLAccessException($"You are not authorized to access the '{schemaType.Name}' type.");
-
-            return schemaType;
-        }
-
-        /// <summary>
-        /// Get registered type by TType name
-        /// </summary>
-        /// <typeparam name="TType"></typeparam>
-        /// <returns>The typed SchemaType<TType> object for configuration</returns>
-        public SchemaType<TType> Type<TType>()
-        {
-            return (SchemaType<TType>)GetSchemaType(typeof(TType), false, null);
-        }
-
-        /// <summary>
-        /// Get registered type by schema type name
-        /// </summary>
-        /// <typeparam name="TType"></typeparam>
-        /// <param name="typeName"></param>
-        /// <returns>The typed SchemaType<TType> object for configuration</returns>
-        public SchemaType<TType> Type<TType>(string typeName)
-        {
-            return (SchemaType<TType>)GetSchemaType(typeName, null);
-        }
-
-        /// <summary>
-        /// Search for a GraphQL type with the given name. Lookup is only done by name.
-        ///
-        /// Customer type mappings are not searched
-        ///
-        /// Use the Type<T>() methods for returning typed SchemaType<T>
-        /// </summary>
-        /// <param name="typeName"></param>
-        /// <returns>An ISchemaType if the type is found in the schema</returns>
-        /// <exception cref="EntityGraphQLCompilerException">If type name not found</exception>
-        public ISchemaType Type(string typeName)
-        {
-            return GetSchemaType(typeName, null);
-        }
-
-        public ISchemaType Type(Type type)
-        {
-            return GetSchemaType(type, false, null);
-        }
-
-        public SchemaType<TType> Type<TType>(Type type)
-        {
-            return (SchemaType<TType>)GetSchemaType(type, false, null);
-        }
-
-        /// <summary>
-        /// Find a schema type for TType and update the type with the configure callback
-        /// </summary>
-        /// <typeparam name="TType"></typeparam>
-        /// <param name="configure"></param>
-        public void UpdateType<TType>(Action<SchemaType<TType>> configure) => configure(Type<TType>());
-
-        /// <summary>
-        /// Returns true if the schema has a type by name defined
-        /// </summary>
-        /// <param name="typeName"></param>
-        /// <returns>True if found. False if not</returns>
-        public bool HasType(string typeName)
-        {
-            if (typeName == QueryContextName)
-                return true;
-
-            foreach (var schemaType in schemaTypes.Values)
-            {
-                if (schemaType.Name == typeName)
-                    return true;
-            }
-            foreach (var mappingType in customTypeMappings.Keys)
-            {
-                if (mappingType.Name == typeName)
-                    return true;
-            }
-            return false;
-        }
-
-        /// <summary>
-        /// Returns true if the schema has a type that has the given dotnet type as its base context
-        /// </summary>
-        /// <param name="type"></param>
-        /// <returns>True if found. False if not</returns>
-        public bool HasType(Type type)
-        {
-            if (type == queryType.TypeDotnet)
-                return true;
-
-            foreach (var schemaType in schemaTypes.Values)
-            {
-                if (schemaType.TypeDotnet == type)
-                    return true;
-            }
-            return customTypeMappings.ContainsKey(type);
-        }
-
-        /// <summary>
-        /// Add a mapping from a Dotnet type to a GraphQL schema type name. Make sure you have added the GraphQL type
-        /// in the schema as a Scalar type or full type
-        ///
-        /// E.g. schema.AddTypeMapping<NpgsqlPolygon>("[Point!]!");
-        /// </summary>
-        /// <param name="gqlType">The GraphQL schema type in full form. E.g. [Int!]!, [Int], Int, etc.</param>
-        /// <typeparam name="TFromType"></typeparam>
-        public void AddTypeMapping<TFromType>(string gqlType)
-        {
-            var typeInfo = GqlTypeInfo.FromGqlType(this, typeof(TFromType), gqlType);
-            // add mapping
-            customTypeMappings.Add(typeof(TFromType), typeInfo);
             SetupIntrospectionTypesAndField();
         }
 
-        /// <summary>
-        /// Get the GqlTypeInfo for a custom type mapping of dotnetType.
-        /// Returns null if there is no mapping
-        /// </summary>
-        /// <param name="dotnetType"></param>
-        /// <returns></returns>
-        public GqlTypeInfo? GetCustomTypeMapping(Type dotnetType)
+        var include = new IncludeDirectiveProcessor();
+        var skip = new SkipDirectiveProcessor();
+        directives.Add(include.Name, include);
+        directives.Add(skip.Name, skip);
+
+        AddAttributeHandler(new ObsoleteAttributeHandler());
+    }
+
+    /// <summary>
+    /// Add a custom type converter to convert query variables into the expected dotnet types. I.e. the incoming variables from
+    /// the request which may be strings or JSON into the dotnet types on the argument classes.
+    /// For example a string to DateTime converter.
+    ///
+    /// EntityGraphQL already handles Guid, DateTime, InputTypes from the schema, arrays/lists, System.Text.Json elements, float/double/decimal/int/short/uint/long/etc
+    /// </summary>
+    /// <param name="typeConverter"></param>
+    public void AddCustomTypeConverter(ICustomTypeConverter typeConverter)
+    {
+        TypeConverters.Add(typeConverter.Type, typeConverter);
+    }
+
+    private void SetupIntrospectionTypesAndField()
+    {
+        if (!introspectionEnabled)
+            return;
+
+        // evaluate Fields lazily so we don't end up in endless loop
+        Type<Models.TypeElement>("__Type")
+            .ReplaceField(
+                "fields",
+                new { includeDeprecated = false },
+                (t, p) => SchemaIntrospection.BuildFieldsForType(this, t.Name!).Where(f => p.includeDeprecated ? f.IsDeprecated || !f.IsDeprecated : !f.IsDeprecated).ToList(),
+                "Fields available on type"
+            );
+
+        Query().ReplaceField("__schema", db => SchemaIntrospection.Make(this), "Introspection of the schema").Returns("__Schema");
+        Query()
+            .ReplaceField(
+                "__type",
+                new { name = ArgumentHelper.Required<string>() },
+                (db, p) => SchemaIntrospection.Make(this).Types.Where(s => s.Name == p.name).First(),
+                "Query a type by name"
+            )
+            .Returns("__Type");
+    }
+
+    /// <summary>
+    /// Execute a query using this schema.
+    /// </summary>
+    /// <param name="gql">The GraphQL query document</param>
+    /// <param name="serviceProvider">A service provider used for looking up the context dependency and services in field selections and mutations</param>
+    /// <param name="user">Optional user/ClaimsPrincipal to check access for queries</param>
+    /// <param name="options"></param>
+    /// <returns></returns>
+    public QueryResult ExecuteRequest(QueryRequest gql, IServiceProvider serviceProvider, ClaimsPrincipal? user, ExecutionOptions? options = null)
+    {
+        return ExecuteRequestAsync(gql, serviceProvider, user, options).GetAwaiter().GetResult();
+    }
+
+    /// <summary>
+    /// Execute a query using this schema.
+    /// </summary>
+    /// <param name="gql">The GraphQL query document</param>
+    /// <param name="serviceProvider">A service provider used for looking up the context dependency and services in field selections and mutations</param>
+    /// <param name="user">Optional user/ClaimsPrincipal to check access for queries</param>
+    /// <param name="options"></param>
+    /// <returns></returns>
+    public async Task<QueryResult> ExecuteRequestAsync(QueryRequest gql, IServiceProvider serviceProvider, ClaimsPrincipal? user, ExecutionOptions? options = null)
+    {
+        return await DoExecuteRequestAsync(gql, default, serviceProvider, user, options);
+    }
+
+    /// <summary>
+    /// Execute a query using this schema.
+    /// </summary>
+    /// <param name="gql">The query</param>
+    /// <param name="context">The context object. An instance of the context the schema was build from. This is used anywhere the context is required</param>
+    /// <param name="serviceProvider">A service provider used for looking up dependencies of field selections and mutations</param>
+    /// <param name="user">Optional user/ClaimsPrincipal to check access for queries</param>
+    /// <param name="options"></param>
+    /// <typeparam name="TContextType"></typeparam>
+    /// <returns></returns>
+    public QueryResult ExecuteRequestWithContext(QueryRequest gql, TContextType context, IServiceProvider? serviceProvider, ClaimsPrincipal? user, ExecutionOptions? options = null)
+    {
+        return ExecuteRequestWithContextAsync(gql, context, serviceProvider, user, options).GetAwaiter().GetResult();
+    }
+
+    /// <summary>
+    /// Execute a query using this schema.
+    /// </summary>
+    /// <param name="gql">The query</param>
+    /// <param name="context">The context object. An instance of the context the schema was build from. This is used anywhere the context is required</param>
+    /// <param name="serviceProvider">A service provider used for looking up dependencies of field selections and mutations</param>
+    /// <param name="user">Optional user/ClaimsPrincipal to check access for queries</param>
+    /// <param name="options"></param>
+    /// <typeparam name="TContextType"></typeparam>
+    /// <returns></returns>
+    public async Task<QueryResult> ExecuteRequestWithContextAsync(
+        QueryRequest gql,
+        TContextType context,
+        IServiceProvider? serviceProvider,
+        ClaimsPrincipal? user,
+        ExecutionOptions? options = null
+    )
+    {
+        return await DoExecuteRequestAsync(gql, context, serviceProvider, user, options);
+    }
+
+    private async Task<QueryResult> DoExecuteRequestAsync(
+        QueryRequest gql,
+        TContextType? overwriteContext,
+        IServiceProvider? serviceProvider,
+        ClaimsPrincipal? user,
+        ExecutionOptions? options
+    )
+    {
+        QueryResult result;
+        try
         {
-            if (customTypeMappings.TryGetValue(dotnetType, out var typeInfo))
-                return typeInfo;
-            return null;
-        }
-
-        /// <summary>
-        /// Return the Root Query schema type. Use this to add/remove/modify fields to the root query
-        /// </summary>
-        /// <returns>Root query schema type</returns>
-        public SchemaType<TContextType> Query() => queryType;
-
-        /// <summary>
-        /// Provide a callback to update the root query schema type - add/remove/modify fields to the root query
-        /// </summary>
-        public void UpdateQuery(Action<SchemaType<TContextType>> configure) => configure(queryType);
-
-        /// <summary>
-        /// Return the Root Mutation schema type. Use this to add/remove/modify mutation fields
-        /// </summary>
-        /// <returns>Root mutation schema type</returns>
-        public MutationType Mutation() => mutationType;
-
-        /// <summary>
-        /// Provide a callback to update the root query schema type - add/remove/modify fields to the root query
-        /// </summary>
-        public void UpdateMutation(Action<MutationType> configure) => configure(mutationType);
-
-        /// <summary>
-        /// Add an Enum type to the schema
-        /// </summary>
-        /// <param name="name"></param>
-        /// <param name="type"></param>
-        /// <param name="description"></param>
-        public ISchemaType AddEnum(string name, Type type, string description)
-        {
-            var schemaType = (ISchemaType)Activator.CreateInstance(typeof(SchemaType<>).MakeGenericType(type), this, type, name, description, null, GqlTypes.Enum, null)!;
-            FinishAddingType(type, schemaType);
-            return schemaType.AddAllFields();
-        }
-
-        /// <summary>
-        /// Add an Enum type to the schema
-        /// </summary>
-        /// <param name="name"></param>
-        /// <param name="description"></param>
-        public SchemaType<TEnum> AddEnum<TEnum>(string name, string description)
-        {
-            return (SchemaType<TEnum>)AddEnum(name, typeof(TEnum), description);
-        }
-
-        /// <summary>
-        /// Add an interface type to the schema
-        /// </summary>
-        /// <param name="type"></param>
-        /// <param name="name"></param>
-        /// <param name="description"></param>
-        /// <returns></returns>
-        public ISchemaType AddInterface(Type type, string name, string? description = null)
-        {
-            var schemaType = (ISchemaType)Activator.CreateInstance(typeof(SchemaType<>).MakeGenericType(type), this, type, name, description, null, GqlTypes.Interface, null)!;
-            FinishAddingType(type, schemaType);
-            return schemaType;
-        }
-
-        /// <summary>
-        /// Add an interface type to the schema
-        /// </summary>
-        /// <param name="type"></param>
-        /// <param name="name"></param>
-        /// <param name="description"></param>
-        /// <returns></returns>
-        public ISchemaType AddInterface<TInterface>(string name, string? description = null)
-        {
-            var schemaType = new SchemaType<TInterface>(this, typeof(TInterface), name, description, null, GqlTypes.Interface);
-            FinishAddingType(typeof(TInterface), schemaType);
-            return schemaType;
-        }
-
-        /// <summary>
-        /// Add an union type to the schema
-        /// </summary>
-        /// <param name="type"></param>
-        /// <param name="name"></param>
-        /// <param name="description"></param>
-        /// <returns></returns>
-        public ISchemaType AddUnion(Type type, string name, string? description = null)
-        {
-            var schemaType = new SchemaType<object>(this, type, name, description, null, GqlTypes.Union);
-            FinishAddingType(type, schemaType);
-            return schemaType;
-        }
-
-        /// <summary>
-        /// Add an union type to the schema
-        /// </summary>
-        /// <param name="type"></param>
-        /// <param name="name"></param>
-        /// <param name="description"></param>
-        /// <returns></returns>
-        public ISchemaType AddUnion<TInterface>(string name, string? description = null)
-        {
-            var schemaType = new SchemaType<TInterface>(this, typeof(TInterface), name, description, null, GqlTypes.Union);
-            FinishAddingType(typeof(TInterface), schemaType);
-            return schemaType;
-        }
-
-        /// <summary>
-        /// Return a list of all Enum types in the schema
-        /// </summary>
-        /// <returns></returns>
-        public List<ISchemaType> GetEnumTypes()
-        {
-            return schemaTypes.Values.Where(t => t.IsEnum).ToList();
-        }
-
-        /// <summary>
-        /// Builds a GraphQL schema definition from the schema.
-        /// </summary>
-        /// <returns>String containing the schema definition</returns>
-        public string ToGraphQLSchemaString()
-        {
-            return SchemaGenerator.Make(this);
-        }
-
-        /// <summary>
-        /// Return a list of types in the schema that are not the root context Query type
-        /// </summary>
-        /// <returns></returns>
-        public IEnumerable<ISchemaType> GetNonContextTypes()
-        {
-            return schemaTypes.Values.Where(s => s.Name != queryType.Name).ToList();
-        }
-
-        /// <summary>
-        /// Return a list of all scalar types in the schema
-        /// </summary>
-        /// <returns></returns>
-        public IEnumerable<ISchemaType> GetScalarTypes()
-        {
-            return schemaTypes.Values.Where(t => t.IsScalar);
-        }
-
-        /// <summary>
-        /// Remove type TSchemaType and any field that returns that type
-        /// </summary>
-        /// <typeparam name="TSchemaType"></typeparam>
-        public void RemoveTypeAndAllFields<TSchemaType>()
-        {
-            RemoveTypeAndAllFields(typeof(TSchemaType).Name);
-        }
-
-        /// <summary>
-        /// Remove type by name and any field that returns that type
-        /// </summary>
-        /// <param name="typeName"></param>
-        public void RemoveTypeAndAllFields(string typeName)
-        {
-            foreach (var context in schemaTypes.Values)
+            options ??= new ExecutionOptions();
+            GraphQLDocument? compiledQuery = null;
+            if (options.EnablePersistedQueries)
             {
-                RemoveFieldsOfType(typeName, context);
+                var persistedQuery = (PersistedQueryExtension?)
+                    ExpressionUtil.ChangeType(gql.Extensions.GetValueOrDefault("persistedQuery"), typeof(PersistedQueryExtension), null, options);
+                if (persistedQuery != null && persistedQuery.Version != 1)
+                    throw new EntityGraphQLExecutionException("PersistedQueryNotSupported");
+
+                string? hash = persistedQuery?.Sha256Hash;
+
+                if (hash == null && gql.Query == null)
+                    throw new EntityGraphQLExecutionException("Please provide a persisted query hash or a query string");
+
+                if (hash != null)
+                {
+                    compiledQuery = queryCache.GetCompiledQueryWithHash(hash);
+                    if (compiledQuery == null && gql.Query == null)
+                        throw new EntityGraphQLExecutionException("PersistedQueryNotFound");
+                    else if (compiledQuery == null)
+                    {
+                        compiledQuery = graphQLCompiler.Compile(gql, new QueryRequestContext(AuthorizationService, user));
+                        queryCache.AddCompiledQuery(hash, compiledQuery);
+                    }
+                }
+                else if (compiledQuery == null)
+                {
+                    // if here they sent query with no hash
+                    // persisted queries will not auto cache it (only when you provide the hash) but is QueryCache is enabled we will cache it
+                    if (options.EnableQueryCache)
+                        compiledQuery = CompileQueryWithCache(gql, options, user);
+                    else
+                        compiledQuery = graphQLCompiler.Compile(gql, new QueryRequestContext(AuthorizationService, user));
+                }
             }
-            schemaTypes.Remove(typeName);
+            else if (options.EnableQueryCache)
+            {
+                compiledQuery = CompileQueryWithCache(gql, options, user);
+            }
+            else
+            {
+                // no cache
+                if (gql.Query == null)
+                {
+                    string? hash = (
+                        (PersistedQueryExtension?)ExpressionUtil.ChangeType(gql.Extensions.GetValueOrDefault("persistedQuery"), typeof(PersistedQueryExtension), null, options)
+                    )?.Sha256Hash;
+                    if (hash != null)
+                        throw new EntityGraphQLExecutionException("PersistedQueryNotSupported");
+
+                    throw new EntityGraphQLException("Query field must be set unless you are using persisted queries");
+                }
+
+                compiledQuery = graphQLCompiler.Compile(gql, new QueryRequestContext(AuthorizationService, user));
+            }
+
+            result = await compiledQuery.ExecuteQueryAsync(overwriteContext, serviceProvider, gql.Variables, gql.OperationName, options);
+        }
+        catch (Exception ex)
+        {
+            result = HandleException(ex);
         }
 
-        private static void RemoveFieldsOfType(string schemaType, ISchemaType contextType)
+        return result;
+    }
+
+    private QueryResult HandleException(Exception exception)
+    {
+        if (logger != null)
+            logErrorMessage(logger, exception);
+
+        var result = new QueryResult();
+        foreach (var (errorMessage, extensions) in GenerateMessage(exception).Distinct())
+            result.AddError(errorMessage, extensions);
+        return result;
+    }
+
+    private IEnumerable<(string errorMessage, IDictionary<string, object>? extensions)> GenerateMessage(Exception exception)
+    {
+        switch (exception)
         {
-            foreach (var field in contextType.GetFields())
+            case EntityGraphQLValidationException validationException:
+                return validationException.ValidationErrors.Select(v => (v, (IDictionary<string, object>?)null));
+            case AggregateException aggregateException:
+                return aggregateException.InnerExceptions.SelectMany(GenerateMessage);
+            case EntityGraphQLException graphqlException:
+                return new[] { (graphqlException.Message, (IDictionary<string, object>?)graphqlException.Extensions) };
+            case TargetInvocationException targetInvocationException:
+                return GenerateMessage(targetInvocationException.InnerException!);
+            case EntityGraphQLFieldException fieldException:
+                return GenerateMessage(fieldException.InnerException!).Select(f => ($"Field '{fieldException.FieldName}' - {f.errorMessage}", f.extensions));
+            default:
+                if (isDevelopment || AllowedExceptions.Any(e => e.IsAllowed(exception)) || exception.GetType().GetCustomAttribute<AllowedExceptionAttribute>() != null)
+                    return new[] { (exception.Message, (IDictionary<string, object>?)null) };
+                return new[] { ("Error occurred", (IDictionary<string, object>?)null) };
+        }
+    }
+
+    private GraphQLDocument CompileQueryWithCache(QueryRequest gql, ExecutionOptions executionOptions, ClaimsPrincipal? user)
+    {
+        GraphQLDocument? compiledQuery;
+        // try to get the compiled query from the cache
+        // cache the result
+        if (gql.Query == null)
+        {
+            string? phash = (
+                (PersistedQueryExtension?)ExpressionUtil.ChangeType(gql.Extensions.GetValueOrDefault("persistedQuery"), typeof(PersistedQueryExtension), null, executionOptions)
+            )?.Sha256Hash;
+            if (phash != null)
+                throw new EntityGraphQLExecutionException("PersistedQueryNotSupported");
+            throw new EntityGraphQLException("Query field must be set unless you are using persisted queries");
+        }
+
+        (compiledQuery, var hash) = queryCache.GetCompiledQuery(gql.Query, null);
+        if (compiledQuery == null)
+        {
+            compiledQuery = graphQLCompiler.Compile(gql, new QueryRequestContext(AuthorizationService, user));
+            queryCache.AddCompiledQuery(hash, compiledQuery);
+        }
+
+        return compiledQuery;
+    }
+
+    /// <summary>
+    /// Add a new Object type into the schema with TBaseType as its context.
+    /// </summary>
+    /// <param name="name">Name of the type</param>
+    /// <param name="description">description of the type</param>
+    /// <typeparam name="TBaseType"></typeparam>
+    /// <returns>The added type for further changes via chaining</returns>
+    public SchemaType<TBaseType> AddType<TBaseType>(string name, string? description)
+    {
+        var gqlType =
+            typeof(TBaseType).IsAbstract || typeof(TBaseType).IsInterface
+                ? GqlTypes.Interface
+                : typeof(TBaseType).IsEnum
+                    ? GqlTypes.Enum
+                    : GqlTypes.QueryObject;
+        var schemaType = new SchemaType<TBaseType>(this, name, description, null, gqlType);
+        FinishAddingType(typeof(TBaseType), schemaType);
+        return schemaType;
+    }
+
+    /// <summary>
+    /// Add a new Object type into the schema with contextType as its context
+    /// </summary>
+    /// <param name="contextType"></param>
+    /// <param name="name">Name of the type</param>
+    /// <param name="description">description of the type</param>
+    /// <returns>The added type for further changes via chaining</returns>
+    public ISchemaType AddType(Type contextType, string name, string? description = null)
+    {
+        var gqlType = contextType.IsAbstract || contextType.IsInterface ? GqlTypes.Interface : GqlTypes.QueryObject;
+        var newType = (ISchemaType)Activator.CreateInstance(typeof(SchemaType<>).MakeGenericType(contextType), this, contextType, name, description, null, gqlType, null)!;
+        FinishAddingType(contextType, newType);
+        return newType;
+    }
+
+    /// <summary>
+    /// Add a new Object type into the schema with TBaseType as its context
+    /// </summary>
+    /// <typeparam name="TBaseType"></typeparam>
+    /// <param name="name">Name of the type</param>
+    /// <param name="description">description of the type</param>
+    /// <param name="updateFunc">Callback called with the schema type where you can further update the type</param>
+    public SchemaType<TBaseType> AddType<TBaseType>(string name, string description, Action<SchemaType<TBaseType>> updateFunc)
+    {
+        var type = AddType<TBaseType>(name, description);
+        updateFunc(type);
+        return type;
+    }
+
+    /// <summary>
+    /// Adds a new Object type into the schema. The name defaults to the TBaseType name
+    /// </summary>
+    /// <param name="description">description of the type</param>
+    /// <typeparam name="TBaseType"></typeparam>
+    /// <returns>The added type for further changes via chaining</returns>
+    public SchemaType<TBaseType> AddType<TBaseType>(string description)
+    {
+        var name = SchemaBuilder.BuildTypeName(typeof(TBaseType));
+        return AddType<TBaseType>(name, description);
+    }
+
+    public ISchemaType AddType(ISchemaType schemaType)
+    {
+        FinishAddingType(schemaType.TypeDotnet, schemaType);
+        return schemaType;
+    }
+
+    private void FinishAddingType(Type contextType, ISchemaType tt)
+    {
+        tt.RequiredAuthorization = AuthorizationService.GetRequiredAuthFromType(contextType);
+        if (string.IsNullOrEmpty(tt.Description))
+        {
+            tt.Description = contextType.GetCustomAttribute<DescriptionAttribute>()?.Description;
+        }
+        schemaTypes.Add(tt.Name, tt);
+    }
+
+    /// <summary>
+    /// Remove TType from the schema
+    /// </summary>
+    /// <typeparam name="TType"></typeparam>
+    /// <returns>The SchemaProvider</returns>
+    public ISchemaProvider RemoveType<TType>()
+    {
+        return RemoveType(GetSchemaType(typeof(TType), false, null).Name);
+    }
+
+    /// <summary>
+    /// Remove TType from the schema
+    /// </summary>
+    /// <param name="schemaType"></param>
+    /// <returns>The SchemaProvider</returns>
+    public ISchemaProvider RemoveType(string schemaType)
+    {
+        schemaTypes.Remove(schemaType);
+        return this;
+    }
+
+    /// <summary>
+    /// Add a GraphQL Input Object type to the schema. Input types are objects used in arguments of fields or mutations
+    /// </summary>
+    /// <param name="name">Name of the type. Used as passed. Case sensitive</param>
+    /// <param name="description">Description of the input type</param>
+    /// <typeparam name="TBaseType"></typeparam>
+    /// <returns>The added type for further changes via chaining</returns>
+    public SchemaType<TBaseType> AddInputType<TBaseType>(string name, string? description = null)
+    {
+        return (SchemaType<TBaseType>)AddInputType(typeof(TBaseType), name, description);
+    }
+
+    /// <summary>
+    /// Add a GraphQL Input Object type to the schema. Input types are objects used in arguments of fields or mutations
+    /// </summary>
+    /// <param name="name">Name of the type. Used as passed. Case sensitive</param>
+    /// <param name="description">Description of the input type</param>
+    /// <returns>The added type for further changes via chaining</returns>
+    public ISchemaType AddInputType(Type type, string name, string? description = null)
+    {
+        var newType = (ISchemaType)Activator.CreateInstance(typeof(SchemaType<>).MakeGenericType(type), this, type, name, description, null, GqlTypes.InputObject, null)!;
+        FinishAddingType(type, newType);
+
+        return newType;
+    }
+
+    /// <summary>
+    /// Adds a new scalar type defined to the schema. Dotnet types of clrType will be treated as gqlTypeName
+    /// </summary>
+    /// <param name="clrType">Dotnet type to mapp to a scalar</param>
+    /// <param name="gqlTypeName">GraphQL scalar type name</param>
+    /// <param name="description">Description of the scalar type</param>
+    /// <returns>The added type for further changes via chaining</returns>
+    public ISchemaType AddScalarType(Type clrType, string gqlTypeName, string? description = null)
+    {
+        var schemaType = (ISchemaType)Activator.CreateInstance(typeof(SchemaType<>).MakeGenericType(clrType), this, gqlTypeName, description, null, GqlTypes.Scalar, null)!;
+        schemaTypes.Add(gqlTypeName, schemaType);
+        return schemaType;
+    }
+
+    /// <summary>
+    /// Adds a new scalar type defined to the schema. Dotnet types of TType will be treated as gqlTypeName
+    /// </summary>
+    /// <param name="clrType">Dotnet type to mapp to a scalar</param>
+    /// <param name="gqlTypeName">GraphQL scalar type name</param>
+    /// <param name="description">Description of the scalar type</param>
+    /// <returns>The added type for further changes via chaining</returns>
+    public SchemaType<TType> AddScalarType<TType>(string gqlTypeName, string? description = null)
+    {
+        var schemaType = new SchemaType<TType>(this, gqlTypeName, description, null, GqlTypes.Scalar);
+        schemaTypes.Add(gqlTypeName, schemaType);
+        return schemaType;
+    }
+
+    /// <summary>
+    /// Add any methods marked with GraphQLMutationAttribute in the given object to the schema. Method names are added as using fieldNamer
+    /// </summary>
+    /// <typeparam name="TType"></typeparam>
+    /// <param name="options">Options for the schema builder</param>
+    public void AddMutationsFrom<TType>(SchemaBuilderOptions? options = null)
+        where TType : class
+    {
+        mutationType.AddFrom<TType>(options);
+    }
+
+    /// <summary>
+    /// Search for a GraphQL type with the given name. Lookup is only done by name.
+    ///
+    /// Customer type mappings are not searched
+    ///
+    /// Use the Type<T>() methods for returning typed SchemaType<T>
+    /// </summary>
+    /// <param name="typeName"></param>
+    /// <returns>An ISchemaType if the type is found in the schema</returns>
+    /// <exception cref="EntityGraphQLCompilerException">If type name not found</exception>
+    public ISchemaType GetSchemaType(string typeName, QueryRequestContext? requestContext)
+    {
+        if (schemaTypes.TryGetValue(typeName, out var schemaType))
+            return SchemaProvider<TContextType>.CheckTypeAccess(schemaType, requestContext);
+
+        throw new EntityGraphQLCompilerException($"Type {typeName} not found in schema");
+    }
+
+    public ISchemaType GetSchemaType(Type dotnetType, QueryRequestContext? requestContext)
+    {
+        return GetSchemaType(dotnetType, false, requestContext);
+    }
+
+    /// <summary>
+    /// Search for a GraphQL type with the given name. Lookup is done by DotNet type first.
+    /// Then by the type name. Then the customTypeMappings are searched
+    ///
+    /// Use the Type<T>() methods for returning typed SchemaType<T>
+    /// </summary>
+    /// <param name="dotnetType"></param>
+    /// <param name="typeFilter">Used the filter the search as dotnet type may be shared across Input type and query
+    /// type with different names in the schema</param>
+    /// <returns></returns>
+    /// <exception cref="EntityGraphQLCompilerException"></exception>
+    public ISchemaType GetSchemaType(Type dotnetType, bool inputTypeScope, QueryRequestContext? requestContext)
+    {
+        if (TryGetSchemaType(dotnetType, inputTypeScope, out var schemaType, requestContext))
+            return schemaType!;
+        throw new EntityGraphQLCompilerException($"No schema type found for dotnet type '{dotnetType.Name}'. Make sure you add it or add a type mapping.");
+    }
+
+    public bool TryGetSchemaType(Type dotnetType, bool inputTypeScope, out ISchemaType? schemaType, QueryRequestContext? requestContext)
+    {
+        // look up by the actual type not the name
+        schemaType =
+            schemaTypes
+                .Values.WhereWhen(t => t.GqlType == GqlTypes.Scalar || t.GqlType == GqlTypes.Enum || t.GqlType == GqlTypes.InputObject, inputTypeScope)
+                .FirstOrDefault(t => t.TypeDotnet == dotnetType) ?? schemaTypes.GetValueOrDefault(dotnetType.Name);
+        if (inputTypeScope && schemaType?.GqlType.IsNotValidForInput() == true)
+        {
+            // chance the Type has an input type that inherits from it
+            schemaType = schemaTypes.Values.Where(t => dotnetType.IsAssignableFrom(t.TypeDotnet) && t.GqlType == GqlTypes.InputObject).FirstOrDefault();
+        }
+
+        if (schemaType == null && customTypeMappings.TryGetValue(dotnetType, out var typeInfo))
+        {
+            schemaType = typeInfo.SchemaType;
+        }
+        if (schemaType == null)
+            return false;
+        schemaType = SchemaProvider<TContextType>.CheckTypeAccess(schemaType, requestContext);
+        return true;
+    }
+
+    private static ISchemaType CheckTypeAccess(ISchemaType schemaType, QueryRequestContext? requestContext)
+    {
+        if (requestContext == null)
+            return schemaType;
+
+        if (requestContext.AuthorizationService != null && !requestContext.AuthorizationService.IsAuthorized(requestContext.User, schemaType.RequiredAuthorization))
+            throw new EntityGraphQLAccessException($"You are not authorized to access the '{schemaType.Name}' type.");
+
+        return schemaType;
+    }
+
+    /// <summary>
+    /// Get registered type by TType name
+    /// </summary>
+    /// <typeparam name="TType"></typeparam>
+    /// <returns>The typed SchemaType<TType> object for configuration</returns>
+    public SchemaType<TType> Type<TType>()
+    {
+        return (SchemaType<TType>)GetSchemaType(typeof(TType), false, null);
+    }
+
+    /// <summary>
+    /// Get registered type by schema type name
+    /// </summary>
+    /// <typeparam name="TType"></typeparam>
+    /// <param name="typeName"></param>
+    /// <returns>The typed SchemaType<TType> object for configuration</returns>
+    public SchemaType<TType> Type<TType>(string typeName)
+    {
+        return (SchemaType<TType>)GetSchemaType(typeName, null);
+    }
+
+    /// <summary>
+    /// Search for a GraphQL type with the given name. Lookup is only done by name.
+    ///
+    /// Customer type mappings are not searched
+    ///
+    /// Use the Type<T>() methods for returning typed SchemaType<T>
+    /// </summary>
+    /// <param name="typeName"></param>
+    /// <returns>An ISchemaType if the type is found in the schema</returns>
+    /// <exception cref="EntityGraphQLCompilerException">If type name not found</exception>
+    public ISchemaType Type(string typeName)
+    {
+        return GetSchemaType(typeName, null);
+    }
+
+    public ISchemaType Type(Type type)
+    {
+        return GetSchemaType(type, false, null);
+    }
+
+    public SchemaType<TType> Type<TType>(Type type)
+    {
+        return (SchemaType<TType>)GetSchemaType(type, false, null);
+    }
+
+    /// <summary>
+    /// Find a schema type for TType and update the type with the configure callback
+    /// </summary>
+    /// <typeparam name="TType"></typeparam>
+    /// <param name="configure"></param>
+    public void UpdateType<TType>(Action<SchemaType<TType>> configure) => configure(Type<TType>());
+
+    /// <summary>
+    /// Returns true if the schema has a type by name defined
+    /// </summary>
+    /// <param name="typeName"></param>
+    /// <returns>True if found. False if not</returns>
+    public bool HasType(string typeName)
+    {
+        if (typeName == QueryContextName)
+            return true;
+
+        foreach (var schemaType in schemaTypes.Values)
+        {
+            if (schemaType.Name == typeName)
+                return true;
+        }
+        foreach (var mappingType in customTypeMappings.Keys)
+        {
+            if (mappingType.Name == typeName)
+                return true;
+        }
+        return false;
+    }
+
+    /// <summary>
+    /// Returns true if the schema has a type that has the given dotnet type as its base context
+    /// </summary>
+    /// <param name="type"></param>
+    /// <returns>True if found. False if not</returns>
+    public bool HasType(Type type)
+    {
+        if (type == queryType.TypeDotnet)
+            return true;
+
+        foreach (var schemaType in schemaTypes.Values)
+        {
+            if (schemaType.TypeDotnet == type)
+                return true;
+        }
+        return customTypeMappings.ContainsKey(type);
+    }
+
+    /// <summary>
+    /// Add a mapping from a Dotnet type to a GraphQL schema type name. Make sure you have added the GraphQL type
+    /// in the schema as a Scalar type or full type
+    ///
+    /// E.g. schema.AddTypeMapping<NpgsqlPolygon>("[Point!]!");
+    /// </summary>
+    /// <param name="gqlType">The GraphQL schema type in full form. E.g. [Int!]!, [Int], Int, etc.</param>
+    /// <typeparam name="TFromType"></typeparam>
+    public void AddTypeMapping<TFromType>(string gqlType)
+    {
+        var typeInfo = GqlTypeInfo.FromGqlType(this, typeof(TFromType), gqlType);
+        // add mapping
+        customTypeMappings.Add(typeof(TFromType), typeInfo);
+        SetupIntrospectionTypesAndField();
+    }
+
+    /// <summary>
+    /// Get the GqlTypeInfo for a custom type mapping of dotnetType.
+    /// Returns null if there is no mapping
+    /// </summary>
+    /// <param name="dotnetType"></param>
+    /// <returns></returns>
+    public GqlTypeInfo? GetCustomTypeMapping(Type dotnetType)
+    {
+        if (customTypeMappings.TryGetValue(dotnetType, out var typeInfo))
+            return typeInfo;
+        return null;
+    }
+
+    /// <summary>
+    /// Return the Root Query schema type. Use this to add/remove/modify fields to the root query
+    /// </summary>
+    /// <returns>Root query schema type</returns>
+    public SchemaType<TContextType> Query() => queryType;
+
+    /// <summary>
+    /// Provide a callback to update the root query schema type - add/remove/modify fields to the root query
+    /// </summary>
+    public void UpdateQuery(Action<SchemaType<TContextType>> configure) => configure(queryType);
+
+    /// <summary>
+    /// Return the Root Mutation schema type. Use this to add/remove/modify mutation fields
+    /// </summary>
+    /// <returns>Root mutation schema type</returns>
+    public MutationType Mutation() => mutationType;
+
+    /// <summary>
+    /// Provide a callback to update the root query schema type - add/remove/modify fields to the root query
+    /// </summary>
+    public void UpdateMutation(Action<MutationType> configure) => configure(mutationType);
+
+    /// <summary>
+    /// Add an Enum type to the schema
+    /// </summary>
+    /// <param name="name"></param>
+    /// <param name="type"></param>
+    /// <param name="description"></param>
+    public ISchemaType AddEnum(string name, Type type, string description)
+    {
+        var schemaType = (ISchemaType)Activator.CreateInstance(typeof(SchemaType<>).MakeGenericType(type), this, type, name, description, null, GqlTypes.Enum, null)!;
+        FinishAddingType(type, schemaType);
+        return schemaType.AddAllFields();
+    }
+
+    /// <summary>
+    /// Add an Enum type to the schema
+    /// </summary>
+    /// <param name="name"></param>
+    /// <param name="description"></param>
+    public SchemaType<TEnum> AddEnum<TEnum>(string name, string description)
+    {
+        return (SchemaType<TEnum>)AddEnum(name, typeof(TEnum), description);
+    }
+
+    /// <summary>
+    /// Add an interface type to the schema
+    /// </summary>
+    /// <param name="type"></param>
+    /// <param name="name"></param>
+    /// <param name="description"></param>
+    /// <returns></returns>
+    public ISchemaType AddInterface(Type type, string name, string? description = null)
+    {
+        var schemaType = (ISchemaType)Activator.CreateInstance(typeof(SchemaType<>).MakeGenericType(type), this, type, name, description, null, GqlTypes.Interface, null)!;
+        FinishAddingType(type, schemaType);
+        return schemaType;
+    }
+
+    /// <summary>
+    /// Add an interface type to the schema
+    /// </summary>
+    /// <param name="type"></param>
+    /// <param name="name"></param>
+    /// <param name="description"></param>
+    /// <returns></returns>
+    public ISchemaType AddInterface<TInterface>(string name, string? description = null)
+    {
+        var schemaType = new SchemaType<TInterface>(this, typeof(TInterface), name, description, null, GqlTypes.Interface);
+        FinishAddingType(typeof(TInterface), schemaType);
+        return schemaType;
+    }
+
+    /// <summary>
+    /// Add an union type to the schema
+    /// </summary>
+    /// <param name="type"></param>
+    /// <param name="name"></param>
+    /// <param name="description"></param>
+    /// <returns></returns>
+    public ISchemaType AddUnion(Type type, string name, string? description = null)
+    {
+        var schemaType = new SchemaType<object>(this, type, name, description, null, GqlTypes.Union);
+        FinishAddingType(type, schemaType);
+        return schemaType;
+    }
+
+    /// <summary>
+    /// Add an union type to the schema
+    /// </summary>
+    /// <param name="type"></param>
+    /// <param name="name"></param>
+    /// <param name="description"></param>
+    /// <returns></returns>
+    public ISchemaType AddUnion<TInterface>(string name, string? description = null)
+    {
+        var schemaType = new SchemaType<TInterface>(this, typeof(TInterface), name, description, null, GqlTypes.Union);
+        FinishAddingType(typeof(TInterface), schemaType);
+        return schemaType;
+    }
+
+    /// <summary>
+    /// Return a list of all Enum types in the schema
+    /// </summary>
+    /// <returns></returns>
+    public List<ISchemaType> GetEnumTypes()
+    {
+        return schemaTypes.Values.Where(t => t.IsEnum).ToList();
+    }
+
+    /// <summary>
+    /// Builds a GraphQL schema definition from the schema.
+    /// </summary>
+    /// <returns>String containing the schema definition</returns>
+    public string ToGraphQLSchemaString()
+    {
+        return SchemaGenerator.Make(this);
+    }
+
+    /// <summary>
+    /// Return a list of types in the schema that are not the root context Query type
+    /// </summary>
+    /// <returns></returns>
+    public IEnumerable<ISchemaType> GetNonContextTypes()
+    {
+        return schemaTypes.Values.Where(s => s.Name != queryType.Name).ToList();
+    }
+
+    /// <summary>
+    /// Return a list of all scalar types in the schema
+    /// </summary>
+    /// <returns></returns>
+    public IEnumerable<ISchemaType> GetScalarTypes()
+    {
+        return schemaTypes.Values.Where(t => t.IsScalar);
+    }
+
+    /// <summary>
+    /// Remove type TSchemaType and any field that returns that type
+    /// </summary>
+    /// <typeparam name="TSchemaType"></typeparam>
+    public void RemoveTypeAndAllFields<TSchemaType>()
+    {
+        RemoveTypeAndAllFields(typeof(TSchemaType).Name);
+    }
+
+    /// <summary>
+    /// Remove type by name and any field that returns that type
+    /// </summary>
+    /// <param name="typeName"></param>
+    public void RemoveTypeAndAllFields(string typeName)
+    {
+        foreach (var context in schemaTypes.Values)
+        {
+            RemoveFieldsOfType(typeName, context);
+        }
+        schemaTypes.Remove(typeName);
+    }
+
+    private static void RemoveFieldsOfType(string schemaType, ISchemaType contextType)
+    {
+        foreach (var field in contextType.GetFields())
+        {
+            try
+            {
+                if (field.ReturnType.SchemaType.Name == schemaType)
+                {
+                    contextType.RemoveField(field.Name);
+                }
+            }
+            catch (EntityGraphQLCompilerException)
+            {
+                // SchemaType looks up the type in the schema. And there is a chance that type is not in there
+                // either not added or removed previously
+            }
+        }
+    }
+
+    /// <summary>
+    /// Search for a directive by name. Throws exception if not found
+    /// </summary>
+    /// <param name="name"></param>
+    /// <returns></returns>
+    /// <exception cref="EntityGraphQLCompilerException"></exception>
+    public IDirectiveProcessor GetDirective(string name)
+    {
+        if (directives.TryGetValue(name, out var directive))
+            return directive;
+        throw new EntityGraphQLCompilerException($"Directive {name} not defined in schema");
+    }
+
+    /// <summary>
+    /// Return a list of directives in the schema
+    /// </summary>
+    /// <returns></returns>
+    public IEnumerable<IDirectiveProcessor> GetDirectives()
+    {
+        return directives.Values.ToList();
+    }
+
+    /// <summary>
+    /// Add a directive to the schema
+    /// </summary>
+    /// <param name="directive"></param>
+    /// <exception cref="EntityGraphQLCompilerException"></exception>
+    public void AddDirective(IDirectiveProcessor directive)
+    {
+        if (directives.ContainsKey(directive.Name))
+            throw new EntityGraphQLCompilerException($"Directive {directive.Name} already exists on schema");
+        directives.Add(directive.Name, directive);
+    }
+
+    /// <summary>
+    /// Build the Query schema by reflection on the context type. Same as SchemaBuilder.FromObject<T>()
+    /// </summary>
+    /// <param name="options"></param>
+    public void PopulateFromContext(SchemaBuilderOptions? options = null)
+    {
+        options ??= new SchemaBuilderOptions();
+        SchemaBuilder.FromObject(this, options);
+    }
+
+    /// <summary>
+    /// Return the Root Subscription schema type. Use this to add/remove/modify subscription fields
+    /// </summary>
+    /// <returns>Root subscription schema type</returns>
+    public SubscriptionType Subscription() => subscriptionType;
+
+    public IExtensionAttributeHandler? GetAttributeHandlerFor(Type attributeType)
+    {
+        if (attributeHandlers.TryGetValue(attributeType, out var handler))
+            return handler;
+        return null;
+    }
+
+    public ISchemaProvider AddAttributeHandler(IExtensionAttributeHandler handler)
+    {
+        foreach (var type in handler.AttributeTypes)
+        {
+            attributeHandlers.Add(type, handler);
+        }
+        return this;
+    }
+
+    public void Dispose()
+    {
+        GC.SuppressFinalize(this);
+        queryCache.Dispose();
+    }
+
+    public void Validate()
+    {
+        // Check all return types to make sure they are in the schema
+        foreach (var schemaType in schemaTypes.Values)
+        {
+            foreach (var field in schemaType.GetFields())
             {
                 try
                 {
-                    if (field.ReturnType.SchemaType.Name == schemaType)
-                    {
-                        contextType.RemoveField(field.Name);
-                    }
+                    // schema type will throw if if can't look it up
+                    var _ = field.ReturnType.SchemaType;
                 }
                 catch (EntityGraphQLCompilerException)
                 {
-                    // SchemaType looks up the type in the schema. And there is a chance that type is not in there
-                    // either not added or removed previously
-                }
-            }
-        }
-
-        /// <summary>
-        /// Search for a directive by name. Throws exception if not found
-        /// </summary>
-        /// <param name="name"></param>
-        /// <returns></returns>
-        /// <exception cref="EntityGraphQLCompilerException"></exception>
-        public IDirectiveProcessor GetDirective(string name)
-        {
-            if (directives.TryGetValue(name, out var directive))
-                return directive;
-            throw new EntityGraphQLCompilerException($"Directive {name} not defined in schema");
-        }
-
-        /// <summary>
-        /// Return a list of directives in the schema
-        /// </summary>
-        /// <returns></returns>
-        public IEnumerable<IDirectiveProcessor> GetDirectives()
-        {
-            return directives.Values.ToList();
-        }
-
-        /// <summary>
-        /// Add a directive to the schema
-        /// </summary>
-        /// <param name="directive"></param>
-        /// <exception cref="EntityGraphQLCompilerException"></exception>
-        public void AddDirective(IDirectiveProcessor directive)
-        {
-            if (directives.ContainsKey(directive.Name))
-                throw new EntityGraphQLCompilerException($"Directive {directive.Name} already exists on schema");
-            directives.Add(directive.Name, directive);
-        }
-
-        /// <summary>
-        /// Build the Query schema by reflection on the context type. Same as SchemaBuilder.FromObject<T>()
-        /// </summary>
-        /// <param name="options"></param>
-        public void PopulateFromContext(SchemaBuilderOptions? options = null)
-        {
-            options ??= new SchemaBuilderOptions();
-            SchemaBuilder.FromObject(this, options);
-        }
-
-        /// <summary>
-        /// Return the Root Subscription schema type. Use this to add/remove/modify subscription fields
-        /// </summary>
-        /// <returns>Root subscription schema type</returns>
-        public SubscriptionType Subscription() => subscriptionType;
-
-        public IExtensionAttributeHandler? GetAttributeHandlerFor(Type attributeType)
-        {
-            if (attributeHandlers.TryGetValue(attributeType, out var handler))
-                return handler;
-            return null;
-        }
-
-        public ISchemaProvider AddAttributeHandler(IExtensionAttributeHandler handler)
-        {
-            foreach (var type in handler.AttributeTypes)
-            {
-                attributeHandlers.Add(type, handler);
-            }
-            return this;
-        }
-
-        public void Dispose()
-        {
-            GC.SuppressFinalize(this);
-            queryCache.Dispose();
-        }
-
-        public void Validate()
-        {
-            // Check all return types to make sure they are in the schema
-            foreach (var schemaType in schemaTypes.Values)
-            {
-                foreach (var field in schemaType.GetFields())
-                {
-                    try
-                    {
-                        // schema type will throw if if can't look it up
-                        var _ = field.ReturnType.SchemaType;
-                    }
-                    catch (EntityGraphQLCompilerException)
-                    {
-                        throw new EntityGraphQLCompilerException(
-                            $"Field '{field.Name}' on type '{schemaType.Name}' returns type '{(field.ReturnType.TypeDotnet.IsEnumerableOrArray() ? field.ReturnType.TypeDotnet.GetEnumerableOrArrayType() : field.ReturnType.TypeDotnet)}' that is not in the schema"
-                        );
-                    }
+                    throw new EntityGraphQLCompilerException(
+                        $"Field '{field.Name}' on type '{schemaType.Name}' returns type '{(field.ReturnType.TypeDotnet.IsEnumerableOrArray() ? field.ReturnType.TypeDotnet.GetEnumerableOrArrayType() : field.ReturnType.TypeDotnet)}' that is not in the schema"
+                    );
                 }
             }
         }

--- a/src/EntityGraphQL/Subscriptions/Broadcaster.cs
+++ b/src/EntityGraphQL/Subscriptions/Broadcaster.cs
@@ -48,7 +48,10 @@ public class Broadcaster<TType> : IObservable<TType>, IDisposable
 
     public virtual void Unsubscribe(IObserver<TType> observer)
     {
-        Subscribers.Remove(observer);
+        lock (Subscribers)
+        {
+            Subscribers.Remove(observer);
+        }
         OnUnsubscribe?.Invoke(observer);
     }
 

--- a/src/EntityGraphQL/Subscriptions/Broadcaster.cs
+++ b/src/EntityGraphQL/Subscriptions/Broadcaster.cs
@@ -1,82 +1,83 @@
 using System;
 using System.Collections.Generic;
 
-namespace EntityGraphQL.Subscriptions
+namespace EntityGraphQL.Subscriptions;
+
+/// <summary>
+/// A simple class to broadcast messages to all subscribers.
+///
+/// Usage:
+/// public class ChatService
+/// {
+///     private readonly Broadcaster<Message> broadcaster = new();
+///
+///     public void PostMessage(string message, string user)
+///     {
+///         // ... do your logic
+///         // broadcast the new message/event to all subscribers
+///         broadcaster.OnNext(msg);
+///     }
+///     // return the broadcaster as an IObservable<>
+///     public IObservable<Message> Subscribe()
+///     {
+///         return broadcaster;
+///     }
+/// }
+///
+/// Note if your events are triggered from multiple services/servers you may want to implement different a broadcaster to handle those
+/// events (likely from some queue or service bus) to then pass them to the websocket subscriptions. Or you could use this class and
+/// have a service wrap it that is listening to the queue or service bus.
+/// </summary>
+/// <typeparam name="TType"></typeparam>
+public class Broadcaster<TType> : IObservable<TType>, IDisposable
 {
+    public List<IObserver<TType>> Subscribers { get; } = [];
+
+    public Action<IObserver<TType>>? OnUnsubscribe { get; set; }
+
     /// <summary>
-    /// A simple class to broadcast messages to all subscribers.
-    /// 
-    /// Usage:
-    /// public class ChatService
-    /// {
-    ///     private readonly Broadcaster<Message> broadcaster = new();
-    ///     
-    ///     public void PostMessage(string message, string user)
-    ///     {
-    ///         // ... do your logic
-    ///         // broadcast the new message/event to all subscribers
-    ///         broadcaster.OnNext(msg);
-    ///     }
-    ///     // return the broadcaster as an IObservable<>
-    ///     public IObservable<Message> Subscribe()
-    ///     {
-    ///         return broadcaster;
-    ///     }
-    /// }
-    /// 
-    /// Note if your events are triggered from multiple services/servers you may want to implement different a broadcaster to handle those
-    /// events (likely from some queue or service bus) to then pass them to the websocket subscriptions. Or you could use this class and 
-    /// have a service wrap it that is listening to the queue or service bus.
+    /// Register an observer to the broadcaster.
     /// </summary>
-    /// <typeparam name="TType"></typeparam>
-    public class Broadcaster<TType> : IObservable<TType>, IDisposable
+    /// <param name="observer"></param>
+    /// <returns></returns>
+    public virtual IDisposable Subscribe(IObserver<TType> observer)
     {
-        private readonly List<IObserver<TType>> subscribers = new();
+        Subscribers.Add(observer);
+        return new GraphQLSubscription<TType>(this, observer);
+    }
 
-        public Action<IObserver<TType>>? OnUnsubscribe { get; set; }
+    public virtual void Unsubscribe(IObserver<TType> observer)
+    {
+        Subscribers.Remove(observer);
+        OnUnsubscribe?.Invoke(observer);
+    }
 
-        /// <summary>
-        /// Register an observer to the broadcaster.
-        /// </summary>
-        /// <param name="observer"></param>
-        /// <returns></returns>
-        public IDisposable Subscribe(IObserver<TType> observer)
+    /// <summary>
+    /// Broadcast the message to all subscribers.
+    /// </summary>
+    /// <param name="value"></param>
+    public virtual void OnNext(TType value)
+    {
+        foreach (var observer in Subscribers)
         {
-            subscribers.Add(observer);
-            return new GraphQLSubscription<TType>(this, observer);
+            observer.OnNext(value);
         }
+    }
 
-        public void Unsubscribe(IObserver<TType> observer)
+    public virtual void OnError(Exception ex)
+    {
+        foreach (var observer in Subscribers)
         {
-            subscribers.Remove(observer);
-            OnUnsubscribe?.Invoke(observer);
+            observer.OnError(ex);
         }
-        /// <summary>
-        /// Broadcast the message to all subscribers.
-        /// </summary>
-        /// <param name="value"></param>
-        public void OnNext(TType value)
-        {
-            foreach (var observer in subscribers)
-            {
-                observer.OnNext(value);
-            }
-        }
-        public void OnError(Exception ex)
-        {
-            foreach (var observer in subscribers)
-            {
-                observer.OnError(ex);
-            }
-        }
+    }
 
-        public void Dispose()
+    public virtual void Dispose()
+    {
+        GC.SuppressFinalize(this);
+        foreach (var observer in Subscribers)
         {
-            GC.SuppressFinalize(this);
-            foreach (var observer in subscribers)
-            {
-                observer.OnCompleted();
-            }
+            observer.OnCompleted();
         }
     }
 }

--- a/src/EntityGraphQL/Subscriptions/GraphQLSubscription.cs
+++ b/src/EntityGraphQL/Subscriptions/GraphQLSubscription.cs
@@ -1,43 +1,20 @@
 using System;
 
-namespace EntityGraphQL.Subscriptions
+namespace EntityGraphQL.Subscriptions;
+
+/// <summary>
+/// Used as the return type of Broadcaster.Subscribe.
+/// Holds the broadcaster and the observer to correctly unsubscribe if this subscription is disposed of.
+/// </summary>
+/// <typeparam name="TType"></typeparam>
+public class GraphQLSubscription<TType>(Broadcaster<TType> broadcaster, IObserver<TType> observer) : IDisposable
 {
-    /// <summary>
-    /// Represents a GraphQL subscription.
-    /// </summary>
-    public interface IGraphQLSubscription : IDisposable
+    private readonly Broadcaster<TType> broadcaster = broadcaster;
+    private readonly IObserver<TType> observer = observer;
+
+    public void Dispose()
     {
-        Action? OnCompleted { get; set; }
-        Action<Exception>? OnError { get; set; }
-        Action<QueryResult>? OnNext { get; set; }
-    }
-
-    /// <summary>
-    /// Used as the return type of Broadcaster.Subscribe. 
-    /// Holds the broadcaster and the observer to correctly unsubscribe if this subscription is disposed of.
-    /// </summary>
-    /// <typeparam name="TType"></typeparam>
-    public class GraphQLSubscription<TType> : IGraphQLSubscription
-    {
-        private readonly Broadcaster<TType> broadcaster;
-        private readonly IObserver<TType> observer;
-
-        public GraphQLSubscription(Broadcaster<TType> broadcaster, IObserver<TType> observer)
-        {
-            this.broadcaster = broadcaster;
-            this.observer = observer;
-        }
-
-        public Action? OnCompleted { get; set; }
-
-        public Action<Exception>? OnError { get; set; }
-
-        public Action<QueryResult>? OnNext { get; set; }
-
-        public void Dispose()
-        {
-            broadcaster.Unsubscribe(observer);
-            GC.SuppressFinalize(this);
-        }
+        broadcaster.Unsubscribe(observer);
+        GC.SuppressFinalize(this);
     }
 }

--- a/src/tests/EntityGraphQL.AspNet.Tests/GraphQLWebSocketServerTests.cs
+++ b/src/tests/EntityGraphQL.AspNet.Tests/GraphQLWebSocketServerTests.cs
@@ -6,285 +6,310 @@ using Microsoft.Extensions.DependencyInjection;
 using Moq;
 using Xunit;
 
-namespace EntityGraphQL.AspNet.Tests
+namespace EntityGraphQL.AspNet.Tests;
+
+/// <summary>
+/// Main focus is testing the websocket server responds to the client events correctly, does the correct errors etc
+///
+/// Remember:
+///     ReceiveAsync is data the GraphQLWebSocketServer is receiving from the client.
+///     SendAsync is data the GraphQLWebSocketServer is sending to the client.
+/// </summary>
+public class GraphQLWebSocketServerTests
 {
-    /// <summary>
-    /// Main focus is testing the websocket server responds to the client events correctly, does the correct errors etc
-    /// 
-    /// Remember:
-    ///     ReceiveAsync is data the GraphQLWebSocketServer is receiving from the client.
-    ///     SendAsync is data the GraphQLWebSocketServer is sending to the client.
-    /// </summary>
-    public class GraphQLWebSocketServerTests
+    private static (GraphQLWebSocketServer<TestQueryContext>, MockSocket, Mock<HttpContext>) Setup()
     {
-        private static (GraphQLWebSocketServer<TestQueryContext>, MockSocket, Mock<HttpContext>) Setup()
-        {
-            var httpContext = SetupMockHttpContext();
-            var socket = new MockSocket();
-            var server = new GraphQLWebSocketServer<TestQueryContext>(socket.Object, httpContext.Object);
-            return (server, socket, httpContext);
-        }
+        var httpContext = SetupMockHttpContext();
+        var socket = new MockSocket();
+        var server = new GraphQLWebSocketServer<TestQueryContext>(socket.Object, httpContext.Object);
+        return (server, socket, httpContext);
+    }
 
-        [Fact]
-        public async void TestConnectionInitGetAcknowledgement()
-        {
-            var (server, socket, _) = Setup();
+    [Fact]
+    public async void TestConnectionInitGetAcknowledgement()
+    {
+        var (server, socket, _) = Setup();
 
-            var sequence = new MockSequence();
-            socket.InSequence(sequence).SetupReceiveAsync($"{{\"type\":\"{GraphQLWSMessageType.ConnectionInit}\"}}");
-            // next read close the socked to end things
-            socket.InSequence(sequence).SetupReceiveCloseAsync();
+        var sequence = new MockSequence();
+        socket.InSequence(sequence).SetupReceiveAsync($"{{\"type\":\"{GraphQLWSMessageType.ConnectionInit}\"}}");
+        // next read close the socked to end things
+        socket.InSequence(sequence).SetupReceiveCloseAsync();
 
-            socket.SetupAndAssertSendAsync($"{{\"type\":\"{GraphQLWSMessageType.ConnectionAck}\"}}");
+        socket.SetupAndAssertSendAsync($"{{\"type\":\"{GraphQLWSMessageType.ConnectionAck}\"}}");
 
-            socket.SetupAndAssertCloseAsync((int)WebSocketCloseStatus.NormalClosure, "Test over");
+        socket.SetupAndAssertCloseAsync((int)WebSocketCloseStatus.NormalClosure, "Test over");
 
-            await server.HandleAsync();
-        }
+        await server.HandleAsync();
+    }
 
-        [Fact]
-        public async void TestTooManyConnectionInitError()
-        {
-            var (server, socket, _) = Setup();
+    [Fact]
+    public async void TestTooManyConnectionInitError()
+    {
+        var (server, socket, _) = Setup();
 
-            var sequence = new MockSequence();
-            socket.InSequence(sequence).SetupReceiveAsync($"{{\"type\":\"{GraphQLWSMessageType.ConnectionInit}\"}}");
-            // client sends again 
-            socket.InSequence(sequence).SetupReceiveAsync($"{{\"type\":\"{GraphQLWSMessageType.ConnectionInit}\"}}");
+        var sequence = new MockSequence();
+        socket.InSequence(sequence).SetupReceiveAsync($"{{\"type\":\"{GraphQLWSMessageType.ConnectionInit}\"}}");
+        // client sends again
+        socket.InSequence(sequence).SetupReceiveAsync($"{{\"type\":\"{GraphQLWSMessageType.ConnectionInit}\"}}");
 
-            socket.SetupAndAssertSendAsync($"{{\"type\":\"{GraphQLWSMessageType.ConnectionAck}\"}}");
+        socket.SetupAndAssertSendAsync($"{{\"type\":\"{GraphQLWSMessageType.ConnectionAck}\"}}");
 
-            socket.SetupAndAssertCloseAsync(4429, "Too many initialisation requests");
+        socket.SetupAndAssertCloseAsync(4429, "Too many initialisation requests");
 
-            await server.HandleAsync();
-        }
-        [Fact]
-        public async void TestPingSendsPong()
-        {
-            var (server, socket, _) = Setup();
+        await server.HandleAsync();
+    }
 
-            var sequence = new MockSequence();
-            socket.InSequence(sequence).SetupReceiveAsync($"{{\"type\":\"{GraphQLWSMessageType.Ping}\"}}");
-            // next read close the socked to end things
-            socket.InSequence(sequence).SetupReceiveCloseAsync();
+    [Fact]
+    public async void TestPingSendsPong()
+    {
+        var (server, socket, _) = Setup();
 
-            socket.SetupAndAssertSendAsync($"{{\"type\":\"{GraphQLWSMessageType.Pong}\"}}");
+        var sequence = new MockSequence();
+        socket.InSequence(sequence).SetupReceiveAsync($"{{\"type\":\"{GraphQLWSMessageType.Ping}\"}}");
+        // next read close the socked to end things
+        socket.InSequence(sequence).SetupReceiveCloseAsync();
 
-            socket.SetupAndAssertCloseAsync((int)WebSocketCloseStatus.NormalClosure, "Test over");
+        socket.SetupAndAssertSendAsync($"{{\"type\":\"{GraphQLWSMessageType.Pong}\"}}");
 
-            await server.HandleAsync();
-        }
-        [Fact]
-        public async void TestSubscribeNoAck()
-        {
-            var (server, socket, _) = Setup();
+        socket.SetupAndAssertCloseAsync((int)WebSocketCloseStatus.NormalClosure, "Test over");
 
-            socket.SetupReceiveAsync($"{{\"type\":\"{GraphQLWSMessageType.Subscribe}\"}}");
+        await server.HandleAsync();
+    }
 
-            socket.SetupAndAssertCloseAsync(4401, "Unauthorized");
+    [Fact]
+    public async void TestSubscribeNoAck()
+    {
+        var (server, socket, _) = Setup();
 
-            await server.HandleAsync();
-        }
-        [Fact]
-        public async void TestSubscribeInvalidNoId()
-        {
-            var (server, socket, _) = Setup();
+        socket.SetupReceiveAsync($"{{\"type\":\"{GraphQLWSMessageType.Subscribe}\"}}");
 
-            var sequence = new MockSequence();
-            socket.InSequence(sequence).SetupReceiveAsync($"{{\"type\":\"{GraphQLWSMessageType.ConnectionInit}\"}}");
-            socket.InSequence(sequence).SetupReceiveAsync($"{{\"type\":\"{GraphQLWSMessageType.Subscribe}\"}}");
+        socket.SetupAndAssertCloseAsync(4401, "Unauthorized");
 
-            socket.SetupAndAssertSendAsync($"{{\"type\":\"{GraphQLWSMessageType.ConnectionAck}\"}}");
+        await server.HandleAsync();
+    }
 
-            socket.SetupAndAssertCloseAsync(4400, "Invalid subscribe message, missing id field.");
+    [Fact]
+    public async void TestSubscribeInvalidNoId()
+    {
+        var (server, socket, _) = Setup();
 
-            await server.HandleAsync();
-        }
-        [Fact]
-        public async void TestSubscribeInvalidNoPayload()
-        {
-            var (server, socket, _) = Setup();
+        var sequence = new MockSequence();
+        socket.InSequence(sequence).SetupReceiveAsync($"{{\"type\":\"{GraphQLWSMessageType.ConnectionInit}\"}}");
+        socket.InSequence(sequence).SetupReceiveAsync($"{{\"type\":\"{GraphQLWSMessageType.Subscribe}\"}}");
 
-            var sequence = new MockSequence();
-            socket.InSequence(sequence).SetupReceiveAsync($"{{\"type\":\"{GraphQLWSMessageType.ConnectionInit}\"}}");
-            socket.InSequence(sequence).SetupReceiveAsync($"{{\"id\":\"{Guid.NewGuid()}\",\"type\":\"{GraphQLWSMessageType.Subscribe}\"}}");
+        socket.SetupAndAssertSendAsync($"{{\"type\":\"{GraphQLWSMessageType.ConnectionAck}\"}}");
 
-            socket.SetupAndAssertSendAsync($"{{\"type\":\"{GraphQLWSMessageType.ConnectionAck}\"}}");
+        socket.SetupAndAssertCloseAsync(4400, "Invalid subscribe message, missing id field.");
 
-            socket.SetupAndAssertCloseAsync(4400, "Invalid subscribe message, missing payload field.");
+        await server.HandleAsync();
+    }
 
-            await server.HandleAsync();
-        }
-        [Fact]
-        public async void TestSubscribeSuccess()
-        {
-            var (server, socket, _) = Setup();
+    [Fact]
+    public async void TestSubscribeInvalidNoPayload()
+    {
+        var (server, socket, _) = Setup();
 
-            var sequence = new MockSequence();
-            socket.InSequence(sequence).SetupReceiveAsync($"{{\"type\":\"{GraphQLWSMessageType.ConnectionInit}\"}}");
-            socket.InSequence(sequence).SetupReceiveAsync(new GraphQLWSRequest
-            {
-                Id = Guid.NewGuid(),
-                Type = GraphQLWSMessageType.Subscribe,
-                Payload = new QueryRequest
+        var sequence = new MockSequence();
+        socket.InSequence(sequence).SetupReceiveAsync($"{{\"type\":\"{GraphQLWSMessageType.ConnectionInit}\"}}");
+        socket.InSequence(sequence).SetupReceiveAsync($"{{\"id\":\"{Guid.NewGuid()}\",\"type\":\"{GraphQLWSMessageType.Subscribe}\"}}");
+
+        socket.SetupAndAssertSendAsync($"{{\"type\":\"{GraphQLWSMessageType.ConnectionAck}\"}}");
+
+        socket.SetupAndAssertCloseAsync(4400, "Invalid subscribe message, missing payload field.");
+
+        await server.HandleAsync();
+    }
+
+    [Fact]
+    public async void TestSubscribeSuccess()
+    {
+        var (server, socket, _) = Setup();
+
+        var sequence = new MockSequence();
+        socket.InSequence(sequence).SetupReceiveAsync($"{{\"type\":\"{GraphQLWSMessageType.ConnectionInit}\"}}");
+        socket
+            .InSequence(sequence)
+            .SetupReceiveAsync(
+                new GraphQLWSRequest
                 {
-                    Query = "subscription DoIt { onMessage { text } }"
+                    Id = Guid.NewGuid().ToString(),
+                    Type = GraphQLWSMessageType.Subscribe,
+                    Payload = new QueryRequest { Query = "subscription DoIt { onMessage { text } }" }
                 }
-            });
-            socket.InSequence(sequence).SetupReceiveCloseAsync();
+            );
+        socket.InSequence(sequence).SetupReceiveCloseAsync();
 
-            socket.SetupAndAssertSendAsync($"{{\"type\":\"{GraphQLWSMessageType.ConnectionAck}\"}}");
+        socket.SetupAndAssertSendAsync($"{{\"type\":\"{GraphQLWSMessageType.ConnectionAck}\"}}");
 
-            socket.SetupAndAssertCloseAsync((int)WebSocketCloseStatus.NormalClosure, "Test over");
+        socket.SetupAndAssertCloseAsync((int)WebSocketCloseStatus.NormalClosure, "Test over");
 
-            await server.HandleAsync();
-        }
-        [Fact]
-        public async void TestSubscribeSameId()
-        {
-            var (server, socket, _) = Setup();
-            var id = Guid.NewGuid();
+        await server.HandleAsync();
+    }
 
-            var sequence = new MockSequence();
-            socket.InSequence(sequence).SetupReceiveAsync($"{{\"type\":\"{GraphQLWSMessageType.ConnectionInit}\"}}");
-            socket.InSequence(sequence).SetupReceiveAsync(new GraphQLWSRequest
-            {
-                Id = id,
-                Type = GraphQLWSMessageType.Subscribe,
-                Payload = new QueryRequest
+    [Fact]
+    public async void TestSubscribeSameId()
+    {
+        var (server, socket, _) = Setup();
+        var id = Guid.NewGuid().ToString();
+
+        var sequence = new MockSequence();
+        socket.InSequence(sequence).SetupReceiveAsync($"{{\"type\":\"{GraphQLWSMessageType.ConnectionInit}\"}}");
+        socket
+            .InSequence(sequence)
+            .SetupReceiveAsync(
+                new GraphQLWSRequest
                 {
-                    Query = "subscription DoIt { onMessage { text } }"
+                    Id = id,
+                    Type = GraphQLWSMessageType.Subscribe,
+                    Payload = new QueryRequest { Query = "subscription DoIt { onMessage { text } }" }
                 }
-            });
-            socket.InSequence(sequence).SetupReceiveAsync(new GraphQLWSRequest
-            {
-                Id = id,
-                Type = GraphQLWSMessageType.Subscribe,
-                Payload = new QueryRequest
+            );
+        socket
+            .InSequence(sequence)
+            .SetupReceiveAsync(
+                new GraphQLWSRequest
                 {
-                    Query = "subscription DoIt { onMessage { text } }"
+                    Id = id,
+                    Type = GraphQLWSMessageType.Subscribe,
+                    Payload = new QueryRequest { Query = "subscription DoIt { onMessage { text } }" }
                 }
-            });
+            );
 
-            socket.SetupAndAssertSendAsync($"{{\"type\":\"{GraphQLWSMessageType.ConnectionAck}\"}}");
+        socket.SetupAndAssertSendAsync($"{{\"type\":\"{GraphQLWSMessageType.ConnectionAck}\"}}");
 
-            socket.SetupAndAssertCloseAsync(4409, $"Subscriber for {id} already exists");
+        socket.SetupAndAssertCloseAsync(4409, $"Subscriber for {id} already exists");
 
-            await server.HandleAsync();
-        }
-        [Fact]
-        public async void TestNextIsSent()
-        {
-            var (server, socket, httpContext) = Setup();
-            var id = Guid.NewGuid();
-            var chatService = httpContext.Object.RequestServices.GetService<TestChatService>()!;
+        await server.HandleAsync();
+    }
 
-            var recvSeq = new MockSequence();
-            socket.InSequence(recvSeq).SetupReceiveAsync($"{{\"type\":\"{GraphQLWSMessageType.ConnectionInit}\"}}");
-            socket.InSequence(recvSeq).SetupReceiveAsync(new GraphQLWSRequest
-            {
-                Id = id,
-                Type = GraphQLWSMessageType.Subscribe,
-                Payload = new QueryRequest
+    [Fact]
+    public async void TestNextIsSent()
+    {
+        var (server, socket, httpContext) = Setup();
+        var id = Guid.NewGuid().ToString();
+        var chatService = httpContext.Object.RequestServices.GetService<TestChatService>()!;
+
+        var recvSeq = new MockSequence();
+        socket.InSequence(recvSeq).SetupReceiveAsync($"{{\"type\":\"{GraphQLWSMessageType.ConnectionInit}\"}}");
+        socket
+            .InSequence(recvSeq)
+            .SetupReceiveAsync(
+                new GraphQLWSRequest
                 {
-                    Query = "subscription DoIt { onMessage { text } }"
-                }
-            }, async () =>
-            {
-                // this runs after server has received the message
-                // We don't know whenthe execution of the subscribe finishes though so we wait a bit :(
-                await Task.Delay(100);
-                chatService.PostMessage("Hello");
-            });
-            socket.InSequence(recvSeq).SetupReceiveCloseAsync();
-
-            var sendSeq = new MockSequence();
-            socket.InSequence(sendSeq).SetupAndAssertSendAsync($"{{\"type\":\"{GraphQLWSMessageType.ConnectionAck}\"}}");
-            socket.InSequence(sendSeq).SetupAndAssertSendAsync($"{{\"payload\":{{\"data\":{{\"onMessage\":{{\"text\":\"Hello\"}}}}}},\"id\":\"{id}\",\"type\":\"{GraphQLWSMessageType.Next}\"}}");
-
-            socket.SetupAndAssertCloseAsync((int)WebSocketCloseStatus.NormalClosure, "Test over");
-
-            await server.HandleAsync();
-        }
-
-        [Fact]
-        public async void TestQueryOverWebsocket()
-        {
-            var (server, socket, httpContext) = Setup();
-            httpContext.Object.RequestServices.GetRequiredService<TestQueryContext>().Messages.Add(new Message { Text = "Hello" });
-            var id = Guid.NewGuid();
-
-            var recvSeq = new MockSequence();
-            socket.InSequence(recvSeq).SetupReceiveAsync($"{{\"type\":\"{GraphQLWSMessageType.ConnectionInit}\"}}");
-            socket.InSequence(recvSeq).SetupReceiveAsync(new GraphQLWSRequest
-            {
-                Id = id,
-                Type = GraphQLWSMessageType.Subscribe,
-                Payload = new QueryRequest
+                    Id = id,
+                    Type = GraphQLWSMessageType.Subscribe,
+                    Payload = new QueryRequest { Query = "subscription DoIt { onMessage { text } }" }
+                },
+                async () =>
                 {
-                    Query = "query GetIt { messages { text } }"
+                    // this runs after server has received the message
+                    // We don't know whenthe execution of the subscribe finishes though so we wait a bit :(
+                    await Task.Delay(100);
+                    chatService.PostMessage("Hello");
                 }
-            });
-            socket.InSequence(recvSeq).SetupReceiveCloseAsync();
+            );
+        socket.InSequence(recvSeq).SetupReceiveCloseAsync();
 
-            var sendSeq = new MockSequence();
-            socket.InSequence(sendSeq).SetupAndAssertSendAsync($"{{\"type\":\"{GraphQLWSMessageType.ConnectionAck}\"}}");
-            socket.InSequence(sendSeq).SetupAndAssertSendAsync($"{{\"payload\":{{\"data\":{{\"messages\":[{{\"text\":\"Hello\"}}]}}}},\"id\":\"{id}\",\"type\":\"{GraphQLWSMessageType.Next}\"}}");
-            socket.InSequence(sendSeq).SetupAndAssertSendAsync($"{{\"id\":\"{id}\",\"type\":\"{GraphQLWSMessageType.Complete}\"}}");
+        var sendSeq = new MockSequence();
+        socket.InSequence(sendSeq).SetupAndAssertSendAsync($"{{\"type\":\"{GraphQLWSMessageType.ConnectionAck}\"}}");
+        socket
+            .InSequence(sendSeq)
+            .SetupAndAssertSendAsync($"{{\"payload\":{{\"data\":{{\"onMessage\":{{\"text\":\"Hello\"}}}}}},\"id\":\"{id}\",\"type\":\"{GraphQLWSMessageType.Next}\"}}");
 
-            socket.SetupAndAssertCloseAsync((int)WebSocketCloseStatus.NormalClosure, "Test over");
+        socket.SetupAndAssertCloseAsync((int)WebSocketCloseStatus.NormalClosure, "Test over");
 
-            await server.HandleAsync();
-        }
+        await server.HandleAsync();
+    }
 
-        [Fact]
-        public async void TestMutationOverWebsocket()
-        {
-            var (server, socket, httpContext) = Setup();
-            httpContext.Object.RequestServices.GetRequiredService<SchemaProvider<TestQueryContext>>().Mutation().Add("postMessage", (string text, TestChatService chat) =>
-            {
-                chat.PostMessage(text);
-                return new Message { Text = text };
-            });
-            var id = Guid.NewGuid();
+    [Fact]
+    public async void TestQueryOverWebsocket()
+    {
+        var (server, socket, httpContext) = Setup();
+        httpContext.Object.RequestServices.GetRequiredService<TestQueryContext>().Messages.Add(new Message { Text = "Hello" });
+        var id = Guid.NewGuid().ToString();
 
-            var recvSeq = new MockSequence();
-            socket.InSequence(recvSeq).SetupReceiveAsync($"{{\"type\":\"{GraphQLWSMessageType.ConnectionInit}\"}}");
-            socket.InSequence(recvSeq).SetupReceiveAsync(new GraphQLWSRequest
-            {
-                Id = id,
-                Type = GraphQLWSMessageType.Subscribe,
-                Payload = new QueryRequest
+        var recvSeq = new MockSequence();
+        socket.InSequence(recvSeq).SetupReceiveAsync($"{{\"type\":\"{GraphQLWSMessageType.ConnectionInit}\"}}");
+        socket
+            .InSequence(recvSeq)
+            .SetupReceiveAsync(
+                new GraphQLWSRequest
                 {
-                    Query = "mutation MutateIt { postMessage(text: \"hey\") { text } }"
+                    Id = id,
+                    Type = GraphQLWSMessageType.Subscribe,
+                    Payload = new QueryRequest { Query = "query GetIt { messages { text } }" }
                 }
-            });
+            );
+        socket.InSequence(recvSeq).SetupReceiveCloseAsync();
 
-            socket.InSequence(recvSeq).SetupReceiveCloseAsync();
+        var sendSeq = new MockSequence();
+        socket.InSequence(sendSeq).SetupAndAssertSendAsync($"{{\"type\":\"{GraphQLWSMessageType.ConnectionAck}\"}}");
+        socket
+            .InSequence(sendSeq)
+            .SetupAndAssertSendAsync($"{{\"payload\":{{\"data\":{{\"messages\":[{{\"text\":\"Hello\"}}]}}}},\"id\":\"{id}\",\"type\":\"{GraphQLWSMessageType.Next}\"}}");
+        socket.InSequence(sendSeq).SetupAndAssertSendAsync($"{{\"id\":\"{id}\",\"type\":\"{GraphQLWSMessageType.Complete}\"}}");
 
-            var sendSeq = new MockSequence();
-            socket.InSequence(sendSeq).SetupAndAssertSendAsync($"{{\"type\":\"{GraphQLWSMessageType.ConnectionAck}\"}}");
-            socket.InSequence(sendSeq).SetupAndAssertSendAsync($"{{\"payload\":{{\"data\":{{\"postMessage\":{{\"text\":\"hey\"}}}}}},\"id\":\"{id}\",\"type\":\"{GraphQLWSMessageType.Next}\"}}");
-            socket.InSequence(sendSeq).SetupAndAssertSendAsync($"{{\"id\":\"{id}\",\"type\":\"{GraphQLWSMessageType.Complete}\"}}");
+        socket.SetupAndAssertCloseAsync((int)WebSocketCloseStatus.NormalClosure, "Test over");
 
-            socket.SetupAndAssertCloseAsync((int)WebSocketCloseStatus.NormalClosure, "Test over");
+        await server.HandleAsync();
+    }
 
-            await server.HandleAsync();
-        }
+    [Fact]
+    public async void TestMutationOverWebsocket()
+    {
+        var (server, socket, httpContext) = Setup();
+        httpContext
+            .Object.RequestServices.GetRequiredService<SchemaProvider<TestQueryContext>>()
+            .Mutation()
+            .Add(
+                "postMessage",
+                (string text, TestChatService chat) =>
+                {
+                    chat.PostMessage(text);
+                    return new Message { Text = text };
+                }
+            );
+        var id = Guid.NewGuid().ToString();
 
-        private static Mock<HttpContext> SetupMockHttpContext()
-        {
-            var chatService = new TestChatService();
-            var schemaContext = new TestQueryContext();
-            var schema = SchemaBuilder.FromObject<TestQueryContext>();
-            schema.Subscription().AddFrom<TestSubscription>();
-            var httpContext = new Mock<HttpContext>();
-            var servicesMock = new Mock<IServiceProvider>();
-            servicesMock.Setup(sp => sp.GetService(typeof(SchemaProvider<TestQueryContext>))).Returns(schema);
-            servicesMock.Setup(sp => sp.GetService(typeof(TestQueryContext))).Returns(schemaContext);
-            servicesMock.Setup(sp => sp.GetService(typeof(TestChatService))).Returns(chatService);
-            httpContext.Setup(c => c.RequestServices).Returns(servicesMock.Object);
-            return httpContext;
-        }
+        var recvSeq = new MockSequence();
+        socket.InSequence(recvSeq).SetupReceiveAsync($"{{\"type\":\"{GraphQLWSMessageType.ConnectionInit}\"}}");
+        socket
+            .InSequence(recvSeq)
+            .SetupReceiveAsync(
+                new GraphQLWSRequest
+                {
+                    Id = id,
+                    Type = GraphQLWSMessageType.Subscribe,
+                    Payload = new QueryRequest { Query = "mutation MutateIt { postMessage(text: \"hey\") { text } }" }
+                }
+            );
+
+        socket.InSequence(recvSeq).SetupReceiveCloseAsync();
+
+        var sendSeq = new MockSequence();
+        socket.InSequence(sendSeq).SetupAndAssertSendAsync($"{{\"type\":\"{GraphQLWSMessageType.ConnectionAck}\"}}");
+        socket
+            .InSequence(sendSeq)
+            .SetupAndAssertSendAsync($"{{\"payload\":{{\"data\":{{\"postMessage\":{{\"text\":\"hey\"}}}}}},\"id\":\"{id}\",\"type\":\"{GraphQLWSMessageType.Next}\"}}");
+        socket.InSequence(sendSeq).SetupAndAssertSendAsync($"{{\"id\":\"{id}\",\"type\":\"{GraphQLWSMessageType.Complete}\"}}");
+
+        socket.SetupAndAssertCloseAsync((int)WebSocketCloseStatus.NormalClosure, "Test over");
+
+        await server.HandleAsync();
+    }
+
+    private static Mock<HttpContext> SetupMockHttpContext()
+    {
+        var chatService = new TestChatService();
+        var schemaContext = new TestQueryContext();
+        var schema = SchemaBuilder.FromObject<TestQueryContext>();
+        schema.Subscription().AddFrom<TestSubscription>();
+        var httpContext = new Mock<HttpContext>();
+        var servicesMock = new Mock<IServiceProvider>();
+        servicesMock.Setup(sp => sp.GetService(typeof(SchemaProvider<TestQueryContext>))).Returns(schema);
+        servicesMock.Setup(sp => sp.GetService(typeof(TestQueryContext))).Returns(schemaContext);
+        servicesMock.Setup(sp => sp.GetService(typeof(TestChatService))).Returns(chatService);
+        httpContext.Setup(c => c.RequestServices).Returns(servicesMock.Object);
+        return httpContext;
     }
 }

--- a/src/tests/EntityGraphQL.Tests/PersistedQueriesTests.cs
+++ b/src/tests/EntityGraphQL.Tests/PersistedQueriesTests.cs
@@ -14,7 +14,8 @@ public class PersistedQueriesTests
         var data = new TestDataContext();
         FillProjectData(data);
 
-        var query = @"{
+        var query =
+            @"{
                     project(id: 99) {
                         name
                         tasks {
@@ -27,9 +28,12 @@ public class PersistedQueriesTests
         var gql = new QueryRequest
         {
             Query = query,
-            Extensions = new Dictionary<string, Dictionary<string, object>>
+            Extensions = new QueryExtensions
             {
-                { "persistedQuery", new PersistedQueryExtension { Sha256Hash = hash } }
+                {
+                    "persistedQuery",
+                    new PersistedQueryExtension { Sha256Hash = hash }
+                }
             }
         };
 
@@ -57,7 +61,8 @@ public class PersistedQueriesTests
         var data = new TestDataContext();
         FillProjectData(data);
 
-        var query = @"{
+        var query =
+            @"{
                     project(id: 99) {
                         name
                         tasks {
@@ -70,9 +75,12 @@ public class PersistedQueriesTests
         var gql = new QueryRequest
         {
             Query = null, // assume it is cached
-            Extensions = new Dictionary<string, Dictionary<string, object>>
+            Extensions = new QueryExtensions
             {
-                { "persistedQuery", new PersistedQueryExtension { Sha256Hash = hash } }
+                {
+                    "persistedQuery",
+                    new PersistedQueryExtension { Sha256Hash = hash }
+                }
             }
         };
 
@@ -89,7 +97,8 @@ public class PersistedQueriesTests
         var data = new TestDataContext();
         FillProjectData(data);
 
-        var query = @"{
+        var query =
+            @"{
                     project(id: 99) {
                         name
                         tasks {
@@ -102,9 +111,12 @@ public class PersistedQueriesTests
         var gql = new QueryRequest
         {
             Query = null, // assume it is cached
-            Extensions = new Dictionary<string, Dictionary<string, object>>
+            Extensions = new QueryExtensions
             {
-                { "persistedQuery", new PersistedQueryExtension { Sha256Hash = hash } }
+                {
+                    "persistedQuery",
+                    new PersistedQueryExtension { Sha256Hash = hash }
+                }
             }
         };
 
@@ -113,6 +125,7 @@ public class PersistedQueriesTests
 
         Assert.Equal("PersistedQueryNotSupported", result.Errors.First().Message);
     }
+
     [Fact]
     public void TestPersistedQueryNotSupportedWrongVersion()
     {
@@ -120,7 +133,8 @@ public class PersistedQueriesTests
         var data = new TestDataContext();
         FillProjectData(data);
 
-        var query = @"{
+        var query =
+            @"{
                     project(id: 99) {
                         name
                         tasks {
@@ -133,9 +147,12 @@ public class PersistedQueriesTests
         var gql = new QueryRequest
         {
             Query = query,
-            Extensions = new Dictionary<string, Dictionary<string, object>>
+            Extensions = new QueryExtensions
             {
-                { "persistedQuery", new PersistedQueryExtension { Sha256Hash = hash, Version = 2 } }
+                {
+                    "persistedQuery",
+                    new PersistedQueryExtension { Sha256Hash = hash, Version = 2 }
+                }
             }
         };
 
@@ -148,42 +165,20 @@ public class PersistedQueriesTests
     private static void FillProjectData(TestDataContext data)
     {
         data.Projects = new List<Project>
+        {
+            new Project
             {
-                new Project
+                Id = 99,
+                Name = "Project 1",
+                Tasks = new List<Task>
                 {
-                    Id = 99,
-                    Name ="Project 1",
-                    Tasks = new List<Task>
-                    {
-                        new Task
-                        {
-                            Id = 0,
-                            Name = "Task 1"
-                        },
-                        new Task
-                        {
-                            Id = 1,
-                            Name = "Task 2"
-                        },
-                        new Task
-                        {
-                            Id = 2,
-                            Name = "Task 3"
-                        },
-                        new Task
-                        {
-                            Id = 3,
-                            Name = "Task 4"
-                        },
-                        new Task
-                        {
-                            Id = 4,
-                            Name = "Task 5"
-                        },
-
-                    }
+                    new Task { Id = 0, Name = "Task 1" },
+                    new Task { Id = 1, Name = "Task 2" },
+                    new Task { Id = 2, Name = "Task 3" },
+                    new Task { Id = 3, Name = "Task 4" },
+                    new Task { Id = 4, Name = "Task 5" },
                 }
-            };
+            }
+        };
     }
-
 }

--- a/src/tests/EntityGraphQL.Tests/SortTests/SortTests.cs
+++ b/src/tests/EntityGraphQL.Tests/SortTests/SortTests.cs
@@ -1,358 +1,344 @@
-using Xunit;
 using System.Collections.Generic;
 using System.Linq;
 using EntityGraphQL.Schema;
 using EntityGraphQL.Schema.FieldExtensions;
+using Xunit;
 
-namespace EntityGraphQL.Tests
+namespace EntityGraphQL.Tests;
+
+public class SortTests
 {
-    public class SortTests
+    [Fact]
+    public void SupportUseSort()
     {
-        [Fact]
-        public void SupportUseSort()
+        var schema = SchemaBuilder.FromObject<TestDataContext>();
+        schema.Type<TestDataContext>().GetField("people", null).UseSort();
+        var gql = new QueryRequest
         {
-            var schema = SchemaBuilder.FromObject<TestDataContext>();
-            schema.Type<TestDataContext>().GetField("people", null)
-                .UseSort();
-            var gql = new QueryRequest
-            {
-                Query = @"query($sort: [QueryPeopleSortInput]) {
+            Query =
+                @"query($sort: [QueryPeopleSortInput]) {
                     people(sort: $sort) { lastName }
                 }",
-                Variables = new QueryVariables {
-                    {"sort", new [] { new {lastName = SortDirection.DESC } } }
-                }
-            };
-            var context = new TestDataContext().FillWithTestData();
-            context.People.Add(new Person
-            {
-                LastName = "Zoo"
-            });
-            var tree = schema.ExecuteRequestWithContext(gql, context, null, null);
-            Assert.Null(tree.Errors);
-            dynamic people = ((IDictionary<string, object>)tree.Data)["people"];
-            Assert.Equal(2, Enumerable.Count(people));
-            var person = Enumerable.First(people);
-            Assert.Equal("Zoo", person.lastName);
-        }
-        [Fact]
-        public void TestSortAttribute()
-        {
-            var schema = SchemaBuilder.FromObject<TestDataContext2>();
+            Variables = new QueryVariables { { "sort", new[] { new { lastName = SortDirection.DESC } } } }
+        };
+        var context = new TestDataContext().FillWithTestData();
+        context.People.Add(new Person { LastName = "Zoo" });
+        var tree = schema.ExecuteRequestWithContext(gql, context, null, null);
+        Assert.Null(tree.Errors);
+        dynamic people = ((IDictionary<string, object>)tree.Data)["people"];
+        Assert.Equal(2, Enumerable.Count(people));
+        var person = Enumerable.First(people);
+        Assert.Equal("Zoo", person.lastName);
+    }
 
-            var gql = new QueryRequest
-            {
-                Query = @"query($sort: [QueryPeopleSortInput]) {
-                    people(sort: $sort) { lastName }
-                }",
-                Variables = new QueryVariables{
-                    {"sort", new [] { new {lastName = "DESC" } } }
-                }
-            };
-            TestDataContext2 context = new();
-            context.FillWithTestData();
-            context.People.Add(new Person
-            {
-                LastName = "Zoo"
-            });
-            var tree = schema.ExecuteRequestWithContext(gql, context, null, null);
-            Assert.Null(tree.Errors);
-            dynamic people = ((IDictionary<string, object>)tree.Data)["people"];
-            Assert.Equal(2, Enumerable.Count(people));
-            var person = Enumerable.First(people);
-            Assert.Equal("Zoo", person.lastName);
-        }
-        private class TestDataContext2 : TestDataContext
-        {
-            [UseSort]
-            public override List<Person> People { get; set; } = new List<Person>();
-        }
+    [Fact]
+    public void TestSortAttribute()
+    {
+        var schema = SchemaBuilder.FromObject<TestDataContext2>();
 
-        [Fact]
-        public void SupportUseSortSelectSortFields()
+        var gql = new QueryRequest
         {
-            var schema = SchemaBuilder.FromObject<TestDataContext>();
-            schema.Type<TestDataContext>().GetField("people", null)
-                .UseSort((Person person) => new
-                {
-                    person.Height,
-                    person.Name
-                });
-            var gql = new QueryRequest
-            {
-                Query = @"query($sort: [QueryPeopleSortInput]) {
+            Query =
+                @"query($sort: [QueryPeopleSortInput]) {
                     people(sort: $sort) { lastName }
                 }",
-                Variables = new QueryVariables{
-                    {"sort", new [] { new {height = "ASC" } } }
-                }
-            };
-            var context = new TestDataContext().FillWithTestData();
-            context.People.Add(new Person
+            Variables = new QueryVariables { { "sort", new[] { new { lastName = "DESC" } } } }
+        };
+        TestDataContext2 context = new();
+        context.FillWithTestData();
+        context.People.Add(new Person { LastName = "Zoo" });
+        var tree = schema.ExecuteRequestWithContext(gql, context, null, null);
+        Assert.Null(tree.Errors);
+        dynamic people = ((IDictionary<string, object>)tree.Data)["people"];
+        Assert.Equal(2, Enumerable.Count(people));
+        var person = Enumerable.First(people);
+        Assert.Equal("Zoo", person.lastName);
+    }
+
+    private class TestDataContext2 : TestDataContext
+    {
+        [UseSort]
+        public override List<Person> People { get; set; } = new List<Person>();
+    }
+
+    [Fact]
+    public void SupportUseSortSelectSortFields()
+    {
+        var schema = SchemaBuilder.FromObject<TestDataContext>();
+        schema.Type<TestDataContext>().GetField("people", null).UseSort((Person person) => new { person.Height, person.Name });
+        var gql = new QueryRequest
+        {
+            Query =
+                @"query($sort: [QueryPeopleSortInput]) {
+                    people(sort: $sort) { lastName }
+                }",
+            Variables = new QueryVariables { { "sort", new[] { new { height = "ASC" } } } }
+        };
+        var context = new TestDataContext().FillWithTestData();
+        context.People.Add(new Person { LastName = "Zoo", Height = 1 });
+        var tree = schema.ExecuteRequestWithContext(gql, context, null, null);
+        Assert.Null(tree.Errors);
+        dynamic people = ((IDictionary<string, object>)tree.Data)["people"];
+        Assert.Equal(2, Enumerable.Count(people));
+        var person = Enumerable.First(people);
+        Assert.Equal("Zoo", person.lastName);
+        var schemaType = schema.Type("QueryPeopleSortInput");
+        var fields = schemaType.GetFields().ToList();
+        Assert.Equal(3, fields.Count);
+        Assert.Equal("__typename", fields[0].Name);
+        Assert.Equal("height", fields[1].Name);
+        Assert.Equal("name", fields[2].Name);
+    }
+
+    [Fact]
+    public void SupportUseSortSelectSortFieldsDeepProperty()
+    {
+        var schema = SchemaBuilder.FromObject<TestDataContext>();
+        schema.Type<TestDataContext>().GetField("people", null).UseSort((Person person) => new { managerName = person.Manager.Name, person.Name });
+        var gql = new QueryRequest
+        {
+            Query =
+                @"query($sort: [QueryPeopleSortInput]) {
+                    people(sort: $sort) { lastName }
+                }",
+            Variables = new QueryVariables { { "sort", new[] { new { managerName = "ASC" } } } }
+        };
+        var context = new TestDataContext().FillWithTestData();
+        foreach (var p in context.People)
+        {
+            p.Manager = new Person { Name = "zbe" };
+        }
+        context.People.Add(
+            new Person
             {
                 LastName = "Zoo",
-                Height = 1
-            });
-            var tree = schema.ExecuteRequestWithContext(gql, context, null, null);
-            Assert.Null(tree.Errors);
-            dynamic people = ((IDictionary<string, object>)tree.Data)["people"];
-            Assert.Equal(2, Enumerable.Count(people));
-            var person = Enumerable.First(people);
-            Assert.Equal("Zoo", person.lastName);
-            var schemaType = schema.Type("QueryPeopleSortInput");
-            var fields = schemaType.GetFields().ToList();
-            Assert.Equal(3, fields.Count);
-            Assert.Equal("__typename", fields[0].Name);
-            Assert.Equal("height", fields[1].Name);
-            Assert.Equal("name", fields[2].Name);
-        }
-        [Fact]
-        public void SupportUseSortSelectSortFieldsDeepProperty()
-        {
-            var schema = SchemaBuilder.FromObject<TestDataContext>();
-            schema.Type<TestDataContext>().GetField("people", null)
-                .UseSort((Person person) => new
-                {
-                    managerName = person.Manager.Name,
-                    person.Name
-                });
-            var gql = new QueryRequest
-            {
-                Query = @"query($sort: [QueryPeopleSortInput]) {
-                    people(sort: $sort) { lastName }
-                }",
-                Variables = new QueryVariables{
-                    {"sort", new [] { new {managerName = "ASC" } } }
-                }
-            };
-            var context = new TestDataContext().FillWithTestData();
-            foreach (var p in context.People)
-            {
-                p.Manager = new Person
-                {
-                    Name = "zbe"
-                };
+                Manager = new Person { Name = "Abe" }
             }
-            context.People.Add(new Person
-            {
-                LastName = "Zoo",
-                Manager = new Person
-                {
-                    Name = "Abe"
-                }
-            });
-            var tree = schema.ExecuteRequestWithContext(gql, context, null, null);
-            Assert.Null(tree.Errors);
-            dynamic people = ((IDictionary<string, object>)tree.Data)["people"];
-            Assert.Equal(2, Enumerable.Count(people));
-            var person = Enumerable.First(people);
-            Assert.Equal("Zoo", person.lastName);
-            var schemaType = schema.Type("QueryPeopleSortInput");
-            var fields = schemaType.GetFields().ToList();
-            Assert.Equal(3, fields.Count);
-            Assert.Equal("__typename", fields[0].Name);
-            Assert.Equal("managerName", fields[1].Name);
-            Assert.Equal("name", fields[2].Name);
-        }
-        [Fact]
-        public void SupportUseSortDefaultWithSelectSortFields()
-        {
-            var schema = SchemaBuilder.FromObject<TestDataContext>();
-            schema.Type<TestDataContext>().GetField("people", null)
-                .UseSort((Person person) => new
-                {
-                    person.Height,
-                    person.Name
-                },
-                (Person person) => person.LastName, SortDirection.DESC);
-            var gql = new QueryRequest
-            {
-                Query = @"query {
-                    people { lastName }
-                }",
-            };
-            var context = new TestDataContext().FillWithTestData();
-            context.People.Add(new Person
-            {
-                LastName = "Zoo",
-                Height = 1
-            });
-            var tree = schema.ExecuteRequestWithContext(gql, context, null, null);
-            Assert.Null(tree.Errors);
-            dynamic people = ((IDictionary<string, object>)tree.Data)["people"];
-            Assert.Equal(2, Enumerable.Count(people));
-            var person = Enumerable.First(people);
-            Assert.Equal("Zoo", person.lastName);
-            var schemaType = schema.Type("QueryPeopleSortInput");
-            var fields = schemaType.GetFields().ToList();
-            Assert.Equal(3, fields.Count);
-            Assert.Equal("__typename", fields[0].Name);
-            Assert.Equal("height", fields[1].Name);
-            Assert.Equal("name", fields[2].Name);
-        }
-        [Fact]
-        public void SupportUseSortDefault()
-        {
-            var schema = SchemaBuilder.FromObject<TestDataContext>();
-            schema.Type<TestDataContext>().GetField("people", null)
-                .UseSort((Person person) => person.Height, SortDirection.ASC);
-            var gql = new QueryRequest
-            {
-                Query = @"query {
-                    people { lastName }
-                }",
-            };
-            var context = new TestDataContext().FillWithTestData();
-            context.People.Add(new Person
-            {
-                LastName = "Zoo",
-                Height = 1
-            });
-            var tree = schema.ExecuteRequestWithContext(gql, context, null, null);
-            Assert.Null(tree.Errors);
-            dynamic people = ((IDictionary<string, object>)tree.Data)["people"];
-            Assert.Equal(2, Enumerable.Count(people));
-            var person = Enumerable.First(people);
-            Assert.Equal("Zoo", person.lastName);
-            var schemaType = schema.Type("QueryPeopleSortInput");
-            var fields = schemaType.GetFields().ToList();
-            Assert.Equal(13, fields.Count);
-            Assert.Contains("people(sort: [QueryPeopleSortInput!] = [{ height: ASC }]): [Person!]", schema.ToGraphQLSchemaString());
-        }
+        );
+        var tree = schema.ExecuteRequestWithContext(gql, context, null, null);
+        Assert.Null(tree.Errors);
+        dynamic people = ((IDictionary<string, object>)tree.Data)["people"];
+        Assert.Equal(2, Enumerable.Count(people));
+        var person = Enumerable.First(people);
+        Assert.Equal("Zoo", person.lastName);
+        var schemaType = schema.Type("QueryPeopleSortInput");
+        var fields = schemaType.GetFields().ToList();
+        Assert.Equal(3, fields.Count);
+        Assert.Equal("__typename", fields[0].Name);
+        Assert.Equal("managerName", fields[1].Name);
+        Assert.Equal("name", fields[2].Name);
+    }
 
-        [Fact]
-        public void SupportUseSortDefaultMulti()
+    [Fact]
+    public void SupportUseSortDefaultWithSelectSortFields()
+    {
+        var schema = SchemaBuilder.FromObject<TestDataContext>();
+        schema
+            .Type<TestDataContext>()
+            .GetField("people", null)
+            .UseSort((Person person) => new { person.Height, person.Name }, (Person person) => person.LastName, SortDirection.DESC);
+        var gql = new QueryRequest
         {
-            var schema = SchemaBuilder.FromObject<TestDataContext>();
-            schema.Type<TestDataContext>().GetField("people", null)
-                .UseSort(
-                    new Sort<Person>((person) => person.Height, SortDirection.ASC),
-                    new Sort<Person>((person) => person.LastName, SortDirection.ASC)
-                );
-            var gql = new QueryRequest
-            {
-                Query = @"query {
+            Query =
+                @"query {
                     people { lastName }
                 }",
-            };
-            var context = new TestDataContext().FillWithTestData();
-            context.People.Add(new Person
-            {
-                LastName = "Zoo",
-                Height = 10
-            });
-            context.People.Add(new Person
-            {
-                LastName = "Abe",
-                Height = 10
-            });
-            var tree = schema.ExecuteRequestWithContext(gql, context, null, null);
-            Assert.Null(tree.Errors);
-            dynamic people = ((IDictionary<string, object>)tree.Data)["people"];
-            Assert.Equal(3, Enumerable.Count(people));
-            var person = Enumerable.First(people);
-            Assert.Equal("Abe", person.lastName);
-            var schemaType = schema.Type("QueryPeopleSortInput");
-            var fields = schemaType.GetFields().ToList();
-            Assert.Equal(13, fields.Count);
-            Assert.Contains("people(sort: [QueryPeopleSortInput!] = [{ height: ASC }, { lastName: ASC }]): [Person!]", schema.ToGraphQLSchemaString());
-        }
+        };
+        var context = new TestDataContext().FillWithTestData();
+        context.People.Add(new Person { LastName = "Zoo", Height = 1 });
+        var tree = schema.ExecuteRequestWithContext(gql, context, null, null);
+        Assert.Null(tree.Errors);
+        dynamic people = ((IDictionary<string, object>)tree.Data)["people"];
+        Assert.Equal(2, Enumerable.Count(people));
+        var person = Enumerable.First(people);
+        Assert.Equal("Zoo", person.lastName);
+        var schemaType = schema.Type("QueryPeopleSortInput");
+        var fields = schemaType.GetFields().ToList();
+        Assert.Equal(3, fields.Count);
+        Assert.Equal("__typename", fields[0].Name);
+        Assert.Equal("height", fields[1].Name);
+        Assert.Equal("name", fields[2].Name);
+    }
 
-        [Fact]
-        public void SupportUseSortOnNonRoot()
+    [Fact]
+    public void SupportUseSortDefault()
+    {
+        var schema = SchemaBuilder.FromObject<TestDataContext>();
+        schema.Type<TestDataContext>().GetField("people", null).UseSort((Person person) => person.Height, SortDirection.ASC);
+        var gql = new QueryRequest
         {
-            var schema = SchemaBuilder.FromObject<TestDataContext>();
-            schema.Type<Project>().GetField("tasks", null)
-                .UseSort();
-            var gql = new QueryRequest
-            {
-                Query = @"query($sort: [ProjectTasksSortInput]) {
+            Query =
+                @"query {
+                    people { lastName }
+                }",
+        };
+        var context = new TestDataContext().FillWithTestData();
+        context.People.Add(new Person { LastName = "Zoo", Height = 1 });
+        var tree = schema.ExecuteRequestWithContext(gql, context, null, null);
+        Assert.Null(tree.Errors);
+        dynamic people = ((IDictionary<string, object>)tree.Data)["people"];
+        Assert.Equal(2, Enumerable.Count(people));
+        var person = Enumerable.First(people);
+        Assert.Equal("Zoo", person.lastName);
+        var schemaType = schema.Type("QueryPeopleSortInput");
+        var fields = schemaType.GetFields().ToList();
+        Assert.Equal(13, fields.Count);
+        Assert.Contains("people(sort: [QueryPeopleSortInput!] = [{ height: ASC }]): [Person!]", schema.ToGraphQLSchemaString());
+    }
+
+    [Fact]
+    public void SupportUseSortDefaultMulti()
+    {
+        var schema = SchemaBuilder.FromObject<TestDataContext>();
+        schema
+            .Type<TestDataContext>()
+            .GetField("people", null)
+            .UseSort(new Sort<Person>((person) => person.Height, SortDirection.ASC), new Sort<Person>((person) => person.LastName, SortDirection.ASC));
+        var gql = new QueryRequest
+        {
+            Query =
+                @"query {
+                    people { lastName }
+                }",
+        };
+        var context = new TestDataContext().FillWithTestData();
+        context.People.Add(new Person { LastName = "Zoo", Height = 10 });
+        context.People.Add(new Person { LastName = "Abe", Height = 10 });
+        var tree = schema.ExecuteRequestWithContext(gql, context, null, null);
+        Assert.Null(tree.Errors);
+        dynamic people = ((IDictionary<string, object>)tree.Data)["people"];
+        Assert.Equal(3, Enumerable.Count(people));
+        var person = Enumerable.First(people);
+        Assert.Equal("Abe", person.lastName);
+        var schemaType = schema.Type("QueryPeopleSortInput");
+        var fields = schemaType.GetFields().ToList();
+        Assert.Equal(13, fields.Count);
+        Assert.Contains("people(sort: [QueryPeopleSortInput!] = [{ height: ASC }, { lastName: ASC }]): [Person!]", schema.ToGraphQLSchemaString());
+    }
+
+    [Fact]
+    public void SupportUseSortOnNonRoot()
+    {
+        var schema = SchemaBuilder.FromObject<TestDataContext>();
+        schema.Type<Project>().GetField("tasks", null).UseSort();
+        var gql = new QueryRequest
+        {
+            Query =
+                @"query($sort: [ProjectTasksSortInput]) {
                     projects {
                         tasks(sort: $sort) { id }
                     }
                 }",
-                Variables = new QueryVariables {
-                    {"sort", new [] { new {id = "DESC" } } }
-                }
-            };
-            var context = new TestDataContext().FillWithTestData();
-            var tree = schema.ExecuteRequestWithContext(gql, context, null, null);
-            Assert.Null(tree.Errors);
-            dynamic projects = ((IDictionary<string, object>)tree.Data)["projects"];
-            Assert.Equal(1, Enumerable.Count(projects));
-            var project = Enumerable.First(projects);
-            Assert.Equal(4, Enumerable.Count(project.tasks));
-            Assert.Equal(4, Enumerable.ElementAt(project.tasks, 0).id);
-            Assert.Equal(3, Enumerable.ElementAt(project.tasks, 1).id);
-            Assert.Equal(2, Enumerable.ElementAt(project.tasks, 2).id);
-            Assert.Equal(1, Enumerable.ElementAt(project.tasks, 3).id);
-        }
-        [Fact]
-        public void SupportUseSortOnNonRootVariableWithClass()
+            Variables = new QueryVariables { { "sort", new[] { new { id = "DESC" } } } }
+        };
+        var context = new TestDataContext().FillWithTestData();
+        var tree = schema.ExecuteRequestWithContext(gql, context, null, null);
+        Assert.Null(tree.Errors);
+        dynamic projects = ((IDictionary<string, object>)tree.Data)["projects"];
+        Assert.Equal(1, Enumerable.Count(projects));
+        var project = Enumerable.First(projects);
+        Assert.Equal(4, Enumerable.Count(project.tasks));
+        Assert.Equal(4, Enumerable.ElementAt(project.tasks, 0).id);
+        Assert.Equal(3, Enumerable.ElementAt(project.tasks, 1).id);
+        Assert.Equal(2, Enumerable.ElementAt(project.tasks, 2).id);
+        Assert.Equal(1, Enumerable.ElementAt(project.tasks, 3).id);
+    }
+
+    [Fact]
+    public void SupportUseSortOnNonRootVariableWithClass()
+    {
+        var schema = SchemaBuilder.FromObject<TestDataContext>();
+        schema.Type<Project>().GetField("tasks", null).UseSort();
+        var gql = new QueryRequest
         {
-            var schema = SchemaBuilder.FromObject<TestDataContext>();
-            schema.Type<Project>().GetField("tasks", null)
-                .UseSort();
-            var gql = new QueryRequest
-            {
-                Query = @"query($sort: [ProjectTasksSortInput]) {
+            Query =
+                @"query($sort: [ProjectTasksSortInput]) {
                     projects {
                         tasks(sort: $sort) { id }
                     }
                 }",
-                Variables = new QueryVariables
-                {
-                    { "sort", new List<IdSort>{new IdSort { Id = SortDirection.DESC } }}
-                }
-            };
-            var context = new TestDataContext().FillWithTestData();
-            var tree = schema.ExecuteRequestWithContext(gql, context, null, null);
-            Assert.Null(tree.Errors);
-            dynamic projects = ((IDictionary<string, object>)tree.Data)["projects"];
-            Assert.Equal(1, Enumerable.Count(projects));
-            var project = Enumerable.First(projects);
-            Assert.Equal(4, Enumerable.Count(project.tasks));
-            Assert.Equal(4, Enumerable.ElementAt(project.tasks, 0).id);
-            Assert.Equal(3, Enumerable.ElementAt(project.tasks, 1).id);
-            Assert.Equal(2, Enumerable.ElementAt(project.tasks, 2).id);
-            Assert.Equal(1, Enumerable.ElementAt(project.tasks, 3).id);
-        }
-        [Fact]
-        public void SupportUseSortOnNonRoot2()
-        {
-            var schema = SchemaBuilder.FromObject<TestDataContext>();
-            schema.Type<Project>().GetField("tasks", null)
-                .UseSort();
-            var gql = new QueryRequest
+            Variables = new QueryVariables
             {
-                Query = @"query($sort: [ProjectTasksSortInput]) {
+                {
+                    "sort",
+                    new List<IdSort> { new IdSort { Id = SortDirection.DESC } }
+                }
+            }
+        };
+        var context = new TestDataContext().FillWithTestData();
+        var tree = schema.ExecuteRequestWithContext(gql, context, null, null);
+        Assert.Null(tree.Errors);
+        dynamic projects = ((IDictionary<string, object>)tree.Data)["projects"];
+        Assert.Equal(1, Enumerable.Count(projects));
+        var project = Enumerable.First(projects);
+        Assert.Equal(4, Enumerable.Count(project.tasks));
+        Assert.Equal(4, Enumerable.ElementAt(project.tasks, 0).id);
+        Assert.Equal(3, Enumerable.ElementAt(project.tasks, 1).id);
+        Assert.Equal(2, Enumerable.ElementAt(project.tasks, 2).id);
+        Assert.Equal(1, Enumerable.ElementAt(project.tasks, 3).id);
+    }
+
+    [Fact]
+    public void SupportUseSortOnNonRoot2()
+    {
+        var schema = SchemaBuilder.FromObject<TestDataContext>();
+        schema.Type<Project>().GetField("tasks", null).UseSort();
+        var gql = new QueryRequest
+        {
+            Query =
+                @"query($sort: [ProjectTasksSortInput]) {
                     project(id: 55) {
                         tasks(sort: $sort) { id }
                     }
                 }",
-                Variables = new QueryVariables{
-                    { "sort", new [] { new {id = "DESC" } } }
-                }
-            };
-            var context = new TestDataContext().FillWithTestData();
-            var tree = schema.ExecuteRequestWithContext(gql, context, null, null);
-            Assert.Null(tree.Errors);
-            dynamic project = ((IDictionary<string, object>)tree.Data)["project"];
-            Assert.Equal(4, Enumerable.Count(project.tasks));
-            Assert.Equal(4, Enumerable.ElementAt(project.tasks, 0).id);
-            Assert.Equal(3, Enumerable.ElementAt(project.tasks, 1).id);
-            Assert.Equal(2, Enumerable.ElementAt(project.tasks, 2).id);
-            Assert.Equal(1, Enumerable.ElementAt(project.tasks, 3).id);
-        }
+            Variables = new QueryVariables { { "sort", new[] { new { id = "DESC" } } } }
+        };
+        var context = new TestDataContext().FillWithTestData();
+        var tree = schema.ExecuteRequestWithContext(gql, context, null, null);
+        Assert.Null(tree.Errors);
+        dynamic project = ((IDictionary<string, object>)tree.Data)["project"];
+        Assert.Equal(4, Enumerable.Count(project.tasks));
+        Assert.Equal(4, Enumerable.ElementAt(project.tasks, 0).id);
+        Assert.Equal(3, Enumerable.ElementAt(project.tasks, 1).id);
+        Assert.Equal(2, Enumerable.ElementAt(project.tasks, 2).id);
+        Assert.Equal(1, Enumerable.ElementAt(project.tasks, 3).id);
     }
 
-    internal class IdSort
+    [Fact]
+    public void TestSortCustomField()
     {
-        public SortDirection Id { get; set; }
-    }
+        var schema = SchemaBuilder.FromObject<TestDataContext>();
+        var data = new TestDataContext();
+        data.FillWithTestData();
 
-    internal class TestArgs
-    {
-        public SortDirection? lastName { get; set; }
+        schema.UpdateType<Project>(type =>
+        {
+            type.AddField("maxHoursEstimatedForSingleTask", project => project.Tasks.Max(t => t.HoursEstimated), "Get the max hours estimated for a single task");
+        });
+        schema.Query().GetField("projects", null).UseSort(true);
+        var gql = new QueryRequest
+        {
+            Query =
+                @"query {
+                    projects(sort: [{maxHoursEstimatedForSingleTask: ASC}]) {
+                        maxHoursEstimatedForSingleTask
+                    }
+                }",
+        };
+
+        var result = schema.ExecuteRequestWithContext(gql, data, null, null);
+        Assert.Null(result.Errors);
+
+        dynamic projects = result.Data["projects"];
     }
+}
+
+internal class IdSort
+{
+    public SortDirection Id { get; set; }
+}
+
+internal class TestArgs
+{
+    public SortDirection? lastName { get; set; }
 }


### PR DESCRIPTION
Gives an option when using `.UseSort()` to tell it to build the sort argument type from the schema fields of the type we are sorting instead of the dotnet properties.

Addressing #365 