### PR TITLE
Add option to ignore specific data annotations

### DIFF
--- a/src/EntityGraphQL/Schema/SchemaBuilder.cs
+++ b/src/EntityGraphQL/Schema/SchemaBuilder.cs
@@ -319,6 +319,12 @@ namespace EntityGraphQL.Schema
                 return false;
             }
 
+            foreach (var attribute in prop.GetCustomAttributes())
+            {
+                if (options.IgnoreDataAnnotations.Contains(attribute.GetType()))
+                    return false;
+            }
+
             return true;
         }
 

--- a/src/EntityGraphQL/Schema/SchemaBuilderOptions.cs
+++ b/src/EntityGraphQL/Schema/SchemaBuilderOptions.cs
@@ -65,6 +65,11 @@ namespace EntityGraphQL.Schema
         /// </summary>
         public bool AddNonAttributedMethodsInControllers { get; set; }
 
+        /// <summary>
+        /// List of DataAnnotation types to ignore when reflecting members.
+        /// </summary>
+        public HashSet<Type> IgnoreDataAnnotations { get; set; } = new();
+
         public OnFieldCreated? OnFieldCreated { get; set; }
     }
 

--- a/src/tests/EntityGraphQL.Tests/SchemaTests/SchemaBuilderFromObjectTests.cs
+++ b/src/tests/EntityGraphQL.Tests/SchemaTests/SchemaBuilderFromObjectTests.cs
@@ -470,6 +470,30 @@ namespace EntityGraphQL.Tests
             Assert.Equal("Field 'hiddenField' not found on type 'Album'", error.Message);
         }
 
+        [Fact]
+        public void TestIgnoreDataAnnotations()
+        {
+            var options = new SchemaBuilderOptions
+            {
+                IgnoreDataAnnotations = new HashSet<Type> { typeof(CustomIgnoreAttribute) }
+            };
+            var schema = SchemaBuilder.FromObject<TestClassWithIgnoredAnnotation>(options);
+
+            Assert.True(schema.Type<TestClassWithIgnoredAnnotation>().HasField("normalField", null));
+            Assert.False(schema.Type<TestClassWithIgnoredAnnotation>().HasField("ignoredField", null));
+        }
+
+        private class CustomIgnoreAttribute : Attribute { }
+
+        private class TestClassWithIgnoredAnnotation
+        {
+            public string NormalField { get; set; }
+
+            [CustomIgnore]
+            public string IgnoredField { get; set; }
+        }
+
+
         private class TestIgnoreTypesSchema
         {
             public IEnumerable<A> As { get; }


### PR DESCRIPTION
This PR adds the ability to ignore specific data annotations when building the schema. 

Key changes:
- Added a new `IgnoreDataAnnotations` property to `SchemaBuilderOptions`
- Updated `SchemaBuilder.ShouldIncludeMember` to check for ignored annotations
- Added a unit test to verify the new functionality

This feature allows users to exclude fields with certain data annotations from the GraphQL schema, providing more flexibility in schema generation.