### PR TITLE
Add error path field

### DIFF
--- a/src/EntityGraphQL/QueryRequest.cs
+++ b/src/EntityGraphQL/QueryRequest.cs
@@ -71,14 +71,30 @@ public class QueryVariables : Dictionary<string, object?>
 public class GraphQLError : Dictionary<string, object>
 {
     private static readonly string MessageKey = "message";
+    private static readonly string PathKey = "path";
 
     public string Message => (string)this[MessageKey];
+
+    public string[] Path
+    {
+        get => (string[])this[PathKey];
+        set => this[PathKey] = value;
+    }
 
     public Dictionary<string, object>? Extensions => (Dictionary<string, object>?)this.GetValueOrDefault(QueryResult.ExtensionsKey);
 
     public GraphQLError(string message, IDictionary<string, object>? extensions)
     {
         this[MessageKey] = message;
+        this[PathKey] = (string[])[];
+        if (extensions != null)
+            this[QueryResult.ExtensionsKey] = new Dictionary<string, object>(extensions);
+    }
+
+    public GraphQLError(string message, string[] path, IDictionary<string, object>? extensions)
+    {
+        this[MessageKey] = message;
+        this[PathKey] = path;
         if (extensions != null)
             this[QueryResult.ExtensionsKey] = new Dictionary<string, object>(extensions);
     }

--- a/src/EntityGraphQL/Schema/SchemaProvider.cs
+++ b/src/EntityGraphQL/Schema/SchemaProvider.cs
@@ -319,6 +319,10 @@ public class SchemaProvider<TContextType> : ISchemaProvider, IDisposable
         return result;
     }
 
+    // Provide the BaseGraphQLField field on EntityGraphQLFieldException (instead of just name), storting path
+    // Passing into GenerateMessage, returning (string errorMessage, string[] path, IDictionary<string, object>? extensions)
+    // and pass into anew AddError to new GraphQLError(string message, string[] path, IDictionary<string, object>? extensions)
+
     private IEnumerable<(string errorMessage, IDictionary<string, object>? extensions)> GenerateMessage(Exception exception)
     {
         switch (exception)

--- a/src/tests/EntityGraphQL.Tests/ValidationTests.cs
+++ b/src/tests/EntityGraphQL.Tests/ValidationTests.cs
@@ -132,6 +132,35 @@ public class ValidationTests
     }
 
     [Fact]
+    public void TestErrorContainsAliasPath_WithGraphQLValidator()
+    {
+        var schema = SchemaBuilder.FromObject<ValidationTestsContext>();
+
+        schema.AddMutationsFrom<ValidationTestsMutations>(new SchemaBuilderOptions() { AutoCreateInputTypes = true });
+
+        var gql = new QueryRequest
+        {
+            Query =
+                @"mutation Mutate($arg: CastMemberArg) {
+                a: updateCastMemberWithGraphQLValidator(arg: $arg)
+                b: updateCastMemberWithGraphQLValidator(arg: $arg)
+            }",
+            Variables = new QueryVariables() { { "arg", new { Actor = "Neil", Character = "Barn" } } },
+        };
+
+        var serviceCollection = new ServiceCollection();
+        serviceCollection.AddSingleton<IGraphQLValidator, GraphQLValidator>();
+        var testContext = new ValidationTestsContext();
+        var results = schema.ExecuteRequestWithContext(gql, testContext, serviceCollection.BuildServiceProvider(), null);
+        Assert.NotNull(results.Errors);
+        Assert.Equal(2, results.Errors.Count);
+        Assert.Equal("Test Error", results.Errors[0].Message);
+        var paths = results.Errors.SelectMany(e => e.Path);
+        Assert.Contains("a", paths);
+        Assert.Contains("b", paths);
+    }
+
+    [Fact]
     public void TestCustomValidationDelegateOnMutation()
     {
         var schema = SchemaBuilder.FromObject<ValidationTestsContext>();


### PR DESCRIPTION
Adding path field to error messages.

Starting with adding the field name of an aliased field to help with identifying error messages when processing multiple mutation fields in a single operation.

```
{
  "errors": [
    {
      "message": "Starship not found",
      "locations": [
        {
          "line": 3,
          "column": 3
        }
      ],
      "path": [
        "secondShip"
      ]
    }
  ],
  "data": {
    "firstShip": "3001",
    "secondShip": null
  }
}
``` 

https://graphql.org/learn/response/#field-errors
https://spec.graphql.org/October2021/#sec-Errors.Error-result-format