### PR TITLE
fix #427 - fix ConnectionPaging GetSkipNumber off-by-one when using Before arg, fix handling when Last > BeforeNum

### DIFF
--- a/src/EntityGraphQL/Schema/FieldExtensions/ConnectionPaging/ConnectionEdgeExtension.cs
+++ b/src/EntityGraphQL/Schema/FieldExtensions/ConnectionPaging/ConnectionEdgeExtension.cs
@@ -100,9 +100,10 @@ public class ConnectionEdgeExtension : BaseFieldExtension
                 nameof(EnumerableExtensions.Skip),
                 [listType],
                 expression,
-                Expression.Call(typeof(ConnectionHelper), nameof(ConnectionHelper.GetSkipNumber), null, argumentParam)
+                Expression.Call(typeof(ConnectionHelper), nameof(ConnectionHelper.GetSkipNumber), null, argumentParam, Expression.Constant(true))
             ),
-            Expression.Call(typeof(ConnectionHelper), nameof(ConnectionHelper.GetTakeNumber), null, argumentParam)
+            Expression.Call(typeof(ConnectionHelper), nameof(ConnectionHelper.GetTakeNumber), null, argumentParam,
+                Expression.Call(typeof(ConnectionHelper), nameof(ConnectionHelper.GetSkipNumber), null, argumentParam, Expression.Constant(false)))
         );
 
         // we have moved the expression from the parent node to here. We need to call the before callback
@@ -175,6 +176,7 @@ public class ConnectionEdgeExtension : BaseFieldExtension
         );
 
         var idxParam = Expression.Parameter(typeof(int), "cursor_idx");
+        var offsetParam = Expression.Call(typeof(ConnectionHelper), nameof(ConnectionHelper.GetSkipNumber), null, argumentParam, Expression.Constant(false));
         // now select with cursor
         baseExpression = Expression.Call(
             typeof(Enumerable),
@@ -187,7 +189,7 @@ public class ConnectionEdgeExtension : BaseFieldExtension
                     new List<MemberBinding>
                     {
                         Expression.Bind(edgeType.GetProperty("Node")!, Expression.PropertyOrField(edgeParam, "Node")),
-                        Expression.Bind(edgeType.GetProperty("Cursor")!, Expression.Call(typeof(ConnectionHelper), "GetCursor", null, argumentParam, idxParam))
+                        Expression.Bind(edgeType.GetProperty("Cursor")!, Expression.Call(typeof(ConnectionHelper), "GetCursor", null, argumentParam, idxParam, offsetParam))
                     }
                 ),
                 edgeParam,

--- a/src/tests/EntityGraphQL.Tests/ConnectionPaging/SkipTakeTests.cs
+++ b/src/tests/EntityGraphQL.Tests/ConnectionPaging/SkipTakeTests.cs
@@ -57,7 +57,22 @@ namespace EntityGraphQL.Tests.ConnectionPaging
             Assert.Equal(4, take);
 
             var skip = ConnectionHelper.GetSkipNumber(args);
-            Assert.Equal(3, skip);
+            Assert.Equal(2, skip);
+        }
+
+        [Fact]
+        public void TestLastAndBefore_WhenLastGreaterThanBeforeNum()
+        {
+            var args = new ConnectionArgs { Last = 4, BeforeNum = 2, };
+
+            var skip = ConnectionHelper.GetSkipNumber(args);
+            Assert.Equal(0, skip);
+            
+            var offset = ConnectionHelper.GetSkipNumber(args, false);
+
+            var take = ConnectionHelper.GetTakeNumber(args, offset);
+            Assert.Equal(1, take);
+
         }
 
         [Fact]


### PR DESCRIPTION
I've been sitting on this one for a few (16) months. I figured I might as well push it up when I saw an issue come in for it.