### PR TITLE
fix: use AndAlso for queryparser to match behaviour of older versions

### DIFF
--- a/src/EntityGraphQL/Compiler/EntityQuery/Grammar/EntityQueryParser.cs
+++ b/src/EntityGraphQL/Compiler/EntityQuery/Grammar/EntityQueryParser.cs
@@ -182,8 +182,8 @@ public sealed class EntityQueryParser
                 EqualStr => ExpressionType.Equal,
                 NotEqualStr => ExpressionType.NotEqual,
                 PowerChar => ExpressionType.Power,
-                AndWord => ExpressionType.And,
-                AndStr => ExpressionType.And,
+                AndWord => ExpressionType.AndAlso,
+                AndStr => ExpressionType.AndAlso,
                 OrWord => ExpressionType.Or,
                 OrStr => ExpressionType.Or,
                 _ => throw new NotSupportedException()


### PR DESCRIPTION
Example query:
```
{ 
    users (filter: "isActive == true && isActive == false") { 
        name 
    } 
}
```

5.3.0: 
- Worked as expected, returns no results.
- Generated the following expression:
```
p_EFCoreDemoContext.Users
    .Where(q_User => ((q_User.IsActive == True) AndAlso (q_User.IsActive == False)))
    .Select(p_User => new Dynamic_users_...() {name = p_User.Name})}	
```

5.4.0: 
- Pomelo MySQL Provider throws a MySqlException due to an error in SQL syntax
- However, SqlServer provider continues to behave fine
- This lib generates the following expression, uses of `And` instead of `AndAlso`.
```
p_EFCoreDemoContext.Users
    .Where(q_User => ((q_User.IsActive == True) And (q_User.IsActive == False)))
    .Select(p_User => new Dynamic_users_...() {name = p_User.Name})
```

Can we update the parser to use `AndAlso` again please?