### PR TITLE
PropertySetTrackingDto, Arguments as Dictinary<string,object?>

### DIFF
--- a/src/EntityGraphQL/Compiler/EntityGraphQLQueryWalker.cs
+++ b/src/EntityGraphQL/Compiler/EntityGraphQLQueryWalker.cs
@@ -132,7 +132,7 @@ internal sealed class EntityGraphQLQueryWalker : QuerySyntaxWalker<IGraphQLNode?
                 var directives = ProcessFieldDirectives(ExecutableDirectiveLocation.VARIABLE_DEFINITION, item.Directives);
                 foreach (var directive in directives)
                 {
-                    directive.VisitNode(ExecutableDirectiveLocation.VARIABLE_DEFINITION, schemaProvider, null, new Dictionary<string, object>(), null, null);
+                    directive.VisitNode(ExecutableDirectiveLocation.VARIABLE_DEFINITION, schemaProvider, null, new Dictionary<string, object?>(), null, null);
                 }
             }
 
@@ -282,7 +282,7 @@ internal sealed class EntityGraphQLQueryWalker : QuerySyntaxWalker<IGraphQLNode?
         }
     }
 
-    public BaseGraphQLQueryField ParseFieldSelect(Expression fieldExp, IField fieldContext, string name, IGraphQLNode context, SelectionSetNode selection, Dictionary<string, object>? arguments)
+    public BaseGraphQLQueryField ParseFieldSelect(Expression fieldExp, IField fieldContext, string name, IGraphQLNode context, SelectionSetNode selection, Dictionary<string, object?>? arguments)
     {
         if (fieldContext.ReturnType.IsList)
         {
@@ -317,7 +317,7 @@ internal sealed class EntityGraphQLQueryWalker : QuerySyntaxWalker<IGraphQLNode?
         string resultName,
         IGraphQLNode context,
         SelectionSetNode selection,
-        Dictionary<string, object>? arguments
+        Dictionary<string, object?>? arguments
     )
     {
         if (context == null)
@@ -346,7 +346,7 @@ internal sealed class EntityGraphQLQueryWalker : QuerySyntaxWalker<IGraphQLNode?
         IGraphQLNode context,
         string name,
         SelectionSetNode selection,
-        Dictionary<string, object>? arguments
+        Dictionary<string, object?>? arguments
     )
     {
         if (context == null)
@@ -362,9 +362,9 @@ internal sealed class EntityGraphQLQueryWalker : QuerySyntaxWalker<IGraphQLNode?
         return graphQLNode;
     }
 
-    private Dictionary<string, object> ProcessArguments(IField field, IEnumerable<ArgumentNode> queryArguments)
+    private Dictionary<string, object?> ProcessArguments(IField field, IEnumerable<ArgumentNode> queryArguments)
     {
-        var args = new Dictionary<string, object>();
+        var args = new Dictionary<string, object?>();
         foreach (var arg in queryArguments)
         {
             var argName = arg.Name.Value;
@@ -373,7 +373,7 @@ internal sealed class EntityGraphQLQueryWalker : QuerySyntaxWalker<IGraphQLNode?
                 throw new EntityGraphQLCompilerException($"No argument '{argName}' found on field '{field.Name}'");
             }
             var r = ParseArgument(argName, field, arg);
-            if (r != null)
+            //if (r != null)
                 args.Add(argName, r);
         }
         return args;
@@ -415,7 +415,7 @@ internal sealed class EntityGraphQLQueryWalker : QuerySyntaxWalker<IGraphQLNode?
             if (!processor.Location.Contains(location))
                 throw new EntityGraphQLCompilerException($"Directive '{directive.Name.Value}' can not be used on '{location}'");
             var argTypes = processor.GetArguments(schemaProvider);
-            var args = new Dictionary<string, object>();
+            var args = new Dictionary<string, object?>();
             foreach (var arg in directive.Arguments)
             {
                 var argVal = ProcessArgumentOrVariable(arg.Name.Value, schemaProvider, arg, argTypes[arg.Name.Value].RawType);
@@ -441,7 +441,7 @@ internal sealed class EntityGraphQLQueryWalker : QuerySyntaxWalker<IGraphQLNode?
         {
             foreach (var directive in ProcessFieldDirectives(ExecutableDirectiveLocation.FRAGMENT_DEFINITION, node.Directives))
             {
-                directive.VisitNode(ExecutableDirectiveLocation.FRAGMENT_DEFINITION, schemaProvider, fragDef, new Dictionary<string, object>(), null, null);
+                directive.VisitNode(ExecutableDirectiveLocation.FRAGMENT_DEFINITION, schemaProvider, fragDef, new Dictionary<string, object?>(), null, null);
             }
         }
 

--- a/src/EntityGraphQL/Compiler/EntityGraphQLQueryWalker.cs
+++ b/src/EntityGraphQL/Compiler/EntityGraphQLQueryWalker.cs
@@ -372,9 +372,7 @@ internal sealed class EntityGraphQLQueryWalker : QuerySyntaxWalker<IGraphQLNode?
             {
                 throw new EntityGraphQLCompilerException($"No argument '{argName}' found on field '{field.Name}'");
             }
-            var r = ParseArgument(argName, field, arg);
-            //if (r != null)
-                args.Add(argName, r);
+            args.Add(argName, ParseArgument(argName, field, arg));
         }
         return args;
     }

--- a/src/EntityGraphQL/Compiler/EntityQuery/Grammar/IdentityExpression.cs
+++ b/src/EntityGraphQL/Compiler/EntityQuery/Grammar/IdentityExpression.cs
@@ -43,7 +43,7 @@ public class IdentityExpression(string name, CompileContext compileContext) : IE
             return Expression.Constant(Enum.Parse(schemaType.TypeDotnet, name));
         }
         var gqlField = schemaType.GetField(name, requestContext);
-        (var exp, _) = gqlField.GetExpression(gqlField.ResolveExpression!, context, null, null, compileContext, new Dictionary<string, object>(), null, null, [], false, new Util.ParameterReplacer());
+        (var exp, _) = gqlField.GetExpression(gqlField.ResolveExpression!, context, null, null, compileContext, new Dictionary<string, object?>(), null, null, [], false, new Util.ParameterReplacer());
         return exp!;
     }
 

--- a/src/EntityGraphQL/Compiler/GqlNodes/BaseGraphQLField.cs
+++ b/src/EntityGraphQL/Compiler/GqlNodes/BaseGraphQLField.cs
@@ -63,7 +63,7 @@ public abstract class BaseGraphQLField : IGraphQLNode, IFieldKey
     /// <summary>
     /// Arguments from inline in the query - not $ variables
     /// </summary>
-    public IReadOnlyDictionary<string, object> Arguments { get; }
+    public IReadOnlyDictionary<string, object?> Arguments { get; }
 
     /// <summary>
     /// True if this field directly has services
@@ -77,14 +77,14 @@ public abstract class BaseGraphQLField : IGraphQLNode, IFieldKey
         Expression? nextFieldContext,
         ParameterExpression? rootParameter,
         IGraphQLNode? parentNode,
-        IReadOnlyDictionary<string, object>? arguments
+        IReadOnlyDictionary<string, object?>? arguments
     )
     {
         Name = name;
         NextFieldContext = nextFieldContext;
         RootParameter = rootParameter;
         ParentNode = parentNode;
-        this.Arguments = arguments ?? new Dictionary<string, object>();
+        this.Arguments = arguments ?? new Dictionary<string, object?>();
         this.Schema = schema;
         Field = field;
     }

--- a/src/EntityGraphQL/Compiler/GqlNodes/BaseGraphQLQueryField.cs
+++ b/src/EntityGraphQL/Compiler/GqlNodes/BaseGraphQLQueryField.cs
@@ -28,7 +28,7 @@ public abstract class BaseGraphQLQueryField : BaseGraphQLField
         Expression? nextFieldContext,
         ParameterExpression? rootParameter,
         IGraphQLNode? parentNode,
-        IReadOnlyDictionary<string, object>? arguments
+        IReadOnlyDictionary<string, object?>? arguments
     )
         : base(schema, field, name, nextFieldContext, rootParameter, parentNode, arguments) { }
 

--- a/src/EntityGraphQL/Compiler/GqlNodes/CompileContext.cs
+++ b/src/EntityGraphQL/Compiler/GqlNodes/CompileContext.cs
@@ -63,7 +63,7 @@ public class CompileContext
 
     public void AddArgsToCompileContext(
         IField field,
-        IReadOnlyDictionary<string, object> args,
+        IReadOnlyDictionary<string, object?> args,
         ParameterExpression? docParam,
         object? docVariables,
         ref object? argumentValue,

--- a/src/EntityGraphQL/Compiler/GqlNodes/ExecutableGraphQLStatement.cs
+++ b/src/EntityGraphQL/Compiler/GqlNodes/ExecutableGraphQLStatement.cs
@@ -33,7 +33,7 @@ public abstract class ExecutableGraphQLStatement : IGraphQLNode
     public IField? Field { get; }
     public bool HasServices => Field?.Services.Count > 0;
 
-    public IReadOnlyDictionary<string, object> Arguments { get; }
+    public IReadOnlyDictionary<string, object?> Arguments { get; }
 
     public string? Name { get; }
 
@@ -52,7 +52,7 @@ public abstract class ExecutableGraphQLStatement : IGraphQLNode
         RootParameter = rootParameter;
         OpDefinedVariables = opVariables;
         this.Schema = schema;
-        Arguments = new Dictionary<string, object>();
+        Arguments = new Dictionary<string, object?>();
         if (OpDefinedVariables.Count > 0)
         {
             var variableType = LinqRuntimeTypeBuilder.GetDynamicType(OpDefinedVariables.ToDictionary(f => f.Key, f => f.Value.RawType), "docVars");

--- a/src/EntityGraphQL/Compiler/GqlNodes/GraphQLDirective.cs
+++ b/src/EntityGraphQL/Compiler/GqlNodes/GraphQLDirective.cs
@@ -9,10 +9,10 @@ namespace EntityGraphQL.Compiler;
 public class GraphQLDirective
 {
     private readonly IDirectiveProcessor processor;
-    private readonly Dictionary<string, object> inlineArgValues;
+    private readonly Dictionary<string, object?> inlineArgValues;
     private readonly string name;
 
-    public GraphQLDirective(string name, IDirectiveProcessor processor, Dictionary<string, object> inlineArgValues)
+    public GraphQLDirective(string name, IDirectiveProcessor processor, Dictionary<string, object?> inlineArgValues)
     {
         this.processor = processor;
         this.inlineArgValues = inlineArgValues;
@@ -23,7 +23,7 @@ public class GraphQLDirective
         ExecutableDirectiveLocation location,
         ISchemaProvider schema,
         IGraphQLNode? node,
-        IReadOnlyDictionary<string, object> args,
+        IReadOnlyDictionary<string, object?> args,
         ParameterExpression? docParam,
         object? docVariables
     )
@@ -33,7 +33,7 @@ public class GraphQLDirective
             schema,
             name,
             null,
-            inlineArgValues.MergeNew(args),
+            inlineArgValues.MergeNewNullable(args),
             processor.GetArguments(schema).Values,
             processor.GetArgumentsType(),
             docParam,

--- a/src/EntityGraphQL/Compiler/GqlNodes/GraphQLDocument.cs
+++ b/src/EntityGraphQL/Compiler/GqlNodes/GraphQLDocument.cs
@@ -49,7 +49,7 @@ public class GraphQLDocument : IGraphQLNode
         Schema = schema;
         Operations = [];
         Fragments = [];
-        Arguments = new Dictionary<string, object>();
+        Arguments = new Dictionary<string, object?>();
     }
 
     public string Name => "Query Request Root";
@@ -57,7 +57,7 @@ public class GraphQLDocument : IGraphQLNode
     public IField? Field { get; }
     public bool HasServices => Field?.Services.Count > 0;
 
-    public IReadOnlyDictionary<string, object> Arguments { get; }
+    public IReadOnlyDictionary<string, object?> Arguments { get; }
 
     public ISchemaProvider Schema { get; }
 

--- a/src/EntityGraphQL/Compiler/GqlNodes/GraphQLFragmentStatement.cs
+++ b/src/EntityGraphQL/Compiler/GqlNodes/GraphQLFragmentStatement.cs
@@ -14,7 +14,7 @@ public class GraphQLFragmentStatement : IGraphQLNode
     public IField? Field { get; }
     public bool HasServices => Field?.Services.Count > 0;
 
-    public IReadOnlyDictionary<string, object> Arguments { get; }
+    public IReadOnlyDictionary<string, object?> Arguments { get; }
 
     public string Name { get; }
 
@@ -28,7 +28,7 @@ public class GraphQLFragmentStatement : IGraphQLNode
         Name = name;
         NextFieldContext = selectContext;
         RootParameter = rootParameter;
-        Arguments = new Dictionary<string, object>();
+        Arguments = new Dictionary<string, object?>();
         Schema = schema;
     }
 

--- a/src/EntityGraphQL/Compiler/GqlNodes/GraphQLListSelectionField.cs
+++ b/src/EntityGraphQL/Compiler/GqlNodes/GraphQLListSelectionField.cs
@@ -42,7 +42,7 @@ public class GraphQLListSelectionField : BaseGraphQLQueryField
         ParameterExpression? rootParameter,
         Expression nodeExpression,
         IGraphQLNode context,
-        Dictionary<string, object>? arguments
+        Dictionary<string, object?>? arguments
     )
         : base(schema, field, name, nextFieldContext, rootParameter, context, arguments)
     {

--- a/src/EntityGraphQL/Compiler/GqlNodes/GraphQLMutationField.cs
+++ b/src/EntityGraphQL/Compiler/GqlNodes/GraphQLMutationField.cs
@@ -17,7 +17,7 @@ public class GraphQLMutationField : BaseGraphQLQueryField
         ISchemaProvider schema,
         string name,
         MutationField mutationField,
-        Dictionary<string, object>? args,
+        Dictionary<string, object?>? args,
         Expression nextFieldContext,
         ParameterExpression rootParameter,
         IGraphQLNode parentNode

--- a/src/EntityGraphQL/Compiler/GqlNodes/GraphQLObjectProjectionField.cs
+++ b/src/EntityGraphQL/Compiler/GqlNodes/GraphQLObjectProjectionField.cs
@@ -39,7 +39,7 @@ public class GraphQLObjectProjectionField : BaseGraphQLQueryField
         Expression nextFieldContext,
         ParameterExpression rootParameter,
         IGraphQLNode parentNode,
-        IReadOnlyDictionary<string, object>? arguments
+        IReadOnlyDictionary<string, object?>? arguments
     )
         : base(schema, field, name, nextFieldContext, rootParameter, parentNode, arguments) { }
 

--- a/src/EntityGraphQL/Compiler/GqlNodes/GraphQLScalarField.cs
+++ b/src/EntityGraphQL/Compiler/GqlNodes/GraphQLScalarField.cs
@@ -15,7 +15,7 @@ public class GraphQLScalarField : BaseGraphQLField
         Expression nextFieldContext,
         ParameterExpression? rootParameter,
         IGraphQLNode parentNode,
-        IReadOnlyDictionary<string, object>? arguments
+        IReadOnlyDictionary<string, object?>? arguments
     )
         : base(schema, field, name, nextFieldContext, rootParameter, parentNode, arguments) { }
 

--- a/src/EntityGraphQL/Compiler/GqlNodes/GraphQLSubscriptionField.cs
+++ b/src/EntityGraphQL/Compiler/GqlNodes/GraphQLSubscriptionField.cs
@@ -17,7 +17,7 @@ public class GraphQLSubscriptionField : BaseGraphQLQueryField
         ISchemaProvider schema,
         string name,
         SubscriptionField subscriptionField,
-        Dictionary<string, object>? args,
+        Dictionary<string, object?>? args,
         Expression nextFieldContext,
         ParameterExpression rootParameter,
         IGraphQLNode parentNode

--- a/src/EntityGraphQL/Compiler/GqlNodes/IGraphQLNode.cs
+++ b/src/EntityGraphQL/Compiler/GqlNodes/IGraphQLNode.cs
@@ -28,7 +28,7 @@ public interface IGraphQLNode
     void AddField(BaseGraphQLField field);
     IField? Field { get; }
     bool HasServices { get; }
-    IReadOnlyDictionary<string, object> Arguments { get; }
+    IReadOnlyDictionary<string, object?> Arguments { get; }
     void AddDirectives(IEnumerable<GraphQLDirective> graphQLDirectives);
 
     /// <summary>

--- a/src/EntityGraphQL/Compiler/Util/ArgumentUtil.cs
+++ b/src/EntityGraphQL/Compiler/Util/ArgumentUtil.cs
@@ -14,7 +14,7 @@ public static class ArgumentUtil
         ISchemaProvider schema,
         string fieldName,
         IField? field,
-        IReadOnlyDictionary<string, object> args,
+        IReadOnlyDictionary<string, object?> args,
         IEnumerable<ArgType> argumentDefinitions,
         Type? argumentsType,
         ParameterExpression? docParam,
@@ -122,7 +122,7 @@ public static class ArgumentUtil
 
     internal static object? BuildArgumentFromMember(
         ISchemaProvider schema,
-        IReadOnlyDictionary<string, object>? args,
+        IReadOnlyDictionary<string, object?>? args,
         string memberName,
         Type memberType,
         object? defaultValue,
@@ -139,6 +139,10 @@ public static class ArgumentUtil
                 return null;
             }
             var item = args[argName];
+            if(item is null)
+            {
+                return null;
+            }
             var constructor = memberType.GetConstructor(new[] { item.GetType() });
             if (constructor == null)
             {

--- a/src/EntityGraphQL/Extensions/DictionaryExtensions.cs
+++ b/src/EntityGraphQL/Extensions/DictionaryExtensions.cs
@@ -15,4 +15,15 @@ public static class DictionaryExtensions
 
         return result;
     }
+
+    public static Dictionary<TKey, TElement?> MergeNewNullable<TKey, TElement>(this IDictionary<TKey, TElement?> source, IReadOnlyDictionary<TKey, TElement?>? other)
+        where TKey : notnull
+    {
+        var result = source != null ? source.ToDictionary(kvp => kvp.Key, kvp => kvp.Value) : [];
+        if (other != null)
+            foreach (var kvp in other)
+                result[kvp.Key] = kvp.Value;
+
+        return result;
+    }
 }

--- a/src/EntityGraphQL/Schema/BaseField.cs
+++ b/src/EntityGraphQL/Schema/BaseField.cs
@@ -105,7 +105,7 @@ public abstract class BaseField : IField
         IGraphQLNode? parentNode,
         ParameterExpression? schemaContext,
         CompileContext compileContext,
-        IReadOnlyDictionary<string, object> args,
+        IReadOnlyDictionary<string, object?> args,
         ParameterExpression? docParam,
         object? docVariables,
         IEnumerable<GraphQLDirective> directives,

--- a/src/EntityGraphQL/Schema/Field.cs
+++ b/src/EntityGraphQL/Schema/Field.cs
@@ -167,7 +167,7 @@ public class Field : BaseField
         IGraphQLNode? parentNode,
         ParameterExpression? schemaContext,
         CompileContext compileContext,
-        IReadOnlyDictionary<string, object> args,
+        IReadOnlyDictionary<string, object?> args,
         ParameterExpression? docParam,
         object? docVariables,
         IEnumerable<GraphQLDirective> directives,
@@ -196,7 +196,7 @@ public class Field : BaseField
     }
 
     private (Expression? fieldExpression, ParameterExpression? argumentParam) PrepareFieldExpression(
-        IReadOnlyDictionary<string, object> args,
+        IReadOnlyDictionary<string, object?> args,
         Expression fieldExpression,
         ParameterReplacer replacer,
         Expression context,

--- a/src/EntityGraphQL/Schema/IField.cs
+++ b/src/EntityGraphQL/Schema/IField.cs
@@ -93,7 +93,7 @@ public interface IField
         IGraphQLNode? parentNode,
         ParameterExpression? schemaContext,
         CompileContext compileContext,
-        IReadOnlyDictionary<string, object> args,
+        IReadOnlyDictionary<string, object?> args,
         ParameterExpression? docParam,
         object? docVariables,
         IEnumerable<GraphQLDirective> directives,

--- a/src/EntityGraphQL/Schema/MethodField.cs
+++ b/src/EntityGraphQL/Schema/MethodField.cs
@@ -102,9 +102,9 @@ public abstract class MethodField : BaseField
                 )!;
                 allArgs.Add(argInstance);
 
-                if (p.ParameterType.BaseType == typeof(PropertySetTrackingDto))
+                if (typeof(IPropertySetTrackingDto).IsAssignableFrom(p.ParameterType))
                 {
-                    ((PropertySetTrackingDto)argInstance).MarkAsSet(gqlRequestArgs?.Keys ?? []);
+                    ((IPropertySetTrackingDto)argInstance).MarkAsSet((gqlRequestArgs ?? new Dictionary<string, object?>()).Keys);
                 }
             }
             else if (gqlRequestArgs != null && Arguments.TryGetValue(p.Name!, out var argField))

--- a/src/EntityGraphQL/Schema/MethodField.cs
+++ b/src/EntityGraphQL/Schema/MethodField.cs
@@ -108,17 +108,7 @@ public abstract class MethodField : BaseField
                 }
             }
             else if (gqlRequestArgs != null && Arguments.TryGetValue(p.Name!, out var argField))
-            {
-                //Dictionary<string, object> nonNullGqlRequestArgs = new();
-                //foreach (var arg in gqlRequestArgs)
-                //{
-                //    if (arg.Value is null)
-                //    {
-                //        continue;
-                //    }
-                //    nonNullGqlRequestArgs.Add(arg.Key, arg.Value);
-                //}
-                
+            {               
                 var value = ArgumentUtil.BuildArgumentFromMember(Schema, gqlRequestArgs, argField.Name, argField.RawType, argField.DefaultValue, validationErrors);
                 if (docVariables != null)
                 {

--- a/src/EntityGraphQL/Schema/MethodField.cs
+++ b/src/EntityGraphQL/Schema/MethodField.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
 using System.Threading.Tasks;
@@ -65,7 +66,7 @@ public abstract class MethodField : BaseField
 
     public virtual async Task<object?> CallAsync(
         object? context,
-        IReadOnlyDictionary<string, object>? gqlRequestArgs,
+        IReadOnlyDictionary<string, object?>? gqlRequestArgs,
         IServiceProvider? serviceProvider,
         ParameterExpression? variableParameter,
         object? docVariables,
@@ -80,6 +81,7 @@ public abstract class MethodField : BaseField
         var argsToValidate = new Dictionary<string, object>();
         object? argInstance = null;
         var validationErrors = new List<string>();
+        var setProperties = new List<string>();
 
         // add parameters and any DI services
         foreach (var p in Method.GetParameters())
@@ -91,7 +93,7 @@ public abstract class MethodField : BaseField
                     Schema,
                     Name,
                     this,
-                    gqlRequestArgs ?? new Dictionary<string, object>(),
+                    gqlRequestArgs ?? new Dictionary<string, object?>(),
                     Arguments.Values,
                     p.ParameterType,
                     variableParameter,
@@ -99,9 +101,24 @@ public abstract class MethodField : BaseField
                     validationErrors
                 )!;
                 allArgs.Add(argInstance);
+
+                if (p.ParameterType.BaseType == typeof(PropertySetTrackingDto))
+                {
+                    ((PropertySetTrackingDto)argInstance).MarkAsSet(gqlRequestArgs?.Keys ?? []);
+                }
             }
             else if (gqlRequestArgs != null && Arguments.TryGetValue(p.Name!, out var argField))
             {
+                //Dictionary<string, object> nonNullGqlRequestArgs = new();
+                //foreach (var arg in gqlRequestArgs)
+                //{
+                //    if (arg.Value is null)
+                //    {
+                //        continue;
+                //    }
+                //    nonNullGqlRequestArgs.Add(arg.Key, arg.Value);
+                //}
+                
                 var value = ArgumentUtil.BuildArgumentFromMember(Schema, gqlRequestArgs, argField.Name, argField.RawType, argField.DefaultValue, validationErrors);
                 if (docVariables != null)
                 {
@@ -193,7 +210,7 @@ public abstract class MethodField : BaseField
         IGraphQLNode? parentNode,
         ParameterExpression? schemaContext,
         CompileContext? compileContext,
-        IReadOnlyDictionary<string, object> args,
+        IReadOnlyDictionary<string, object?> args,
         ParameterExpression? docParam,
         object? docVariables,
         IEnumerable<GraphQLDirective> directives,

--- a/src/EntityGraphQL/Schema/PropertyTracker/IPropertySetTrackingDto.cs
+++ b/src/EntityGraphQL/Schema/PropertyTracker/IPropertySetTrackingDto.cs
@@ -1,0 +1,9 @@
+﻿using System.Collections.Generic;
+
+namespace EntityGraphQL.Schema;
+public interface IPropertySetTrackingDto
+{
+    bool IsSet(string propertyName);
+    void MarkAsSet(IEnumerable<string> propertiesName);
+    void MarkAsSet(string propertyName);
+}

--- a/src/EntityGraphQL/Schema/PropertyTracker/PropertySetTrackingDto.cs
+++ b/src/EntityGraphQL/Schema/PropertyTracker/PropertySetTrackingDto.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace EntityGraphQL.Schema;
+
+public class PropertySetTrackingDto : IPropertySetTrackingDto
+{
+    private HashSet<string> setProperties = new(StringComparer.OrdinalIgnoreCase);
+
+    public void MarkAsSet(string propertyName) => setProperties.Add(propertyName);
+    public void MarkAsSet(IEnumerable<string> propertiesName)
+    {
+        foreach (var prop in propertiesName)
+        {
+            setProperties.Add(prop);
+        }
+    }
+
+    public bool IsSet(string propertyName) => setProperties.Contains(propertyName);
+}

--- a/src/examples/demo/Mutations/DemoMutations.cs
+++ b/src/examples/demo/Mutations/DemoMutations.cs
@@ -73,39 +73,23 @@ public class DemoMutations
             return null;
         }
 
-        if (args.IsSet(nameof(args.Name)))
-        {
-            if (!string.IsNullOrEmpty(args.Name))
-            {
-                movie.Name = args.Name;
-            }
-        }
-        if (args.IsSet(nameof(args.Genre)))
-        {
-            if (args.Genre.HasValue)
-            {
-                movie.Genre = args.Genre.Value;
-            }
-        }
-        if (args.IsSet(nameof(args.Released)))
-        {
-            if (args.Released.HasValue)
-            {
-                movie.Released = args.Released.Value;
-            }
-        }
-        if (args.IsSet(nameof(args.Rating)))
-        {
-            if (args.Rating.HasValue)
-            {
-                movie.Rating = args.Rating.Value;
-            }
-        }
         // Cannot be null if not set
         if (args.IsSet(nameof(args.DirectorId)))
-        {
             movie.DirectorId = args.DirectorId;
-        }
+
+        if (!string.IsNullOrEmpty(args.Name))
+            movie.Name = args.Name;    
+   
+        if (args.Genre.HasValue)
+            movie.Genre = args.Genre.Value;
+        
+   
+        if (args.Released.HasValue)
+            movie.Released = args.Released.Value;
+        
+
+        if (args.Rating.HasValue)
+            movie.Rating = args.Rating.Value;
 
         db.Movies.Update(movie);
         db.SaveChanges();
@@ -224,12 +208,6 @@ public class UpdateMovieArgs : PropertySetTrackingDto
     public DateTime? Released;
     public uint? DirectorId { get; set; }
 }
-
-public class MovideDirector
-{
-    public long Id { get; set; }
-}
-
 
 public class AddActorArgs
 {

--- a/src/examples/demo/Mutations/DemoMutations.cs
+++ b/src/examples/demo/Mutations/DemoMutations.cs
@@ -62,6 +62,56 @@ public class DemoMutations
         return ctx => ctx.Movies.First(m => m.Id == movie.Id);
     }
 
+
+    [GraphQLMutation("Add a new Movie object")]
+    public Expression<Func<DemoContext, Movie>>? UpdateMovie(DemoContext db, UpdateMovieArgs args, IGraphQLValidator validator)
+    {
+        var movie = db.Movies.FirstOrDefault(x => x.Id == args.Id);
+        if(movie is null)
+        {
+            validator.AddError("Movie not found");
+            return null;
+        }
+
+        if (args.IsSet(nameof(args.Name)))
+        {
+            if (!string.IsNullOrEmpty(args.Name))
+            {
+                movie.Name = args.Name;
+            }
+        }
+        if (args.IsSet(nameof(args.Genre)))
+        {
+            if (args.Genre.HasValue)
+            {
+                movie.Genre = args.Genre.Value;
+            }
+        }
+        if (args.IsSet(nameof(args.Released)))
+        {
+            if (args.Released.HasValue)
+            {
+                movie.Released = args.Released.Value;
+            }
+        }
+        if (args.IsSet(nameof(args.Rating)))
+        {
+            if (args.Rating.HasValue)
+            {
+                movie.Rating = args.Rating.Value;
+            }
+        }
+        // Cannot be null if not set
+        if (args.IsSet(nameof(args.DirectorId)))
+        {
+            movie.DirectorId = args.DirectorId;
+        }
+
+        db.Movies.Update(movie);
+        db.SaveChanges();
+        return ctx => ctx.Movies.First(m => m.Id == movie.Id);
+    }
+
     [GraphQLMutation]
     public Expression<Func<DemoContext, Person>>? AddActor(DemoContext db, [GraphQLArguments] AddActorArgs args, IGraphQLValidator validator)
     {
@@ -157,13 +207,29 @@ public class AddMovieArgs
     public required string Name { get; set; }
     public double Rating { get; set; }
     public DateTime Released;
-    public Detail? Details { get; set; }
 }
 
 public class Detail
 {
     public required string Description { get; set; }
 }
+
+[GraphQLArguments]
+public class UpdateMovieArgs : PropertySetTrackingDto
+{
+    public required long Id { get; set; }
+    public Genre? Genre;
+    public string? Name { get; set; }
+    public double? Rating { get; set; }
+    public DateTime? Released;
+    public uint? DirectorId { get; set; }
+}
+
+public class MovideDirector
+{
+    public long Id { get; set; }
+}
+
 
 public class AddActorArgs
 {

--- a/src/examples/demo/schema.graphql
+++ b/src/examples/demo/schema.graphql
@@ -230,10 +230,12 @@ type Mutation {
 	addActor2(firstName: String!, lastName: String!, movieId: Int!): [Person!]!
 	addActor3(names: [String!]!, movieId: Int!): [Person!]!
 	"""Add a new Movie object"""
-	addMovie(name: String!, rating: Float!, details: Detail, genre: Genre!, released: Date!): Movie!
+	addMovie(name: String!, rating: Float!, genre: Genre!, released: Date!): Movie!
 	"""Example of a mutation that takes 0 arguments"""
 	exampleNoArgs: Movie!
 	"""Example of a mutation that does not use the context or arguments but does use registered services"""
 	exampleNoArgsWithService: Int!
+	"""Add a new Movie object"""
+	updateMovie(id: Int!, name: String, rating: Float, directorId: Int, genre: Genre, released: Date): Movie!
 }
 


### PR DESCRIPTION
Implementation for #441. Inherit mutation model from `PropertySetTrackingDto` so you can use `IsSet("PROPERTY_NAME")` method to check if property was provided in query.
Arguments type changed from `Dictionary<string, object>?` to `Dictionary<string, object?>?`.
I have changed `ProcessArguments` to return arguments with null value. Please check `BuildArgumentFromMember` function, it may not work correctly.
