### PR TITLE
fix: replace bitwise "ExpressionType.Or" with conditional OrElse

### DIFF
--- a/src/EntityGraphQL/Compiler/EntityQuery/Grammar/EntityQueryParser.cs
+++ b/src/EntityGraphQL/Compiler/EntityQuery/Grammar/EntityQueryParser.cs
@@ -182,8 +182,8 @@ public sealed class EntityQueryParser
                 PowerChar => ExpressionType.Power,
                 AndWord => ExpressionType.AndAlso,
                 AndStr => ExpressionType.AndAlso,
-                OrWord => ExpressionType.Or,
-                OrStr => ExpressionType.Or,
+                OrWord => ExpressionType.OrElse,
+                OrStr => ExpressionType.OrElse,
                 _ => throw new NotSupportedException()
             };
             binaryExp = new Binary(op, left, right);


### PR DESCRIPTION
Assuming the use of bitwise `ExpressionType.Or` was not deliberate. I think `ExpressionType.OrElse` is the correct expression type here :)