### PR TITLE
fix #398 - do access checks at expression build time not string query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Fixes
 
 - #393 - handle `DateTimeOffset` in filter expressions
+- #398 - make sure user credentials are not cached if using the compiled query cache
 
 # 5.4.1
 

--- a/src/Benchmarks/CacheBenchmarks.cs
+++ b/src/Benchmarks/CacheBenchmarks.cs
@@ -41,7 +41,7 @@ namespace Benchmarks
         [Benchmark]
         public void FirstStageCompile()
         {
-            graphQLCompiler.Compile(gql, new QueryRequestContext(null, null));
+            graphQLCompiler.Compile(gql);
         }
 
         [Benchmark]

--- a/src/EntityGraphQL.AspNet/WebSockets/WebSocketSubscription.cs
+++ b/src/EntityGraphQL.AspNet/WebSockets/WebSocketSubscription.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using EntityGraphQL.Compiler;
+using EntityGraphQL.Schema;
 
 namespace EntityGraphQL.AspNet.WebSockets;
 
@@ -37,7 +38,12 @@ public sealed class WebSocketSubscription<TQueryContext, TEventType> : IDisposab
     {
         try
         {
-            var data = subscriptionStatement.ExecuteSubscriptionEvent<TQueryContext, TEventType>(subscriptionNode, value, server.Context.RequestServices);
+            var data = subscriptionStatement.ExecuteSubscriptionEvent<TQueryContext, TEventType>(
+                subscriptionNode,
+                value,
+                server.Context.RequestServices,
+                new QueryRequestContext(subscriptionStatement.Schema.AuthorizationService, server.Context.User)
+            );
             var result = new QueryResult();
             result.SetData(new Dictionary<string, object?> { { subscriptionNode.Name, data } });
             server.SendNextAsync(OperationId, result).GetAwaiter().GetResult();

--- a/src/EntityGraphQL/Compiler/EntityQuery/EntityQueryCompiler.cs
+++ b/src/EntityGraphQL/Compiler/EntityQuery/EntityQueryCompiler.cs
@@ -81,7 +81,7 @@ namespace EntityGraphQL.Compiler.EntityQuery
             ExecutionOptions executionOptions
         )
         {
-            var compileContext = new CompileContext(executionOptions, null);
+            var compileContext = new CompileContext(executionOptions, null, requestContext);
             var expressionParser = new EntityQueryParser(context, schemaProvider, requestContext, methodProvider, compileContext);
             var expression = expressionParser.Parse(query);
             return expression;

--- a/src/EntityGraphQL/Compiler/GqlNodes/BaseGraphQLField.cs
+++ b/src/EntityGraphQL/Compiler/GqlNodes/BaseGraphQLField.cs
@@ -157,6 +157,8 @@ namespace EntityGraphQL.Compiler
             if (fieldNode == null)
                 return null;
 
+            CheckFieldAccess(compileContext.RequestContext);
+
             return ((BaseGraphQLField)fieldNode).GetFieldExpression(
                 compileContext,
                 serviceProvider,
@@ -390,6 +392,23 @@ namespace EntityGraphQL.Compiler
                 return node.OpName;
             }
             return null;
+        }
+
+        /// <summary>
+        /// Throws exception if the user does not have access to the field or the return type
+        /// </summary>
+        /// <param name="requestContext"></param>
+        internal void CheckFieldAccess(QueryRequestContext requestContext)
+        {
+            if (Field == null || ParentNode == null)
+                return;
+
+            var field = Field.FromType?.GetField(Field.Name, requestContext);
+            if (field != null)
+            {
+                // check type
+                Schema.CheckTypeAccess(field.ReturnType.SchemaType, requestContext);
+            }
         }
     }
 

--- a/src/EntityGraphQL/Compiler/GqlNodes/CompileContext.cs
+++ b/src/EntityGraphQL/Compiler/GqlNodes/CompileContext.cs
@@ -13,11 +13,12 @@ namespace EntityGraphQL.Compiler
         private readonly Dictionary<ParameterExpression, object?> constantParameters = new();
         private readonly Dictionary<IField, ParameterExpression> constantParametersForField = new();
 
-        public CompileContext(ExecutionOptions options, Dictionary<string, object>? bulkData)
+        public CompileContext(ExecutionOptions options, Dictionary<string, object>? bulkData, QueryRequestContext requestContext)
         {
             BulkData = bulkData;
             BulkParameter = bulkData != null ? Expression.Parameter(bulkData.GetType(), "bulkData") : null;
             ExecutionOptions = options;
+            RequestContext = requestContext;
         }
 
         public List<ParameterExpression> Services
@@ -32,6 +33,7 @@ namespace EntityGraphQL.Compiler
         public Dictionary<string, object>? BulkData { get; }
         public ParameterExpression? BulkParameter { get; }
         public ExecutionOptions ExecutionOptions { get; }
+        public QueryRequestContext RequestContext { get; }
 
         public void AddServices(IEnumerable<ParameterExpression> services)
         {

--- a/src/EntityGraphQL/Compiler/GqlNodes/ExecutableGraphQLStatement.cs
+++ b/src/EntityGraphQL/Compiler/GqlNodes/ExecutableGraphQLStatement.cs
@@ -69,7 +69,8 @@ public abstract class ExecutableGraphQLStatement : IGraphQLNode
         List<GraphQLFragmentStatement> fragments,
         Func<string, string> fieldNamer,
         ExecutionOptions options,
-        QueryVariables? variables
+        QueryVariables? variables,
+        QueryRequestContext requestContext
     )
     {
         if (context == null && serviceProvider == null)
@@ -99,7 +100,7 @@ public abstract class ExecutableGraphQLStatement : IGraphQLNode
 #endif
                 var contextToUse = GetContextToUse(context, serviceProvider!, fieldNode)!;
 
-                (var data, var didExecute) = await CompileAndExecuteNodeAsync(new CompileContext(options, null), contextToUse, serviceProvider, fragments, fieldNode, docVariables);
+                (var data, var didExecute) = await CompileAndExecuteNodeAsync(new CompileContext(options, null, requestContext), contextToUse, serviceProvider, fragments, fieldNode, docVariables);
 #if DEBUG
                 if (options.IncludeDebugInfo)
                 {
@@ -211,7 +212,7 @@ public abstract class ExecutableGraphQLStatement : IGraphQLNode
                 var bulkData = ResolveBulkLoaders(compileContext, serviceProvider, node, runningContext, replacer, newContextType);
 
                 // new context
-                compileContext = new(compileContext.ExecutionOptions, bulkData);
+                compileContext = new(compileContext.ExecutionOptions, bulkData, compileContext.RequestContext);
 
                 // we now know the selection type without services and need to build the full select on that type
                 // need to rebuild the full query

--- a/src/EntityGraphQL/Compiler/GqlNodes/GraphQLMutationStatement.cs
+++ b/src/EntityGraphQL/Compiler/GqlNodes/GraphQLMutationStatement.cs
@@ -26,7 +26,8 @@ public class GraphQLMutationStatement : ExecutableGraphQLStatement
         List<GraphQLFragmentStatement> fragments,
         Func<string, string> fieldNamer,
         ExecutionOptions options,
-        QueryVariables? variables
+        QueryVariables? variables,
+        QueryRequestContext requestContext
     )
         where TContext : default
     {
@@ -43,7 +44,7 @@ public class GraphQLMutationStatement : ExecutableGraphQLStatement
 
         // Mutation fields don't directly have services to collect. This is handled after the mutation is executed.
         // When we are building/executing the selection on the mutation result services are handled
-        CompileContext compileContext = new(options, null);
+        CompileContext compileContext = new(options, null, requestContext);
         foreach (var field in QueryFields)
         {
             try

--- a/src/EntityGraphQL/Compiler/GqlNodes/GraphQLQueryStatement.cs
+++ b/src/EntityGraphQL/Compiler/GqlNodes/GraphQLQueryStatement.cs
@@ -19,7 +19,8 @@ public class GraphQLQueryStatement : ExecutableGraphQLStatement
         List<GraphQLFragmentStatement> fragments,
         Func<string, string> fieldNamer,
         ExecutionOptions options,
-        QueryVariables? variables
+        QueryVariables? variables,
+        QueryRequestContext requestContext
     )
         where TContext : default
     {
@@ -30,6 +31,6 @@ public class GraphQLQueryStatement : ExecutableGraphQLStatement
             if (directive.VisitNode(ExecutableDirectiveLocation.QUERY, Schema, this, Arguments, null, null) == null)
                 return Task.FromResult(result);
         }
-        return base.ExecuteAsync(context, serviceProvider, fragments, fieldNamer, options, variables);
+        return base.ExecuteAsync(context, serviceProvider, fragments, fieldNamer, options, variables, requestContext);
     }
 }

--- a/src/EntityGraphQL/Compiler/GqlNodes/GraphQLSubscriptionStatement.cs
+++ b/src/EntityGraphQL/Compiler/GqlNodes/GraphQLSubscriptionStatement.cs
@@ -31,7 +31,8 @@ public class GraphQLSubscriptionStatement : GraphQLMutationStatement
         List<GraphQLFragmentStatement> fragments,
         Func<string, string> fieldNamer,
         ExecutionOptions options,
-        QueryVariables? variables
+        QueryVariables? variables,
+        QueryRequestContext requestContext
     )
         where TContext : default
     {
@@ -50,7 +51,7 @@ public class GraphQLSubscriptionStatement : GraphQLMutationStatement
                 return result;
         }
 
-        CompileContext compileContext = new(options, null);
+        CompileContext compileContext = new(options, null, requestContext);
         foreach (var field in QueryFields)
         {
             try
@@ -110,16 +111,16 @@ public class GraphQLSubscriptionStatement : GraphQLMutationStatement
         return new GraphQLSubscribeResult(returnType, result, this, node);
     }
 
-    public object? ExecuteSubscriptionEvent<TQueryContext, TType>(GraphQLSubscriptionField node, TType eventValue, IServiceProvider serviceProvider)
+    public object? ExecuteSubscriptionEvent<TQueryContext, TType>(GraphQLSubscriptionField node, TType eventValue, IServiceProvider serviceProvider, QueryRequestContext requestContext)
     {
-        return ExecuteSubscriptionEventAsync<TQueryContext, TType>(node, eventValue, serviceProvider).GetAwaiter().GetResult();
+        return ExecuteSubscriptionEventAsync<TQueryContext, TType>(node, eventValue, serviceProvider, requestContext).GetAwaiter().GetResult();
     }
 
-    public Task<object?> ExecuteSubscriptionEventAsync<TQueryContext, TType>(GraphQLSubscriptionField node, TType eventValue, IServiceProvider serviceProvider)
+    public Task<object?> ExecuteSubscriptionEventAsync<TQueryContext, TType>(GraphQLSubscriptionField node, TType eventValue, IServiceProvider serviceProvider, QueryRequestContext requestContext)
     {
         var context = (TQueryContext)serviceProvider.GetRequiredService(typeof(TQueryContext));
 
-        var result = MakeSelectionFromResultAsync(new CompileContext(options!, null), node, node.ResultSelection!, context, serviceProvider, fragments!, docVariables, eventValue);
+        var result = MakeSelectionFromResultAsync(new CompileContext(options!, null, requestContext), node, node.ResultSelection!, context, serviceProvider, fragments!, docVariables, eventValue);
         return result;
     }
 

--- a/src/EntityGraphQL/Compiler/GraphQLCompiler.cs
+++ b/src/EntityGraphQL/Compiler/GraphQLCompiler.cs
@@ -1,62 +1,55 @@
-using System.Security.Claims;
 using EntityGraphQL.Schema;
 using HotChocolate.Language;
 
-namespace EntityGraphQL.Compiler
+namespace EntityGraphQL.Compiler;
+
+/// <summary>
+/// Compiles a Graph QL query document string into an AST for processing.
+/// </summary>
+public class GraphQLCompiler
 {
-    /// <summary>
-    /// Comiles a Graph QL query document string into an AST for processing.
-    /// </summary>
-    public class GraphQLCompiler
+    private readonly ISchemaProvider schemaProvider;
+
+    public GraphQLCompiler(ISchemaProvider schemaProvider)
     {
-        private readonly ISchemaProvider schemaProvider;
+        this.schemaProvider = schemaProvider;
+    }
 
-        public GraphQLCompiler(ISchemaProvider schemaProvider)
+    /// Parses a GraphQL-like query syntax into a tree representing the requested object graph. E.g.
+    /// {
+    ///   entity/query {
+    ///     field1,
+    ///     field2,
+    ///     relation { field }
+    ///   },
+    ///   ...
+    /// }
+    ///
+    /// The returned DataQueryNode is a root node, it's Fields are the top level data queries
+    public GraphQLDocument Compile(string query, QueryVariables? variables = null)
+    {
+        if (variables == null)
         {
-            this.schemaProvider = schemaProvider;
+            variables = new QueryVariables();
         }
+        return Compile(new QueryRequest { Query = query, Variables = variables });
+    }
 
-        /// Parses a GraphQL-like query syntax into a tree respresenting the requested object graph. E.g.
-        /// {
-        ///   entity/query {
-        ///     field1,
-        ///     field2,
-        ///     relation { field }
-        ///   },
-        ///   ...
-        /// }
-        ///
-        /// The returned DataQueryNode is a root node, it's Fields are the top level data queries
-        public GraphQLDocument Compile(string query, QueryVariables? variables = null, IGqlAuthorizationService? authService = null, ClaimsPrincipal? user = null)
-        {
-            if (variables == null)
-            {
-                variables = new QueryVariables();
-            }
-            return Compile(new QueryRequest { Query = query, Variables = variables }, new QueryRequestContext(authService, user));
-        }
+    public GraphQLDocument Compile(string query)
+    {
+        return Compile(new QueryRequest { Query = query });
+    }
 
-        public GraphQLDocument Compile(QueryRequest query, IGqlAuthorizationService? authService = null, ClaimsPrincipal? user = null)
-        {
-            return Compile(query, new QueryRequestContext(authService, user));
-        }
+    public GraphQLDocument Compile(QueryRequest query)
+    {
+        if (query.Query == null)
+            throw new EntityGraphQLCompilerException($"GraphQL Query can not be null");
 
-        public GraphQLDocument Compile(string query, QueryRequestContext context)
-        {
-            return Compile(new QueryRequest { Query = query }, context);
-        }
-
-        public GraphQLDocument Compile(QueryRequest query, QueryRequestContext context)
-        {
-            if (query.Query == null)
-                throw new EntityGraphQLCompilerException($"GraphQL Query can not be null");
-
-            DocumentNode document = Utf8GraphQLParser.Parse(query.Query, ParserOptions.Default);
-            var walker = new EntityGraphQLQueryWalker(schemaProvider, query.Variables, context);
-            walker.Visit(document, null);
-            if (walker.Document == null)
-                throw new EntityGraphQLCompilerException($"Error compiling query: {query.Query}");
-            return walker.Document;
-        }
+        DocumentNode document = Utf8GraphQLParser.Parse(query.Query, ParserOptions.Default);
+        var walker = new EntityGraphQLQueryWalker(schemaProvider, query.Variables);
+        walker.Visit(document, null);
+        if (walker.Document == null)
+            throw new EntityGraphQLCompilerException($"Error compiling query: {query.Query}");
+        return walker.Document;
     }
 }

--- a/src/EntityGraphQL/Schema/BaseSchemaTypeWithFields.cs
+++ b/src/EntityGraphQL/Schema/BaseSchemaTypeWithFields.cs
@@ -89,13 +89,9 @@ namespace EntityGraphQL.Schema
         {
             if (FieldsByName.TryGetValue(identifier, out var field))
             {
-                if (requestContext != null && requestContext.AuthorizationService != null && !requestContext.AuthorizationService.IsAuthorized(requestContext.User, field.RequiredAuthorization))
+                if (requestContext != null && !requestContext.AuthorizationService.IsAuthorized(requestContext.User, field.RequiredAuthorization))
                     throw new EntityGraphQLAccessException($"You are not authorized to access the '{identifier}' field on type '{Name}'.");
-                if (
-                    requestContext != null
-                    && requestContext.AuthorizationService != null
-                    && !requestContext.AuthorizationService.IsAuthorized(requestContext.User, field.ReturnType.SchemaType.RequiredAuthorization)
-                )
+                if (requestContext != null && !requestContext.AuthorizationService.IsAuthorized(requestContext.User, field.ReturnType.SchemaType.RequiredAuthorization))
                     throw new EntityGraphQLAccessException($"You are not authorized to access the '{field.ReturnType.SchemaType.Name}' type returned by field '{identifier}'.");
 
                 return FieldsByName[identifier];
@@ -133,7 +129,7 @@ namespace EntityGraphQL.Schema
         {
             if (FieldsByName.TryGetValue(identifier, out var field))
             {
-                if (requestContext != null && requestContext.AuthorizationService != null && !requestContext.AuthorizationService.IsAuthorized(requestContext.User, field.RequiredAuthorization))
+                if (requestContext != null && !requestContext.AuthorizationService.IsAuthorized(requestContext.User, field.RequiredAuthorization))
                     return false;
 
                 return true;

--- a/src/EntityGraphQL/Schema/ISchemaProvider.cs
+++ b/src/EntityGraphQL/Schema/ISchemaProvider.cs
@@ -79,5 +79,6 @@ namespace EntityGraphQL.Schema
         /// Throws an EntityGraphQLCompilerException if the schema is not valid
         /// </summary>
         void Validate();
+        ISchemaType CheckTypeAccess(ISchemaType schemaType, QueryRequestContext? requestContext);
     }
 }

--- a/src/EntityGraphQL/Schema/QueryRequestContext.cs
+++ b/src/EntityGraphQL/Schema/QueryRequestContext.cs
@@ -1,19 +1,18 @@
 using System.Security.Claims;
 
-namespace EntityGraphQL.Schema
-{
-    /// <summary>
-    /// Holds information about the user executing the current GraphQL request
-    /// </summary>
-    public class QueryRequestContext
-    {
-        public QueryRequestContext(IGqlAuthorizationService? authorizationService, ClaimsPrincipal? user)
-        {
-            AuthorizationService = authorizationService;
-            User = user;
-        }
+namespace EntityGraphQL.Schema;
 
-        public IGqlAuthorizationService? AuthorizationService { get; }
-        public ClaimsPrincipal? User { get; }
+/// <summary>
+/// Holds information about the user executing the current GraphQL request
+/// </summary>
+public class QueryRequestContext
+{
+    public QueryRequestContext(IGqlAuthorizationService? authorizationService, ClaimsPrincipal? user)
+    {
+        AuthorizationService = authorizationService ?? new RoleBasedAuthorization();
+        User = user;
     }
+
+    public IGqlAuthorizationService AuthorizationService { get; }
+    public ClaimsPrincipal? User { get; }
 }

--- a/src/tests/EntityGraphQL.AspNet.Tests/PoliciesTests.cs
+++ b/src/tests/EntityGraphQL.AspNet.Tests/PoliciesTests.cs
@@ -138,7 +138,7 @@ namespace EntityGraphQL.AspNet.Tests
                 new SchemaBuilderSchemaOptions { AuthorizationService = new PolicyOrRoleBasedAuthorization(services.GetService<IAuthorizationService>()!) }
             );
 
-            var claims = new ClaimsIdentity(new[] { new Claim(ClaimTypes.Role, "admin") }, "authed");
+            var claims = new ClaimsIdentity([new Claim(ClaimTypes.Role, "admin")], "authed");
             var gql = new QueryRequest
             {
                 Query =
@@ -149,7 +149,8 @@ namespace EntityGraphQL.AspNet.Tests
 
             var result = schema.ExecuteRequestWithContext(gql, new PolicyDataContext(), services, new ClaimsPrincipal(claims));
 
-            Assert.Equal("You are not authorized to access the 'type' field on type 'Project'.", result.Errors!.First().Message);
+            Assert.NotNull(result.Errors);
+            Assert.Equal("Field 'projects' - You are not authorized to access the 'type' field on type 'Project'.", result.Errors!.First().Message);
 
             claims = new ClaimsIdentity(new[] { new Claim(ClaimTypes.Role, "admin"), new Claim(ClaimTypes.Role, "can-type") }, "authed");
             result = schema.ExecuteRequestWithContext(gql, new PolicyDataContext(), services, new ClaimsPrincipal(claims));
@@ -180,7 +181,7 @@ namespace EntityGraphQL.AspNet.Tests
 
             var result = schema.ExecuteRequestWithContext(gql, new PolicyDataContext(), services, new ClaimsPrincipal(claims));
 
-            Assert.Equal("You are not authorized to access the 'Project' type returned by field 'projects'.", result.Errors!.First().Message);
+            Assert.Equal("Field 'projects' - You are not authorized to access the 'Project' type returned by field 'projects'.", result.Errors!.First().Message);
 
             claims = new ClaimsIdentity(new[] { new Claim(ClaimTypes.Role, "admin") }, "authed");
             result = schema.ExecuteRequestWithContext(gql, new PolicyDataContext(), services, new ClaimsPrincipal(claims));
@@ -213,7 +214,7 @@ namespace EntityGraphQL.AspNet.Tests
 
             var result = schema.ExecuteRequestWithContext(gql, new PolicyDataContext(), services, new ClaimsPrincipal(claims));
 
-            Assert.Equal("You are not authorized to access the 'Project' type returned by field 'project'.", result.Errors!.First().Message);
+            Assert.Equal("Field 'tasks' - You are not authorized to access the 'Project' type returned by field 'project'.", result.Errors!.First().Message);
 
             claims = new ClaimsIdentity(new[] { new Claim(ClaimTypes.Role, "admin") }, "authed");
             result = schema.ExecuteRequestWithContext(gql, new PolicyDataContext(), services, new ClaimsPrincipal(claims));

--- a/src/tests/EntityGraphQL.Tests/EntityQuery/EntityQueryCompilerTests.cs
+++ b/src/tests/EntityGraphQL.Tests/EntityQuery/EntityQueryCompilerTests.cs
@@ -309,7 +309,7 @@ public class EntityQueryCompilerTests
     {
         var schema = SchemaBuilder.FromObject<TestSchema>();
         var param = Expression.Parameter(typeof(Person));
-        var expressionParser = new EntityQueryParser(param, schema, null, null, new CompileContext(executionOptions, null));
+        var expressionParser = new EntityQueryParser(param, schema, null, null, new CompileContext(executionOptions, null, new QueryRequestContext(null, null)));
         var exp = expressionParser.Parse("gender == Female");
         var res = (bool)Expression.Lambda(exp, param).Compile().DynamicInvoke(new Person { Gender = Gender.Female });
         Assert.True(res);

--- a/src/tests/EntityGraphQL.Tests/QueryTests/QueryTests.cs
+++ b/src/tests/EntityGraphQL.Tests/QueryTests/QueryTests.cs
@@ -256,14 +256,13 @@ namespace EntityGraphQL.Tests
         public void TestAliasDeep()
         {
             var tree = new GraphQLCompiler(SchemaBuilder.FromObject<TestDataContext>()).Compile(
-                @"
-        {
-        people { id
-        		projects {
-        			n: name
-        		}
-        	}
-        }"
+                @"{
+                people { id
+                        projects {
+                            n: name
+                        }
+                    }
+                }"
             );
 
             Assert.Single(tree.Operations.First().QueryFields);

--- a/src/tests/EntityGraphQL.Tests/QueryTests/ServiceFieldTests.cs
+++ b/src/tests/EntityGraphQL.Tests/QueryTests/ServiceFieldTests.cs
@@ -1348,7 +1348,7 @@ public class ServiceFieldTests
         var context = new TestDataContext();
         context.FillWithTestData();
 
-        var doc = new GraphQLCompiler(schema).Compile(gql, new QueryRequestContext(null, null));
+        var doc = new GraphQLCompiler(schema).Compile(gql);
 
         Assert.Single(doc.Operations);
         Assert.Single(doc.Operations[0].QueryFields);
@@ -1381,13 +1381,13 @@ public class ServiceFieldTests
 
         // what we want to test here is that ctx.People.FirstOrDefault().Id is pulled up into the pre-services expression
         var graphQLCompiler = new GraphQLCompiler(schema);
-        var compiledQuery = graphQLCompiler.Compile(gql, new QueryRequestContext(null, null));
+        var compiledQuery = graphQLCompiler.Compile(gql);
         var query = compiledQuery.Operations[0];
         var node = query.QueryFields[0];
 
         // first stage without services
         var expression = node.GetNodeExpression(
-            new CompileContext(new ExecutionOptions(), null),
+            new CompileContext(new ExecutionOptions(), null, new QueryRequestContext(null, null)),
             serviceCollection.BuildServiceProvider(),
             [],
             query.OpVariableParameter,

--- a/src/tests/EntityGraphQL.Tests/RoleAuthorizationTests.cs
+++ b/src/tests/EntityGraphQL.Tests/RoleAuthorizationTests.cs
@@ -87,7 +87,7 @@ namespace EntityGraphQL.Tests
 
             var result = schema.ExecuteRequestWithContext(gql, new RolesDataContext(), null, new ClaimsPrincipal(claims));
 
-            Assert.Equal("You are not authorized to access the 'type' field on type 'Project'.", result.Errors.First().Message);
+            Assert.Equal("Field 'projects' - You are not authorized to access the 'type' field on type 'Project'.", result.Errors.First().Message);
 
             claims = new ClaimsIdentity(new[] { new Claim(ClaimTypes.Role, "admin"), new Claim(ClaimTypes.Role, "can-type") }, "authed");
             result = schema.ExecuteRequestWithContext(gql, new RolesDataContext(), null, new ClaimsPrincipal(claims));
@@ -111,7 +111,7 @@ namespace EntityGraphQL.Tests
 
             var result = schema.ExecuteRequestWithContext(gql, new RolesDataContext(), null, new ClaimsPrincipal(claims));
 
-            Assert.Equal("You are not authorized to access the 'Project' type returned by field 'projects'.", result.Errors.First().Message);
+            Assert.Equal("Field 'projects' - You are not authorized to access the 'Project' type returned by field 'projects'.", result.Errors.First().Message);
 
             claims = new ClaimsIdentity(new[] { new Claim(ClaimTypes.Role, "admin") }, "authed");
             result = schema.ExecuteRequestWithContext(gql, new RolesDataContext(), null, new ClaimsPrincipal(claims));
@@ -135,7 +135,7 @@ namespace EntityGraphQL.Tests
             var result = schema.ExecuteRequestWithContext(gql, new RolesDataContext(), null, null);
 
             Assert.NotNull(result.Errors);
-            Assert.Equal("You are not authorized to access the 'Project' type returned by field 'projects'.", result.Errors.First().Message);
+            Assert.Equal("Field 'projects' - You are not authorized to access the 'Project' type returned by field 'projects'.", result.Errors.First().Message);
         }
 
         [Fact]
@@ -156,7 +156,7 @@ namespace EntityGraphQL.Tests
 
             var result = schema.ExecuteRequestWithContext(gql, new RolesDataContext(), null, new ClaimsPrincipal(claims));
 
-            Assert.Equal("You are not authorized to access the 'Project' type returned by field 'project'.", result.Errors.First().Message);
+            Assert.Equal("Field 'tasks' - You are not authorized to access the 'Project' type returned by field 'project'.", result.Errors.First().Message);
 
             claims = new ClaimsIdentity(new[] { new Claim(ClaimTypes.Role, "admin") }, "authed");
             result = schema.ExecuteRequestWithContext(gql, new RolesDataContext(), null, new ClaimsPrincipal(claims));
@@ -182,7 +182,7 @@ namespace EntityGraphQL.Tests
 
             var result = schema.ExecuteRequestWithContext(gql, new RolesDataContext(), null, new ClaimsPrincipal(claims));
 
-            Assert.Equal("You are not authorized to access the 'description' field on type 'Task'.", result.Errors.First().Message);
+            Assert.Equal("Field 'tasks' - You are not authorized to access the 'description' field on type 'Task'.", result.Errors.First().Message);
 
             claims = new ClaimsIdentity(new[] { new Claim(ClaimTypes.Role, "can-description") }, "authed");
             result = schema.ExecuteRequestWithContext(gql, new RolesDataContext(), null, new ClaimsPrincipal(claims));


### PR DESCRIPTION
User credentials were used when compiling from the query string to our nodes. This removes that and does the access checks at expression building time.